### PR TITLE
feat: hierarchical bus, persistent agents, live agent list

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -15,16 +15,23 @@ pub struct AgentConfig {
     pub system_prompt: String,
     pub work_dir: String,
     pub max_turns: u32,
-    /// Optional Linux user to run the claude process as.
+    /// Optional Linux user to run the agent process as.
     #[serde(default)]
     pub unix_user: Option<String>,
     /// Budget cap in USD.
     #[serde(default = "default_budget_usd")]
     pub budget_usd: f64,
+    /// Command to run. Defaults to ["claude"].
+    #[serde(default = "default_agent_command")]
+    pub command: Vec<String>,
 }
 
 fn default_budget_usd() -> f64 {
     50.0
+}
+
+fn default_agent_command() -> Vec<String> {
+    vec!["claude".to_string()]
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,6 +65,10 @@ fn save_state(state: &AgentState) -> Result<()> {
     let content = serde_yaml::to_string(state)?;
     std::fs::write(&path, content)?;
     Ok(())
+}
+
+pub fn save_state_pub(state: &AgentState) -> Result<()> {
+    save_state(state)
 }
 
 /// Create a new agent (saves state file; does not start a worker process).
@@ -98,6 +109,7 @@ pub async fn create_or_recover(def: &config::AgentDef) -> Result<AgentState> {
         max_turns: def.max_turns,
         unix_user: def.unix_user.clone(),
         budget_usd: def.budget_usd,
+        command: def.command.clone(),
     };
     create(&cfg).await
 }
@@ -198,20 +210,25 @@ pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<S
     Ok(response_text)
 }
 
-/// Build the tokio Command for running claude, respecting unix_user if set.
-fn build_command(cfg: &AgentConfig, args: &[String]) -> Command {
+/// Build the tokio Command for running the agent process.
+/// Uses cfg.command as the executable (defaults to ["claude"]).
+/// When unix_user is set, wraps with sudo and strips SSH env vars.
+pub fn build_command(cfg: &AgentConfig, args: &[String]) -> Command {
+    let (bin, prefix) = split_command(&cfg.command);
     let mut cmd = match &cfg.unix_user {
         Some(user) => {
             let mut c = Command::new("sudo");
-            c.args(["-u", user, "-H", "--", "claude"]);
+            c.args(["-u", user, "-H", "--"]);
+            c.arg(bin);
+            c.args(prefix);
             c.args(args);
-            // Strip SSH agent socket so the child cannot inherit the parent's keys.
             c.env_remove("SSH_AUTH_SOCK");
             c.env_remove("SSH_AGENT_PID");
             c
         }
         None => {
-            let mut c = Command::new("claude");
+            let mut c = Command::new(bin);
+            c.args(prefix);
             c.args(args);
             c
         }
@@ -220,6 +237,14 @@ fn build_command(cfg: &AgentConfig, args: &[String]) -> Command {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     cmd
+}
+
+fn split_command(command: &[String]) -> (&str, &[String]) {
+    match command {
+        [] => ("claude", &[]),
+        [bin] => (bin.as_str(), &[]),
+        [bin, rest @ ..] => (bin.as_str(), rest),
+    }
 }
 
 /// List all agents whose state files exist on disk.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -28,6 +28,10 @@ impl BusState {
         }
     }
 
+    fn list_clients(&self) -> Vec<String> {
+        self.clients.keys().cloned().collect()
+    }
+
     fn route(&self, msg: &Message) {
         let target = &msg.target;
 
@@ -174,6 +178,21 @@ async fn handle_connection(stream: UnixStream, state: Arc<RwLock<BusState>>) -> 
             }
             Envelope::Register(_) => {
                 warn!(client = %name, "ignoring duplicate register");
+            }
+            Envelope::List => {
+                let bus = state.read().await;
+                let clients = bus.list_clients();
+                if let Some(client) = bus.clients.get(&name) {
+                    let resp = Message {
+                        id: "list-response".to_string(),
+                        source: "bus".to_string(),
+                        target: name.clone(),
+                        payload: serde_json::json!({"type": "list_response", "clients": clients}),
+                        reply_to: None,
+                        metadata: crate::message::Metadata::default(),
+                    };
+                    let _ = client.tx.send(resp);
+                }
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,13 +72,47 @@ pub struct AgentDef {
     #[serde(default)]
     pub system_prompt: String,
     pub work_dir: String,
-    /// Optional Linux user to run the claude process as.
+    /// Optional Linux user to run the agent process as.
     pub unix_user: Option<String>,
     #[serde(default = "default_max_turns")]
     pub max_turns: u32,
     /// Budget cap in USD. Worker rejects tasks when this is exceeded.
     #[serde(default = "default_budget_usd")]
     pub budget_usd: f64,
+    /// Command to run as the agent process. Defaults to ["claude"].
+    #[serde(default = "default_command")]
+    pub command: Vec<String>,
+    /// Persistent agents are auto-started on `deskd serve` and restarted on
+    /// crash. Non-persistent agents are spawned on demand. Default: true.
+    #[serde(default = "default_persistent")]
+    pub persistent: bool,
+    /// Socket path for this agent's own sub-bus.
+    /// Sub-agents spawned by this agent connect here, not to the root bus.
+    /// If None, auto-derived as `{bus_dir}/{name}.sock`.
+    pub sub_bus_socket: Option<String>,
+}
+
+fn default_command() -> Vec<String> {
+    vec!["claude".to_string()]
+}
+
+fn default_persistent() -> bool {
+    true
+}
+
+impl AgentDef {
+    /// Compute the sub-bus socket path for this agent.
+    pub fn sub_bus_path(&self, root_bus: &str) -> String {
+        if let Some(ref p) = self.sub_bus_socket {
+            return p.clone();
+        }
+        let root = std::path::Path::new(root_bus);
+        let dir = root.parent().unwrap_or(std::path::Path::new("/tmp"));
+        let stem = root.file_stem().and_then(|s| s.to_str()).unwrap_or("deskd");
+        dir.join(format!("{}-{}.sock", stem, self.name))
+            .to_string_lossy()
+            .into_owned()
+    }
 }
 
 impl WorkspaceConfig {
@@ -184,5 +218,66 @@ agents:
         let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(cfg.agents[0].unix_user.as_deref(), Some("agent-kira"));
         assert_eq!(cfg.agents[0].budget_usd, 25.0);
+    }
+
+    #[test]
+    fn test_agent_def_persistent_default() {
+        let yaml = r#"
+agents:
+  - name: kira
+    model: claude-opus-4-6
+    work_dir: /tmp
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.agents[0].persistent, "persistent should default to true");
+        assert!(cfg.agents[0].sub_bus_socket.is_none());
+    }
+
+    #[test]
+    fn test_agent_def_non_persistent() {
+        let yaml = r#"
+agents:
+  - name: worker
+    model: claude-opus-4-6
+    work_dir: /tmp
+    persistent: false
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(!cfg.agents[0].persistent);
+    }
+
+    #[test]
+    fn test_sub_bus_path_auto_derived() {
+        let def = AgentDef {
+            name: "kira".to_string(),
+            model: "m".to_string(),
+            system_prompt: String::new(),
+            work_dir: "/tmp".to_string(),
+            unix_user: None,
+            max_turns: 100,
+            budget_usd: 50.0,
+            command: vec!["claude".to_string()],
+            persistent: true,
+            sub_bus_socket: None,
+        };
+        assert_eq!(def.sub_bus_path("/run/deskd/root.sock"), "/run/deskd/root-kira.sock");
+        assert_eq!(def.sub_bus_path("/tmp/deskd.sock"), "/tmp/deskd-kira.sock");
+    }
+
+    #[test]
+    fn test_sub_bus_path_explicit() {
+        let def = AgentDef {
+            name: "kira".to_string(),
+            model: "m".to_string(),
+            system_prompt: String::new(),
+            work_dir: "/tmp".to_string(),
+            unix_user: None,
+            max_turns: 100,
+            budget_usd: 50.0,
+            command: vec!["claude".to_string()],
+            persistent: true,
+            sub_bus_socket: Some("/custom/kira.sock".to_string()),
+        };
+        assert_eq!(def.sub_bus_path("/run/deskd/root.sock"), "/custom/kira.sock");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,12 +53,15 @@ enum AgentAction {
         /// Max turns per task.
         #[arg(long, default_value = "100")]
         max_turns: u32,
-        /// Linux user to run claude as (optional).
+        /// Linux user to run the agent process as (optional).
         #[arg(long)]
         unix_user: Option<String>,
         /// Budget cap in USD.
         #[arg(long, default_value = "50.0")]
         budget_usd: f64,
+        /// Command to run as the agent process (default: claude).
+        #[arg(long = "command")]
+        command: Vec<String>,
     },
     /// Send a task to an agent (via bus if running, direct otherwise).
     Send {
@@ -81,8 +84,12 @@ enum AgentAction {
         #[arg(long, default_value = DEFAULT_SOCKET)]
         socket: String,
     },
-    /// List all registered agents with their stats.
-    List,
+    /// List registered agents with their stats (and live status if bus is running).
+    List {
+        /// Bus socket path — when provided, shows which agents are currently connected.
+        #[arg(long, default_value = DEFAULT_SOCKET)]
+        socket: String,
+    },
     /// Show detailed stats for an agent.
     Stats {
         /// Agent name.
@@ -119,6 +126,7 @@ async fn main() -> anyhow::Result<()> {
                 max_turns,
                 unix_user,
                 budget_usd,
+                command,
             } => {
                 let cfg = agent::AgentConfig {
                     name: name.clone(),
@@ -128,6 +136,7 @@ async fn main() -> anyhow::Result<()> {
                     max_turns,
                     unix_user,
                     budget_usd,
+                    command: if command.is_empty() { vec!["claude".to_string()] } else { command },
                 };
                 let state = agent::create(&cfg).await?;
                 println!("Agent {} created", state.config.name);
@@ -156,19 +165,24 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
             }
-            AgentAction::List => {
+            AgentAction::List { socket } => {
                 let agents = agent::list().await?;
+                // Query live connected agents from bus (best-effort).
+                let live = query_live_agents(&socket).await.unwrap_or_default();
+
                 if agents.is_empty() {
                     println!("No agents registered");
                 } else {
                     println!(
-                        "{:<15} {:<8} {:<10} {:<12} {}",
-                        "NAME", "TURNS", "COST", "USER", "MODEL"
+                        "{:<15} {:<7} {:<8} {:<10} {:<12} {}",
+                        "NAME", "STATUS", "TURNS", "COST", "USER", "MODEL"
                     );
                     for a in agents {
+                        let status = if live.contains(&a.config.name) { "live" } else { "idle" };
                         println!(
-                            "{:<15} {:<8} ${:<9.2} {:<12} {}",
+                            "{:<15} {:<7} {:<8} ${:<9.2} {:<12} {}",
                             a.config.name,
+                            status,
                             a.total_turns,
                             a.total_cost,
                             a.config.unix_user.as_deref().unwrap_or("-"),
@@ -217,13 +231,32 @@ async fn serve(socket: String, config_path: Option<String>) -> anyhow::Result<()
         .map(|ws| ws.bus.socket.clone())
         .unwrap_or(socket);
 
-    // Auto-spawn workers for all agents defined in workspace config.
+    // Auto-spawn persistent agents defined in workspace config.
     if let Some(ref ws) = workspace {
         for def in &ws.agents {
+            if !def.persistent {
+                info!(agent = %def.name, "skipping non-persistent agent (on-demand only)");
+                continue;
+            }
+
             let state = agent::create_or_recover(def).await?;
             let name = state.config.name.clone();
+
+            // Each persistent agent gets its own sub-bus for scoped sub-agent spawning.
+            let sub_bus = def.sub_bus_path(&effective_socket);
+            {
+                let sub = sub_bus.clone();
+                let agent_name = name.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = bus::serve(&sub).await {
+                        tracing::error!(agent = %agent_name, socket = %sub, error = %e, "sub-bus failed");
+                    }
+                });
+            }
+            info!(agent = %name, sub_bus = %sub_bus, "started sub-bus for agent");
+
+            // Worker connects to the ROOT bus (receives tasks from external world).
             let sock = effective_socket.clone();
-            info!(agent = %name, "launching worker");
             tokio::spawn(async move {
                 if let Err(e) = worker::run(&name, &sock).await {
                     tracing::error!(agent = %name, error = %e, "worker exited with error");
@@ -232,7 +265,7 @@ async fn serve(socket: String, config_path: Option<String>) -> anyhow::Result<()
         }
     }
 
-    info!(socket = %effective_socket, "starting bus");
+    info!(socket = %effective_socket, "starting root bus");
     tokio::select! {
         result = bus::serve(&effective_socket) => { result?; }
         _ = tokio::signal::ctrl_c() => {
@@ -241,4 +274,48 @@ async fn serve(socket: String, config_path: Option<String>) -> anyhow::Result<()
     }
 
     Ok(())
+}
+
+/// Query the bus for currently connected agent names.
+/// Returns empty vec if the bus is not running or unreachable.
+async fn query_live_agents(socket_path: &str) -> anyhow::Result<std::collections::HashSet<String>> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixStream;
+
+    if !std::path::Path::new(socket_path).exists() {
+        return Ok(Default::default());
+    }
+
+    let mut stream = UnixStream::connect(socket_path).await?;
+
+    // Register as transient query client.
+    let reg = serde_json::json!({"type": "register", "name": "cli-list-query", "subscriptions": []});
+    let mut line = serde_json::to_string(&reg)?;
+    line.push('\n');
+    stream.write_all(line.as_bytes()).await?;
+
+    // Send list query.
+    let query = serde_json::json!({"type": "list"});
+    let mut qline = serde_json::to_string(&query)?;
+    qline.push('\n');
+    stream.write_all(qline.as_bytes()).await?;
+
+    // Read the response (one message).
+    let (reader, _) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    let timeout = tokio::time::Duration::from_secs(2);
+    let resp_line = tokio::time::timeout(timeout, lines.next_line()).await??;
+
+    if let Some(line) = resp_line {
+        let v: serde_json::Value = serde_json::from_str(&line)?;
+        if let Some(arr) = v["payload"]["clients"].as_array() {
+            return Ok(arr.iter()
+                .filter_map(|c| c.as_str())
+                .map(|s| s.to_string())
+                .collect());
+        }
+    }
+
+    Ok(Default::default())
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -34,6 +34,8 @@ fn default_priority() -> u8 {
 pub enum Envelope {
     Register(Register),
     Message(Message),
+    /// Query: list currently connected agents on this bus.
+    List,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Three related features that shape the agent topology.

## 1. Hierarchical (scoped) bus

Each persistent agent gets its own sub-bus socket. Sub-agents spawned by an agent connect to the **agent's** bus, not the root. Agents can only communicate within their own scope.

```
root bus (/run/deskd/root.sock)
├── kira [worker connects to root]
│   kira sub-bus (/run/deskd/root-kira.sock)
│       task-1 (ephemeral) ──connects──► kira's bus
│       task-2 (ephemeral) ──connects──► kira's bus
└── assistant [worker connects to root]
    assistant sub-bus (/run/deskd/root-assistant.sock)
        research-1 ──connects──► assistant's bus
```

Sub-bus socket auto-derived: `/run/deskd/root.sock` → `/run/deskd/root-kira.sock`. Overridable via `sub_bus_socket` in config.

## 2. Persistent vs ephemeral agents

```yaml
agents:
  - name: kira
    persistent: true   # default — auto-started, sub-bus created, recovered on restart

  - name: scraper
    persistent: false  # NOT auto-started — spawned on demand by other agents
```

## 3. `deskd agent list` with live status

```
NAME            STATUS  TURNS    COST       USER         MODEL
kira            live    42       $3.14      agent-kira   claude-opus-4-6
scraper         idle    0        $0.00      -            claude-sonnet-4-6
```

Queries bus via `{"type":"list"}` → `list_response`. Falls back gracefully if bus is not running.

## Protocol change

`message.rs`: added `Envelope::List` variant. `bus.rs`: handles `List` → responds with `list_response` message to requesting client.

## Depends on

PR #13 (workspace config). Branch based on `feat/workspace-config`.