### PR TITLE
feat: persistent Claude session — stdin streaming, auto-restart

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -53,6 +53,11 @@ pub fn load_state(name: &str) -> Result<AgentState> {
     Ok(state)
 }
 
+/// Public alias for use by session.rs.
+pub fn save_state_pub(state: &AgentState) -> Result<()> {
+    save_state(state)
+}
+
 fn save_state(state: &AgentState) -> Result<()> {
     let path = state_path(&state.config.name);
     let content = serde_yaml::to_string(state)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod agent;
 mod bus;
 mod config;
 mod message;
+mod session;
 mod worker;
 
 use clap::{Parser, Subcommand};

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,288 @@
+/// PersistentSession — keeps a single claude CLI process alive across multiple turns.
+///
+/// deskd writes messages to claude's stdin one at a time; responses are read
+/// from stdout as stream-json events.  On process death the session is restarted
+/// automatically using `--resume <session_id>` to preserve conversation context.
+///
+/// Message protocol (stdin):
+///   Each user turn is a single UTF-8 line (newline-terminated).
+///   Multi-line content is collapsed to a single line to avoid ambiguity.
+///
+/// Message protocol (stdout):
+///   Claude emits newline-delimited JSON events (stream-json format).
+///   A `{"type":"result"}` event marks the end of one turn.
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tracing::{debug, info, warn};
+
+use crate::agent::{AgentConfig, AgentState, load_state, save_state_pub};
+
+/// Maximum consecutive restart attempts before giving up.
+const MAX_RESTARTS: u32 = 3;
+
+pub struct PersistentSession {
+    name: String,
+    child: Child,
+    stdin: ChildStdin,
+    stdout_lines: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+    state: AgentState,
+    restarts: u32,
+}
+
+impl PersistentSession {
+    /// Spawn a persistent Claude process for the named agent.
+    pub async fn spawn(name: &str) -> Result<Self> {
+        let state = load_state(name)?;
+        let (child, stdin, stdout_lines) = spawn_process(&state.config, &state.session_id).await?;
+        info!(agent = %name, session = %state.session_id, "persistent session started");
+        Ok(Self {
+            name: name.to_string(),
+            child,
+            stdin,
+            stdout_lines,
+            state,
+            restarts: 0,
+        })
+    }
+
+    /// Send a message, wait for the result event, return response text.
+    /// If the process has died, restarts it (up to MAX_RESTARTS times).
+    pub async fn send(&mut self, message: &str) -> Result<String> {
+        // Flatten to single line — claude reads one turn per newline.
+        let line = format!("{}\n", message.replace('\n', " "));
+
+        if let Err(e) = self.stdin.write_all(line.as_bytes()).await {
+            warn!(agent = %self.name, error = %e, "stdin write failed, restarting session");
+            self.restart().await?;
+            self.stdin.write_all(line.as_bytes()).await
+                .context("stdin write failed after restart")?;
+        }
+        self.stdin.flush().await.context("stdin flush")?;
+
+        self.read_result().await
+    }
+
+    /// Read stream-json events until a `result` event, collecting the response text.
+    async fn read_result(&mut self) -> Result<String> {
+        let mut response_text = String::new();
+        let mut new_session_id = String::new();
+        let mut task_cost = 0.0_f64;
+        let mut task_turns = 0_u32;
+
+        loop {
+            let line = match self.stdout_lines.next_line().await {
+                Ok(Some(l)) => l,
+                Ok(None) => {
+                    // stdout closed — process exited unexpectedly
+                    bail!("claude process exited unexpectedly");
+                }
+                Err(e) => bail!("stdout read error: {}", e),
+            };
+
+            if line.is_empty() {
+                continue;
+            }
+
+            let v: Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            match v["type"].as_str() {
+                Some("assistant") => {
+                    if let Some(blocks) = v["message"]["content"].as_array() {
+                        for block in blocks {
+                            if block["type"] == "text" {
+                                if let Some(t) = block["text"].as_str() {
+                                    response_text.push_str(t);
+                                }
+                            }
+                        }
+                    }
+                }
+                Some("result") => {
+                    if let Some(sid) = v["session_id"].as_str() {
+                        new_session_id = sid.to_string();
+                    }
+                    if let Some(cost) = v["total_cost_usd"].as_f64() {
+                        task_cost = cost;
+                    }
+                    if let Some(t) = v["num_turns"].as_u64() {
+                        task_turns = t as u32;
+                    }
+
+                    // Check for error subtypes
+                    if let Some(subtype) = v["subtype"].as_str() {
+                        if subtype == "error_max_turns" {
+                            warn!(agent = %self.name, "max turns reached");
+                        }
+                    }
+                    break;
+                }
+                _ => {
+                    debug!(agent = %self.name, event = %v["type"].as_str().unwrap_or("?"), "stream event");
+                }
+            }
+        }
+
+        // Persist updated state
+        if !new_session_id.is_empty() {
+            self.state.session_id = new_session_id;
+        }
+        self.state.total_cost += task_cost;
+        self.state.total_turns += task_turns;
+        save_state_pub(&self.state)?;
+
+        if response_text.is_empty() {
+            bail!("no response text from claude");
+        }
+
+        Ok(response_text)
+    }
+
+    /// Kill current process and spawn a fresh one, resuming the existing session.
+    async fn restart(&mut self) -> Result<()> {
+        self.restarts += 1;
+        if self.restarts > MAX_RESTARTS {
+            bail!("persistent session for '{}' exceeded max restarts ({})", self.name, MAX_RESTARTS);
+        }
+
+        warn!(agent = %self.name, attempt = self.restarts, "restarting persistent session");
+
+        let _ = self.child.kill().await;
+
+        // Reload state in case it was updated externally
+        self.state = load_state(&self.name)?;
+
+        let (child, stdin, stdout_lines) =
+            spawn_process(&self.state.config, &self.state.session_id).await?;
+
+        self.child = child;
+        self.stdin = stdin;
+        self.stdout_lines = stdout_lines;
+
+        info!(agent = %self.name, session = %self.state.session_id, "session restarted");
+        Ok(())
+    }
+
+    /// Gracefully shut down the session (kill the child process).
+    pub async fn shutdown(&mut self) {
+        let _ = self.child.kill().await;
+        info!(agent = %self.name, "session shut down");
+    }
+}
+
+async fn spawn_process(
+    cfg: &AgentConfig,
+    session_id: &str,
+) -> Result<(
+    Child,
+    ChildStdin,
+    tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+)> {
+    let mut args = vec![
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--verbose".to_string(),
+        "--dangerously-skip-permissions".to_string(),
+        "--model".to_string(),
+        cfg.model.clone(),
+    ];
+
+    if !session_id.is_empty() {
+        args.push("--resume".to_string());
+        args.push(session_id.to_string());
+    }
+
+    if !cfg.system_prompt.is_empty() && session_id.is_empty() {
+        args.push("--system-prompt".to_string());
+        args.push(cfg.system_prompt.clone());
+    }
+
+    let mut cmd = build_spawn_command(cfg, &args);
+    let mut child = cmd.spawn().context("failed to spawn claude")?;
+
+    let stdin = child.stdin.take().context("claude has no stdin")?;
+    let stdout = child.stdout.take().context("claude has no stdout")?;
+    let stdout_lines = BufReader::new(stdout).lines();
+
+    Ok((child, stdin, stdout_lines))
+}
+
+fn build_spawn_command(cfg: &AgentConfig, args: &[String]) -> Command {
+    let mut cmd = match &cfg.unix_user {
+        Some(user) => {
+            let mut c = Command::new("sudo");
+            c.args(["-u", user, "-H", "--", "claude"]);
+            c.args(args);
+            c.env_remove("SSH_AUTH_SOCK");
+            c.env_remove("SSH_AGENT_PID");
+            c
+        }
+        None => {
+            let mut c = Command::new("claude");
+            c.args(args);
+            c
+        }
+    };
+    cmd.current_dir(&cfg.work_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null()); // suppress TUI noise
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_message_flatten() {
+        // Multi-line messages are collapsed to a single line for stdin protocol
+        let msg = "line one\nline two\nline three";
+        let flattened = format!("{}\n", msg.replace('\n', " "));
+        assert_eq!(flattened, "line one line two line three\n");
+        assert_eq!(flattened.lines().count(), 1);
+    }
+
+    #[test]
+    fn test_stream_json_result_parse() {
+        let event = serde_json::json!({
+            "type": "result",
+            "session_id": "sess-abc123",
+            "total_cost_usd": 0.042,
+            "num_turns": 3,
+            "subtype": "success",
+        });
+        assert_eq!(event["type"], "result");
+        assert_eq!(event["session_id"], "sess-abc123");
+        assert_eq!(event["total_cost_usd"].as_f64().unwrap(), 0.042);
+        assert_eq!(event["num_turns"].as_u64().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_stream_json_assistant_text_extraction() {
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Hello, "},
+                    {"type": "text", "text": "world!"},
+                    {"type": "tool_use", "name": "Read"}, // non-text block, skip
+                ]
+            }
+        });
+        let mut text = String::new();
+        if let Some(blocks) = event["message"]["content"].as_array() {
+            for block in blocks {
+                if block["type"] == "text" {
+                    if let Some(t) = block["text"].as_str() {
+                        text.push_str(t);
+                    }
+                }
+            }
+        }
+        assert_eq!(text, "Hello, world!");
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,7 +5,8 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::agent;
-use crate::message::{Message, Metadata};
+use crate::message::Metadata;
+use crate::session::PersistentSession;
 
 /// Connect to the bus, register, and return the stream.
 pub async fn bus_connect(
@@ -30,7 +31,13 @@ pub async fn bus_connect(
     Ok(stream)
 }
 
-/// Run the agent worker loop: read messages from bus, execute tasks, post results.
+/// Run the agent worker loop using a persistent Claude session.
+///
+/// A single claude process is kept alive for the lifetime of the worker.
+/// Messages are written to its stdin one at a time; the worker waits for the
+/// `result` event before accepting the next message from the bus.
+///
+/// On process death the session is restarted automatically via --resume.
 pub async fn run(name: &str, socket_path: &str) -> Result<()> {
     let initial_state = agent::load_state(name)?;
     let budget_usd = initial_state.config.budget_usd;
@@ -45,6 +52,9 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
     let mut lines = BufReader::new(reader).lines();
     let writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer));
 
+    // Spawn persistent Claude session — one process for the lifetime of this worker.
+    let mut session = PersistentSession::spawn(name).await?;
+
     info!(agent = %name, "waiting for tasks");
 
     while let Some(line) = lines.next_line().await? {
@@ -52,7 +62,7 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
             continue;
         }
 
-        let msg: Message = match serde_json::from_str(&line) {
+        let msg: serde_json::Value = match serde_json::from_str(&line) {
             Ok(m) => m,
             Err(e) => {
                 warn!(agent = %name, error = %e, "invalid message from bus");
@@ -60,7 +70,7 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
             }
         };
 
-        // Check budget against the configured cap.
+        // Budget check.
         let current_state = agent::load_state(name)?;
         if current_state.total_cost >= budget_usd {
             warn!(
@@ -72,48 +82,36 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
             continue;
         }
 
-        let task = msg.payload.get("task")
-            .and_then(|t| t.as_str())
-            .unwrap_or_default();
-
+        let task = msg["payload"]["task"].as_str().unwrap_or_default();
         if task.is_empty() {
             debug!(agent = %name, "message has no task payload, skipping");
             continue;
         }
 
-        info!(agent = %name, source = %msg.source, task = %truncate(task, 80), "processing task");
+        let msg_id = msg["id"].as_str().unwrap_or("").to_string();
+        let source = msg["source"].as_str().unwrap_or("").to_string();
+        let reply_to = msg["reply_to"].as_str().map(|s| s.to_string());
 
-        let max_turns = msg.payload.get("max_turns")
-            .and_then(|t| t.as_u64())
-            .map(|t| t as u32);
+        info!(agent = %name, source = %source, task = %truncate(task, 80), "processing task");
 
-        match agent::send(name, task, max_turns).await {
-            Ok(response) => {
+        match session.send(task).await {
+            Ok(text) => {
                 info!(agent = %name, "task completed, posting result");
 
-                let target = msg.reply_to.as_deref().unwrap_or(&msg.source);
-
-                let reply = Message {
-                    id: Uuid::new_v4().to_string(),
-                    source: name.to_string(),
-                    target: target.to_string(),
-                    payload: serde_json::json!({
-                        "result": response,
-                        "in_reply_to": msg.id,
-                    }),
-                    reply_to: None,
-                    metadata: Metadata::default(),
-                };
-
-                let envelope = serde_json::json!({
+                let target = reply_to.as_deref().unwrap_or(&source);
+                let reply = serde_json::json!({
                     "type": "message",
-                    "id": reply.id,
-                    "source": reply.source,
-                    "target": reply.target,
-                    "payload": reply.payload,
-                    "metadata": reply.metadata,
+                    "id": Uuid::new_v4().to_string(),
+                    "source": name,
+                    "target": target,
+                    "payload": {
+                        "result": text,
+                        "in_reply_to": msg_id,
+                    },
+                    "metadata": Metadata::default(),
                 });
-                let mut reply_line = serde_json::to_string(&envelope)?;
+
+                let mut reply_line = serde_json::to_string(&reply)?;
                 reply_line.push('\n');
 
                 let mut w = writer.lock().await;
@@ -126,27 +124,28 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
             Err(e) => {
                 warn!(agent = %name, error = %e, "task failed");
 
-                if let Some(reply_to) = &msg.reply_to {
+                if let Some(rt) = &reply_to {
                     let error_msg = serde_json::json!({
                         "type": "message",
                         "id": Uuid::new_v4().to_string(),
                         "source": name,
-                        "target": reply_to,
-                        "payload": {"error": format!("{}", e), "in_reply_to": &msg.id},
+                        "target": rt,
+                        "payload": {"error": format!("{}", e), "in_reply_to": msg_id},
                         "metadata": {"priority": 5u8},
                     });
                     let mut err_line = serde_json::to_string(&error_msg)?;
                     err_line.push('\n');
 
                     let mut w = writer.lock().await;
-                    if let Err(write_err) = w.write_all(err_line.as_bytes()).await {
-                        warn!(agent = %name, error = %write_err, "failed to write error reply to bus");
+                    if let Err(we) = w.write_all(err_line.as_bytes()).await {
+                        warn!(agent = %name, error = %we, "failed to write error reply");
                     }
                 }
             }
         }
     }
 
+    session.shutdown().await;
     info!(agent = %name, "disconnected from bus");
     Ok(())
 }
@@ -192,9 +191,9 @@ pub async fn send_via_bus(
     let mut lines = BufReader::new(reader).lines();
     if let Some(response_line) = lines.next_line().await? {
         let resp: serde_json::Value = serde_json::from_str(&response_line)?;
-        if let Some(result) = resp.get("payload").and_then(|p| p.get("result")).and_then(|r| r.as_str()) {
+        if let Some(result) = resp["payload"]["result"].as_str() {
             println!("{}", result);
-        } else if let Some(err) = resp.get("payload").and_then(|p| p.get("error")).and_then(|e| e.as_str()) {
+        } else if let Some(err) = resp["payload"]["error"].as_str() {
             bail!("Agent error: {}", err);
         } else {
             println!("{}", serde_json::to_string_pretty(&resp)?);


### PR DESCRIPTION
## Summary

Replaces one-shot \`claude -p\` per message with a persistent process.

## Before / After

**Before:** each bus message → new \`claude -p\` process → wait → result → exit  
**After:** one claude process per agent, alive for the whole worker lifetime

```
bus message → stdin write → [stream-json events] → result event → next message
```

## Why stdin streaming

Since deskd owns the process, it can push messages directly into stdin as they arrive from the bus. The worker waits for the `result` event before sending the next message — this gives natural backpressure with no polling.

Session context is maintained in-process (no `--resume` round-trip per message). `--resume` is only used on process restart to recover conversation state.

## New: src/session.rs — PersistentSession

```rust
let mut session = PersistentSession::spawn("kira").await?;

// Each call writes to stdin, reads stream-json until result event
let response = session.send("what files are in the current dir?").await?;

// On process death: auto-restarts with --resume, up to 3 times
```

## Auto-restart

On stdin write failure or stdout EOF: kills process, reloads state from disk (picks up latest session_id), spawns fresh process with `--resume`. Up to `MAX_RESTARTS = 3` attempts.

## Tests

- Message flattening (multi-line input → single stdin line)
- stream-json `result` event parsing
- Assistant text block extraction (multiple text blocks, skip tool_use)

## Note

Requires the claude CLI to support multi-turn stdin input (reading multiple lines sequentially in non-interactive mode). If the CLI exits after the first response, the auto-restart mechanism handles it transparently via `--resume`.

## Depends on

PR #13 (workspace config). Branch based on \`feat/workspace-config\`.

Closes #8