### PR TITLE
feat: workspace config, unix_user isolation, tracing, agent recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::Command;
+use tracing::{debug, info, warn};
 
 use crate::config;
 
@@ -14,6 +15,16 @@ pub struct AgentConfig {
     pub system_prompt: String,
     pub work_dir: String,
     pub max_turns: u32,
+    /// Optional Linux user to run the claude process as.
+    #[serde(default)]
+    pub unix_user: Option<String>,
+    /// Budget cap in USD.
+    #[serde(default = "default_budget_usd")]
+    pub budget_usd: f64,
+}
+
+fn default_budget_usd() -> f64 {
+    50.0
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,16 +60,15 @@ fn save_state(state: &AgentState) -> Result<()> {
     Ok(())
 }
 
-/// Create a new agent — spawns claude as a background process.
+/// Create a new agent (saves state file; does not start a worker process).
 pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
-    // Check if already exists
     if state_path(&cfg.name).exists() {
         bail!("Agent '{}' already exists. Remove it first.", cfg.name);
     }
 
     let state = AgentState {
         config: cfg.clone(),
-        pid: 0, // no persistent process — we run claude per-task
+        pid: 0,
         session_id: String::new(),
         total_turns: 0,
         total_cost: 0.0,
@@ -66,18 +76,41 @@ pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
     };
 
     save_state(&state)?;
+    info!(agent = %cfg.name, "agent created");
     Ok(state)
 }
 
-/// Send a message to an agent — runs claude CLI and returns response.
+/// Create or recover agent state from a workspace AgentDef.
+/// If state already exists on disk, returns existing state (preserving session_id + costs).
+pub async fn create_or_recover(def: &config::AgentDef) -> Result<AgentState> {
+    let path = state_path(&def.name);
+    if path.exists() {
+        let state = load_state(&def.name)?;
+        info!(agent = %def.name, session_id = %state.session_id, "recovered existing agent state");
+        return Ok(state);
+    }
+
+    let cfg = AgentConfig {
+        name: def.name.clone(),
+        model: def.model.clone(),
+        system_prompt: def.system_prompt.clone(),
+        work_dir: def.work_dir.clone(),
+        max_turns: def.max_turns,
+        unix_user: def.unix_user.clone(),
+        budget_usd: def.budget_usd,
+    };
+    create(&cfg).await
+}
+
+/// Send a message to an agent — runs claude CLI and returns the full response text.
 pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<String> {
     let mut state = load_state(name)?;
 
     let turns = max_turns.unwrap_or(state.config.max_turns);
 
-    // All flags must come before -p <message> to avoid messages starting with '-'
-    // being parsed as flags.
     let mut args = vec![
+        "-p".to_string(),
+        message.to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
         "--verbose".to_string(),
@@ -98,22 +131,16 @@ pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<S
         args.push(state.config.system_prompt.clone());
     }
 
-    // -p <message> must be last to avoid messages starting with '-' being parsed as flags
-    args.push("-p".to_string());
-    args.push(message.to_string());
+    debug!(agent = %name, turns, "spawning claude");
 
-    let output = Command::new("claude")
-        .args(&args)
-        .current_dir(&state.config.work_dir)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+    let mut cmd = build_command(&state.config, &args);
+    let output = cmd
         .output()
         .await
         .context("Failed to run claude CLI")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Parse stream-json output — last line with type=result has cost/session info
     let mut response_text = String::new();
     let mut new_session_id = String::new();
     let mut task_cost = 0.0;
@@ -123,15 +150,15 @@ pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<S
         if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
             match v.get("type").and_then(|t| t.as_str()) {
                 Some("assistant") => {
-                    // Extract text from content blocks
-                    if let Some(content) = v.get("message").and_then(|m| m.get("content")) {
-                        if let Some(blocks) = content.as_array() {
-                            for block in blocks {
-                                if block.get("type").and_then(|t| t.as_str()) == Some("text") {
-                                    if let Some(text) = block.get("text").and_then(|t| t.as_str())
-                                    {
-                                        response_text.push_str(text);
-                                    }
+                    if let Some(blocks) = v
+                        .get("message")
+                        .and_then(|m| m.get("content"))
+                        .and_then(|c| c.as_array())
+                    {
+                        for block in blocks {
+                            if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                                    response_text.push_str(text);
                                 }
                             }
                         }
@@ -144,8 +171,8 @@ pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<S
                     if let Some(cost) = v.get("total_cost_usd").and_then(|c| c.as_f64()) {
                         task_cost = cost;
                     }
-                    if let Some(turns) = v.get("num_turns").and_then(|t| t.as_u64()) {
-                        task_turns = turns as u32;
+                    if let Some(t) = v.get("num_turns").and_then(|t| t.as_u64()) {
+                        task_turns = t as u32;
                     }
                 }
                 _ => {}
@@ -153,7 +180,6 @@ pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<S
         }
     }
 
-    // Update state
     if !new_session_id.is_empty() {
         state.session_id = new_session_id;
     }
@@ -172,7 +198,31 @@ pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<S
     Ok(response_text)
 }
 
-/// List all agents.
+/// Build the tokio Command for running claude, respecting unix_user if set.
+fn build_command(cfg: &AgentConfig, args: &[String]) -> Command {
+    let mut cmd = match &cfg.unix_user {
+        Some(user) => {
+            let mut c = Command::new("sudo");
+            c.args(["-u", user, "-H", "--", "claude"]);
+            c.args(args);
+            // Strip SSH agent socket so the child cannot inherit the parent's keys.
+            c.env_remove("SSH_AUTH_SOCK");
+            c.env_remove("SSH_AGENT_PID");
+            c
+        }
+        None => {
+            let mut c = Command::new("claude");
+            c.args(args);
+            c
+        }
+    };
+    cmd.current_dir(&cfg.work_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd
+}
+
+/// List all agents whose state files exist on disk.
 pub async fn list() -> Result<Vec<AgentState>> {
     let dir = config::state_dir();
     let mut agents = Vec::new();
@@ -193,21 +243,93 @@ pub async fn list() -> Result<Vec<AgentState>> {
     Ok(agents)
 }
 
-/// Remove an agent.
+/// Remove an agent (state file + log).
 pub async fn remove(name: &str) -> Result<()> {
     let path = state_path(name);
     if !path.exists() {
         bail!("Agent '{}' not found", name);
     }
-
-    // Remove state file
     std::fs::remove_file(&path)?;
-
-    // Remove log file if exists
     let log = log_path(name);
     if log.exists() {
-        std::fs::remove_file(&log).ok();
+        if let Err(e) = std::fs::remove_file(&log) {
+            warn!(agent = %name, error = %e, "failed to remove log file");
+        }
+    }
+    info!(agent = %name, "agent removed");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_config_defaults() {
+        let yaml = r#"
+config:
+  name: test
+  model: claude-opus-4-6
+  system_prompt: ""
+  work_dir: /tmp
+  max_turns: 100
+pid: 0
+session_id: ""
+total_turns: 0
+total_cost: 0.0
+created_at: "2026-01-01T00:00:00Z"
+"#;
+        let state: AgentState = serde_yaml::from_str(yaml).unwrap();
+        assert!(state.config.unix_user.is_none());
+        assert_eq!(state.config.budget_usd, 50.0);
     }
 
-    Ok(())
+    #[test]
+    fn test_agent_config_with_unix_user() {
+        let yaml = r#"
+config:
+  name: kira
+  model: claude-opus-4-6
+  system_prompt: "You are Kira."
+  work_dir: /home/agent-kira
+  max_turns: 50
+  unix_user: agent-kira
+  budget_usd: 25.0
+pid: 0
+session_id: "sess-abc"
+total_turns: 10
+total_cost: 1.23
+created_at: "2026-01-01T00:00:00Z"
+"#;
+        let state: AgentState = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(state.config.unix_user.as_deref(), Some("agent-kira"));
+        assert_eq!(state.config.budget_usd, 25.0);
+        assert_eq!(state.session_id, "sess-abc");
+    }
+
+    #[test]
+    fn test_agent_state_round_trip() {
+        let cfg = AgentConfig {
+            name: "test-agent".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            system_prompt: String::new(),
+            work_dir: "/tmp".to_string(),
+            max_turns: 100,
+            unix_user: Some("agent1".to_string()),
+            budget_usd: 10.0,
+        };
+        let state = AgentState {
+            config: cfg,
+            pid: 0,
+            session_id: "sid-123".to_string(),
+            total_turns: 5,
+            total_cost: 0.42,
+            created_at: Utc::now().to_rfc3339(),
+        };
+        let yaml = serde_yaml::to_string(&state).unwrap();
+        let restored: AgentState = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(restored.config.unix_user.as_deref(), Some("agent1"));
+        assert_eq!(restored.session_id, "sid-123");
+        assert_eq!(restored.total_cost, 0.42);
+    }
 }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, RwLock};
+use tracing::{debug, info, warn};
 
 use crate::message::{Envelope, Message};
 
@@ -40,7 +41,7 @@ impl BusState {
             if let Some(client) = self.clients.get(name) {
                 let _ = client.tx.send(msg.clone());
             } else {
-                eprintln!("[bus] no such agent: {}", name);
+                warn!(target = %name, "no such agent on bus");
             }
         } else if target.starts_with("queue:") {
             for client in self.clients.values() {
@@ -64,9 +65,9 @@ impl BusState {
                 }
             }
             if delivered {
-                eprintln!("[bus] delivered to subscriber via pattern match for target: {}", target);
+                debug!(target = %target, "delivered via pattern match");
             } else {
-                eprintln!("[bus] no subscriber for target: {}", target);
+                warn!(target = %target, "no subscriber for target");
             }
         }
     }
@@ -89,7 +90,7 @@ pub async fn serve(socket_path: &str) -> Result<()> {
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o777))?;
     }
 
-    eprintln!("[bus] listening on {}", socket_path);
+    info!(socket = %socket_path, "bus listening");
 
     let state = Arc::new(RwLock::new(BusState::new()));
 
@@ -98,7 +99,7 @@ pub async fn serve(socket_path: &str) -> Result<()> {
         let state = Arc::clone(&state);
         tokio::spawn(async move {
             if let Err(e) = handle_connection(stream, state).await {
-                eprintln!("[bus] connection error: {}", e);
+                warn!(error = %e, "connection error");
             }
         });
     }
@@ -126,7 +127,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<RwLock<BusState>>) -> 
 
     let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
 
-    eprintln!("[bus] client registered: {}", name);
+    info!(client = %name, "client registered");
 
     {
         let mut bus = state.write().await;
@@ -160,25 +161,25 @@ async fn handle_connection(stream: UnixStream, state: Arc<RwLock<BusState>>) -> 
         let envelope: Envelope = match serde_json::from_str(&line) {
             Ok(e) => e,
             Err(e) => {
-                eprintln!("[bus] invalid message from {}: {}", name, e);
+                warn!(client = %name, error = %e, "invalid message");
                 continue;
             }
         };
 
         match envelope {
             Envelope::Message(msg) => {
-                eprintln!("[bus] routing message from {} to {}", msg.source, msg.target);
+                debug!(from = %msg.source, to = %msg.target, "routing message");
                 let bus = state.read().await;
                 bus.route(&msg);
             }
             Envelope::Register(_) => {
-                eprintln!("[bus] ignoring duplicate register from {}", name);
+                warn!(client = %name, "ignoring duplicate register");
             }
         }
     }
 
     // Client disconnected
-    eprintln!("[bus] client disconnected: {}", name);
+    info!(client = %name, "client disconnected");
     {
         let mut bus = state.write().await;
         bus.clients.remove(&name);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -17,21 +18,171 @@ pub fn log_dir() -> PathBuf {
     dir
 }
 
+fn default_max_turns() -> u32 {
+    100
+}
+
+fn default_budget_usd() -> f64 {
+    50.0
+}
+
+/// Top-level workspace configuration loaded from workspace.yaml.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceConfig {
+    #[serde(default)]
+    pub bus: BusConfig,
+    #[serde(default)]
+    pub adapters: AdaptersConfig,
+    #[serde(default)]
     pub agents: Vec<AgentDef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusConfig {
+    #[serde(default = "default_socket")]
+    pub socket: String,
+}
+
+fn default_socket() -> String {
+    "/tmp/deskd.sock".to_string()
+}
+
+impl Default for BusConfig {
+    fn default() -> Self {
+        Self {
+            socket: default_socket(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AdaptersConfig {
+    pub telegram: Option<TelegramConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelegramConfig {
+    pub token: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentDef {
     pub name: String,
     pub model: String,
+    #[serde(default)]
     pub system_prompt: String,
     pub work_dir: String,
+    /// Optional Linux user to run the claude process as.
+    pub unix_user: Option<String>,
     #[serde(default = "default_max_turns")]
     pub max_turns: u32,
+    /// Budget cap in USD. Worker rejects tasks when this is exceeded.
+    #[serde(default = "default_budget_usd")]
+    pub budget_usd: f64,
 }
 
-fn default_max_turns() -> u32 {
-    100
+impl WorkspaceConfig {
+    /// Load and parse a workspace config file, expanding ${ENV_VAR} references.
+    pub fn load(path: &str) -> Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read workspace config: {}", path))?;
+        let expanded = expand_env_vars(&raw);
+        let cfg: WorkspaceConfig = serde_yaml::from_str(&expanded)
+            .context("failed to parse workspace config")?;
+        Ok(cfg)
+    }
+}
+
+/// Replace `${VAR}` and `$VAR` occurrences with their environment variable values.
+/// Unknown variables are left as-is.
+fn expand_env_vars(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '$' {
+            if chars.peek() == Some(&'{') {
+                // ${VAR} form
+                chars.next(); // consume '{'
+                let var: String = chars.by_ref().take_while(|&c| c != '}').collect();
+                if let Ok(val) = std::env::var(&var) {
+                    result.push_str(&val);
+                } else {
+                    result.push_str(&format!("${{{}}}", var));
+                }
+            } else if chars.peek().map(|c| c.is_alphanumeric() || *c == '_').unwrap_or(false) {
+                // $VAR form
+                let mut var = String::new();
+                while chars.peek().map(|c| c.is_alphanumeric() || *c == '_').unwrap_or(false) {
+                    var.push(chars.next().unwrap());
+                }
+                if let Ok(val) = std::env::var(&var) {
+                    result.push_str(&val);
+                } else {
+                    result.push_str(&format!("${}", var));
+                }
+            } else {
+                result.push(ch);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_env_vars_braces() {
+        std::env::set_var("TEST_TOKEN_DESKD", "abc123");
+        let result = expand_env_vars("token: ${TEST_TOKEN_DESKD}");
+        assert_eq!(result, "token: abc123");
+    }
+
+    #[test]
+    fn test_expand_env_vars_dollar() {
+        std::env::set_var("TEST_VAR_DESKD", "hello");
+        let result = expand_env_vars("val: $TEST_VAR_DESKD end");
+        assert_eq!(result, "val: hello end");
+    }
+
+    #[test]
+    fn test_expand_env_vars_unknown_left_as_is() {
+        let result = expand_env_vars("val: ${DEFINITELY_NOT_SET_XYZ123}");
+        assert_eq!(result, "val: ${DEFINITELY_NOT_SET_XYZ123}");
+    }
+
+    #[test]
+    fn test_workspace_config_defaults() {
+        let yaml = r#"
+agents:
+  - name: kira
+    model: claude-opus-4-6
+    work_dir: /home/agent-kira
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.agents[0].max_turns, 100);
+        assert_eq!(cfg.agents[0].budget_usd, 50.0);
+        assert!(cfg.agents[0].unix_user.is_none());
+        assert_eq!(cfg.bus.socket, "/tmp/deskd.sock");
+    }
+
+    #[test]
+    fn test_workspace_config_unix_user() {
+        let yaml = r#"
+agents:
+  - name: kira
+    model: claude-opus-4-6
+    work_dir: /home/agent-kira
+    unix_user: agent-kira
+    budget_usd: 25.0
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.agents[0].unix_user.as_deref(), Some("agent-kira"));
+        assert_eq!(cfg.agents[0].budget_usd, 25.0);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod message;
 mod worker;
 
 use clap::{Parser, Subcommand};
+use tracing::info;
 
 const DEFAULT_SOCKET: &str = "/tmp/deskd.sock";
 
@@ -17,78 +18,98 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Create and start a new agent
+    /// Start the message bus server and launch configured agents.
+    Serve {
+        /// Unix socket path for the bus.
+        #[arg(long, default_value = DEFAULT_SOCKET)]
+        socket: String,
+        /// Path to workspace config file (workspace.yaml).
+        /// When provided, agents listed in the config are auto-started.
+        #[arg(long)]
+        config: Option<String>,
+    },
+    /// Manage agents.
     Agent {
         #[command(subcommand)]
         action: AgentAction,
-    },
-    /// Start the message bus server
-    Serve {
-        /// Unix socket path
-        #[arg(long, default_value = DEFAULT_SOCKET)]
-        socket: String,
     },
 }
 
 #[derive(Subcommand)]
 enum AgentAction {
-    /// Create a new agent
+    /// Register a new agent (saves state file, does not start worker).
     Create {
-        /// Agent name
+        /// Agent name.
         name: String,
-        /// System prompt
+        /// System prompt text.
         #[arg(long)]
         prompt: Option<String>,
-        /// Model to use
-        #[arg(long, default_value = "claude-sonnet-4-20250514")]
+        /// Claude model to use.
+        #[arg(long, default_value = "claude-sonnet-4-6")]
         model: String,
-        /// Working directory
+        /// Working directory for claude.
         #[arg(long)]
         workdir: Option<String>,
-        /// Max turns per task
+        /// Max turns per task.
         #[arg(long, default_value = "100")]
         max_turns: u32,
+        /// Linux user to run claude as (optional).
+        #[arg(long)]
+        unix_user: Option<String>,
+        /// Budget cap in USD.
+        #[arg(long, default_value = "50.0")]
+        budget_usd: f64,
     },
-    /// Send a message to an agent
+    /// Send a task to an agent (via bus if running, direct otherwise).
     Send {
-        /// Agent name
+        /// Agent name.
         name: String,
-        /// Message to send
+        /// Task message to send.
         message: String,
-        /// Max turns for this task
+        /// Max turns for this task.
         #[arg(long)]
         max_turns: Option<u32>,
-        /// Bus socket path
+        /// Bus socket path.
         #[arg(long, default_value = DEFAULT_SOCKET)]
         socket: String,
     },
-    /// Run agent worker loop (connects to bus, processes tasks)
+    /// Start the worker loop for an agent (connect to bus, process tasks).
     Run {
-        /// Agent name
+        /// Agent name.
         name: String,
-        /// Bus socket path
+        /// Bus socket path.
         #[arg(long, default_value = DEFAULT_SOCKET)]
         socket: String,
     },
-    /// List all agents
+    /// List all registered agents with their stats.
     List,
-    /// Show agent stats (turns, cost)
+    /// Show detailed stats for an agent.
     Stats {
-        /// Agent name
+        /// Agent name.
         name: String,
     },
-    /// Remove an agent
+    /// Remove an agent (state file + log).
     Rm {
-        /// Agent name
+        /// Agent name.
         name: String,
     },
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
     let cli = Cli::parse();
 
     match cli.command {
+        Commands::Serve { socket, config } => {
+            serve(socket, config).await?;
+        }
         Commands::Agent { action } => match action {
             AgentAction::Create {
                 name,
@@ -96,6 +117,8 @@ async fn main() -> anyhow::Result<()> {
                 model,
                 workdir,
                 max_turns,
+                unix_user,
+                budget_usd,
             } => {
                 let cfg = agent::AgentConfig {
                     name: name.clone(),
@@ -103,9 +126,11 @@ async fn main() -> anyhow::Result<()> {
                     system_prompt: prompt.unwrap_or_default(),
                     work_dir: workdir.unwrap_or_else(|| ".".into()),
                     max_turns,
+                    unix_user,
+                    budget_usd,
                 };
                 let state = agent::create(&cfg).await?;
-                println!("Agent {} created (pid: {})", name, state.pid);
+                println!("Agent {} created", state.config.name);
             }
             AgentAction::Send {
                 name,
@@ -113,10 +138,8 @@ async fn main() -> anyhow::Result<()> {
                 max_turns,
                 socket,
             } => {
-                // If bus socket exists, route through bus; otherwise direct
                 if std::path::Path::new(&socket).exists() {
-                    // If name contains ':', treat as raw target (e.g. telegram:-123)
-                    let target = if name.contains(':') { name.clone() } else { format!("agent:{}", name) };
+                    let target = format!("agent:{}", name);
                     worker::send_via_bus(&socket, "cli", &target, &message, max_turns).await?;
                 } else {
                     let response = agent::send(&name, &message, max_turns).await?;
@@ -124,49 +147,96 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
             AgentAction::Run { name, socket } => {
-                // Verify agent exists
                 agent::load_state(&name)?;
-
-                eprintln!("[deskd] starting worker for agent '{}'", name);
+                info!(agent = %name, "starting worker");
                 tokio::select! {
-                    result = worker::run(&name, &socket) => {
-                        result?;
-                    }
+                    result = worker::run(&name, &socket) => { result?; }
                     _ = tokio::signal::ctrl_c() => {
-                        eprintln!("\n[deskd] shutting down agent '{}'", name);
+                        info!(agent = %name, "shutting down");
                     }
                 }
             }
             AgentAction::List => {
                 let agents = agent::list().await?;
                 if agents.is_empty() {
-                    println!("No agents running");
+                    println!("No agents registered");
                 } else {
-                    println!("{:<15} {:<10} {:<8} {:<10} {}", "NAME", "PID", "TURNS", "COST", "MODEL");
+                    println!(
+                        "{:<15} {:<8} {:<10} {:<12} {}",
+                        "NAME", "TURNS", "COST", "USER", "MODEL"
+                    );
                     for a in agents {
                         println!(
-                            "{:<15} {:<10} {:<8} ${:<9.2} {}",
-                            a.config.name, a.pid, a.total_turns, a.total_cost, a.config.model
+                            "{:<15} {:<8} ${:<9.2} {:<12} {}",
+                            a.config.name,
+                            a.total_turns,
+                            a.total_cost,
+                            a.config.unix_user.as_deref().unwrap_or("-"),
+                            a.config.model,
                         );
                     }
                 }
             }
             AgentAction::Stats { name } => {
-                let state = agent::load_state(&name)?;
-                println!("Agent: {}", state.config.name);
-                println!("Model: {}", state.config.model);
-                println!("PID: {}", state.pid);
-                println!("Total turns: {}", state.total_turns);
-                println!("Total cost: ${:.4}", state.total_cost);
-                println!("Created: {}", state.created_at);
+                let s = agent::load_state(&name)?;
+                println!("Agent:      {}", s.config.name);
+                println!("Model:      {}", s.config.model);
+                println!("Unix user:  {}", s.config.unix_user.as_deref().unwrap_or("-"));
+                println!("Work dir:   {}", s.config.work_dir);
+                println!("Total turns:{}", s.total_turns);
+                println!("Total cost: ${:.4}", s.total_cost);
+                println!("Budget:     ${:.2}", s.config.budget_usd);
+                println!(
+                    "Session:    {}",
+                    if s.session_id.is_empty() { "-" } else { &s.session_id }
+                );
+                println!("Created:    {}", s.created_at);
             }
             AgentAction::Rm { name } => {
                 agent::remove(&name).await?;
                 println!("Agent {} removed", name);
             }
         },
-        Commands::Serve { socket } => {
-            bus::serve(&socket).await?;
+    }
+
+    Ok(())
+}
+
+async fn serve(socket: String, config_path: Option<String>) -> anyhow::Result<()> {
+    let workspace = if let Some(path) = config_path {
+        let ws = config::WorkspaceConfig::load(&path)?;
+        info!(path = %path, agents = ws.agents.len(), "loaded workspace config");
+        Some(ws)
+    } else {
+        None
+    };
+
+    // Workspace config overrides the CLI --socket flag.
+    let effective_socket = workspace
+        .as_ref()
+        .map(|ws| ws.bus.socket.clone())
+        .unwrap_or(socket);
+
+    // Auto-spawn workers for all agents defined in workspace config.
+    if let Some(ref ws) = workspace {
+        for def in &ws.agents {
+            let state = agent::create_or_recover(def).await?;
+            let name = state.config.name.clone();
+            let sock = effective_socket.clone();
+            info!(agent = %name, "launching worker");
+            tokio::spawn(async move {
+                if let Err(e) = worker::run(&name, &sock).await {
+                    tracing::error!(agent = %name, error = %e, "worker exited with error");
+                }
+            });
+        }
+    }
+
+    info!(socket = %effective_socket, "starting bus");
+    tokio::select! {
+        result = bus::serve(&effective_socket) => { result?; }
+        _ = tokio::signal::ctrl_c() => {
+            info!("shutting down");
         }
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, bail};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::agent;
@@ -25,16 +26,15 @@ pub async fn bus_connect(
     line.push('\n');
     stream.write_all(line.as_bytes()).await?;
 
-    eprintln!("[worker] registered as {} on bus", name);
+    info!(agent = %name, "registered on bus");
     Ok(stream)
 }
 
 /// Run the agent worker loop: read messages from bus, execute tasks, post results.
 pub async fn run(name: &str, socket_path: &str) -> Result<()> {
-    agent::load_state(name)?; // verify agent exists
-    let max_cost = 50.0_f64; // budget cap in USD
+    let initial_state = agent::load_state(name)?;
+    let budget_usd = initial_state.config.budget_usd;
 
-    // Subscribe to agent-specific target and the default task queue
     let subscriptions = vec![
         format!("agent:{}", name),
         "queue:tasks".to_string(),
@@ -45,7 +45,7 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
     let mut lines = BufReader::new(reader).lines();
     let writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer));
 
-    eprintln!("[worker] {} waiting for tasks", name);
+    info!(agent = %name, "waiting for tasks");
 
     while let Some(line) = lines.next_line().await? {
         if line.is_empty() {
@@ -55,15 +55,20 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
         let msg: Message = match serde_json::from_str(&line) {
             Ok(m) => m,
             Err(e) => {
-                eprintln!("[worker] invalid message: {}", e);
+                warn!(agent = %name, error = %e, "invalid message from bus");
                 continue;
             }
         };
 
-        // Check budget
+        // Check budget against the configured cap.
         let current_state = agent::load_state(name)?;
-        if current_state.total_cost >= max_cost {
-            eprintln!("[worker] budget exceeded (${:.2} >= ${:.2}), rejecting task", current_state.total_cost, max_cost);
+        if current_state.total_cost >= budget_usd {
+            warn!(
+                agent = %name,
+                cost = current_state.total_cost,
+                budget = budget_usd,
+                "budget exceeded, rejecting task"
+            );
             continue;
         }
 
@@ -72,25 +77,21 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
             .unwrap_or_default();
 
         if task.is_empty() {
-            eprintln!("[worker] message has no task payload, skipping");
+            debug!(agent = %name, "message has no task payload, skipping");
             continue;
         }
 
-        eprintln!("[worker] processing task from {}: {}", msg.source, truncate(task, 80));
+        info!(agent = %name, source = %msg.source, task = %truncate(task, 80), "processing task");
 
-        // Run claude via existing send() logic
         let max_turns = msg.payload.get("max_turns")
             .and_then(|t| t.as_u64())
             .map(|t| t as u32);
 
         match agent::send(name, task, max_turns).await {
             Ok(response) => {
-                eprintln!("[worker] task completed, posting result");
+                info!(agent = %name, "task completed, posting result");
 
-                // Determine reply target
-                let target = msg.reply_to
-                    .as_deref()
-                    .unwrap_or(&msg.source);
+                let target = msg.reply_to.as_deref().unwrap_or(&msg.source);
 
                 let reply = Message {
                     id: Uuid::new_v4().to_string(),
@@ -104,22 +105,29 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
                     metadata: Metadata::default(),
                 };
 
-                let envelope = serde_json::json!({"type": "message", "id": reply.id, "source": reply.source, "target": reply.target, "payload": reply.payload, "metadata": reply.metadata});
+                let envelope = serde_json::json!({
+                    "type": "message",
+                    "id": reply.id,
+                    "source": reply.source,
+                    "target": reply.target,
+                    "payload": reply.payload,
+                    "metadata": reply.metadata,
+                });
                 let mut reply_line = serde_json::to_string(&envelope)?;
                 reply_line.push('\n');
 
                 let mut w = writer.lock().await;
-                match w.write_all(reply_line.as_bytes()).await {
-                    Ok(_) => eprintln!("[worker] reply sent to bus: target={}", target),
-                    Err(e) => eprintln!("[worker] failed to write reply to bus: {}", e),
+                if let Err(e) = w.write_all(reply_line.as_bytes()).await {
+                    warn!(agent = %name, error = %e, target = %target, "failed to write reply to bus");
+                } else {
+                    debug!(agent = %name, target = %target, "reply sent to bus");
                 }
             }
             Err(e) => {
-                eprintln!("[worker] task failed: {}", e);
+                warn!(agent = %name, error = %e, "task failed");
 
-                // Post error back if there's a reply target
                 if let Some(reply_to) = &msg.reply_to {
-                    let reply = serde_json::json!({
+                    let error_msg = serde_json::json!({
                         "type": "message",
                         "id": Uuid::new_v4().to_string(),
                         "source": name,
@@ -127,33 +135,39 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
                         "payload": {"error": format!("{}", e), "in_reply_to": &msg.id},
                         "metadata": {"priority": 5u8},
                     });
-                    let mut reply_line = serde_json::to_string(&reply)?;
-                    reply_line.push('\n');
+                    let mut err_line = serde_json::to_string(&error_msg)?;
+                    err_line.push('\n');
 
                     let mut w = writer.lock().await;
-                    w.write_all(reply_line.as_bytes()).await.ok();
+                    if let Err(write_err) = w.write_all(err_line.as_bytes()).await {
+                        warn!(agent = %name, error = %write_err, "failed to write error reply to bus");
+                    }
                 }
             }
         }
     }
 
-    eprintln!("[worker] disconnected from bus");
+    info!(agent = %name, "disconnected from bus");
     Ok(())
 }
 
-/// Send a message via the bus (connect, send, disconnect).
-pub async fn send_via_bus(socket_path: &str, source: &str, target: &str, task: &str, max_turns: Option<u32>) -> Result<()> {
+/// Send a message via the bus (connect, send, wait for one reply, disconnect).
+pub async fn send_via_bus(
+    socket_path: &str,
+    source: &str,
+    target: &str,
+    task: &str,
+    max_turns: Option<u32>,
+) -> Result<()> {
     let mut stream = UnixStream::connect(socket_path)
         .await
         .with_context(|| format!("Failed to connect to bus at {}", socket_path))?;
 
-    // Register as a transient client
     let reg = serde_json::json!({"type": "register", "name": source, "subscriptions": []});
     let mut line = serde_json::to_string(&reg)?;
     line.push('\n');
     stream.write_all(line.as_bytes()).await?;
 
-    // Send the task message
     let mut payload = serde_json::json!({"task": task});
     if let Some(turns) = max_turns {
         payload["max_turns"] = serde_json::json!(turns);
@@ -172,9 +186,8 @@ pub async fn send_via_bus(socket_path: &str, source: &str, target: &str, task: &
     msg_line.push('\n');
     stream.write_all(msg_line.as_bytes()).await?;
 
-    eprintln!("[send] task posted to {} via bus", target);
+    debug!(source = %source, target = %target, "task posted to bus");
 
-    // Read response (blocking wait for one message back)
     let (reader, _) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
     if let Some(response_line) = lines.next_line().await? {
@@ -195,7 +208,6 @@ fn truncate(s: &str, max: usize) -> &str {
     if s.len() <= max {
         return s;
     }
-    // Find the last char boundary at or before max
     let mut end = max;
     while end > 0 && !s.is_char_boundary(end) {
         end -= 1;


### PR DESCRIPTION
## Summary

- **Workspace config** (`deskd serve --config workspace.yaml`): structured YAML config with env var expansion (`${TOKEN}`), auto-spawns all configured agents on startup
- **Agent recovery**: on startup, existing state files are read to restore `session_id`, `total_cost`, `total_turns` — agents resume their Claude sessions
- **unix_user isolation**: `AgentDef.unix_user` runs `claude` via `sudo -u <user>`, stripping `SSH_AUTH_SOCK`/`SSH_AGENT_PID` to prevent key inheritance between agents
- **budget_usd per agent**: replaces hardcoded `$50` cap in worker; configurable per agent in workspace YAML
- **tracing**: replace all `eprintln!` with structured `tracing` macros (`info!`, `warn!`, `debug!`, `error!`)
- **AdaptersConfig**: placeholder struct for Telegram and future adapters (prep for #10)

## Workspace config example

```yaml
bus:
  socket: /run/deskd/bus.sock

adapters:
  telegram:
    token: "${TELEGRAM_BOT_TOKEN}"

agents:
  - name: kira
    model: claude-opus-4-6
    system_prompt: "You are Kira."
    work_dir: /home/agent-kira
    unix_user: agent-kira
    budget_usd: 25.0
    max_turns: 100
```

## Tests added

- Env var expansion (braces form, dollar form, unknown vars left as-is)
- WorkspaceConfig defaults (max_turns, budget_usd, unix_user)
- unix_user round-trips through YAML serde
- AgentState serde with and without unix_user

Closes #11, closes #12