### PR TITLE
feat: agent spawn — ephemeral sub-agents via deskd agent spawn

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -115,7 +115,9 @@ pub async fn create_or_recover(def: &config::AgentDef) -> Result<AgentState> {
 }
 
 /// Send a message to an agent — runs claude CLI and returns the full response text.
-pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<String> {
+/// `sub_bus`: optional path to this agent's sub-bus socket, injected as DESKD_SUB_BUS
+/// into the claude process so it can call `deskd agent spawn`.
+pub async fn send(name: &str, message: &str, max_turns: Option<u32>, sub_bus: Option<&str>) -> Result<String> {
     let mut state = load_state(name)?;
 
     let turns = max_turns.unwrap_or(state.config.max_turns);
@@ -145,7 +147,13 @@ pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<S
 
     debug!(agent = %name, turns, "spawning claude");
 
-    let mut cmd = build_command(&state.config, &args);
+    // Build env vars to inject: agent identity + sub-bus path for agent_spawn support.
+    let mut extra_env: Vec<(&str, &str)> = vec![("DESKD_AGENT_NAME", name)];
+    if let Some(bus) = sub_bus {
+        extra_env.push(("DESKD_SUB_BUS", bus));
+    }
+
+    let mut cmd = build_command(&state.config, &args, &extra_env);
     let output = cmd
         .output()
         .await
@@ -213,7 +221,8 @@ pub async fn send(name: &str, message: &str, max_turns: Option<u32>) -> Result<S
 /// Build the tokio Command for running the agent process.
 /// Uses cfg.command as the executable (defaults to ["claude"]).
 /// When unix_user is set, wraps with sudo and strips SSH env vars.
-pub fn build_command(cfg: &AgentConfig, args: &[String]) -> Command {
+/// extra_env: additional environment variables to pass to the process.
+pub fn build_command(cfg: &AgentConfig, args: &[String], extra_env: &[(&str, &str)]) -> Command {
     let (bin, prefix) = split_command(&cfg.command);
     let mut cmd = match &cfg.unix_user {
         Some(user) => {
@@ -233,6 +242,9 @@ pub fn build_command(cfg: &AgentConfig, args: &[String]) -> Command {
             c
         }
     };
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
     cmd.current_dir(&cfg.work_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -266,6 +278,45 @@ pub async fn list() -> Result<Vec<AgentState>> {
     }
 
     Ok(agents)
+}
+
+/// Spawn an ephemeral sub-agent: create, run task, clean up.
+/// `bus_socket` — the sub-bus of the parent agent (not the root bus).
+/// Returns the agent's text response.
+pub async fn spawn_ephemeral(
+    name: &str,
+    task: &str,
+    model: &str,
+    work_dir: &str,
+    max_turns: u32,
+    bus_socket: &str,
+    parent_name: &str,
+) -> Result<String> {
+    // Use a unique name to avoid collisions when run in parallel.
+    let unique_name = format!("{}-{}", name, uuid::Uuid::new_v4().as_simple());
+
+    let cfg = AgentConfig {
+        name: unique_name.clone(),
+        model: model.to_string(),
+        system_prompt: String::new(),
+        work_dir: work_dir.to_string(),
+        max_turns,
+        unix_user: None,
+        budget_usd: 50.0,
+        command: default_agent_command(),
+    };
+
+    create(&cfg).await?;
+    info!(agent = %unique_name, parent = %parent_name, bus = %bus_socket, "spawning ephemeral sub-agent");
+
+    let result = send(&unique_name, task, Some(max_turns), None).await;
+
+    // Always clean up, even on error.
+    if let Err(e) = remove(&unique_name).await {
+        warn!(agent = %unique_name, error = %e, "failed to clean up ephemeral agent");
+    }
+
+    result
 }
 
 /// Remove an agent (state file + log).
@@ -342,6 +393,7 @@ created_at: "2026-01-01T00:00:00Z"
             max_turns: 100,
             unix_user: Some("agent1".to_string()),
             budget_usd: 10.0,
+            command: vec!["claude".to_string()],
         };
         let state = AgentState {
             config: cfg,

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,27 @@ enum AgentAction {
         /// Agent name.
         name: String,
     },
+    /// Spawn an ephemeral sub-agent, run a task, print result, clean up.
+    /// Intended to be called by a running agent via bash tool.
+    /// Sub-agent connects to the parent agent's sub-bus (DESKD_SUB_BUS env var by default).
+    Spawn {
+        /// Sub-agent name prefix (a UUID suffix is appended to ensure uniqueness).
+        name: String,
+        /// Task to run.
+        task: String,
+        /// Sub-bus socket the spawned agent should use (defaults to $DESKD_SUB_BUS).
+        #[arg(long)]
+        socket: Option<String>,
+        /// Working directory for the spawned agent (defaults to current dir).
+        #[arg(long)]
+        work_dir: Option<String>,
+        /// Claude model to use.
+        #[arg(long, default_value = "claude-sonnet-4-6")]
+        model: String,
+        /// Max turns for this task.
+        #[arg(long, default_value = "50")]
+        max_turns: u32,
+    },
 }
 
 #[tokio::main]
@@ -151,7 +172,7 @@ async fn main() -> anyhow::Result<()> {
                     let target = format!("agent:{}", name);
                     worker::send_via_bus(&socket, "cli", &target, &message, max_turns).await?;
                 } else {
-                    let response = agent::send(&name, &message, max_turns).await?;
+                    let response = agent::send(&name, &message, max_turns, None).await?;
                     println!("{}", response);
                 }
             }
@@ -159,7 +180,7 @@ async fn main() -> anyhow::Result<()> {
                 agent::load_state(&name)?;
                 info!(agent = %name, "starting worker");
                 tokio::select! {
-                    result = worker::run(&name, &socket) => { result?; }
+                    result = worker::run(&name, &socket, None) => { result?; }
                     _ = tokio::signal::ctrl_c() => {
                         info!(agent = %name, "shutting down");
                     }
@@ -210,6 +231,37 @@ async fn main() -> anyhow::Result<()> {
                 agent::remove(&name).await?;
                 println!("Agent {} removed", name);
             }
+            AgentAction::Spawn {
+                name,
+                task,
+                socket,
+                work_dir,
+                model,
+                max_turns,
+            } => {
+                // Resolve bus socket: flag > env var > error.
+                let bus_socket = socket
+                    .or_else(|| std::env::var("DESKD_SUB_BUS").ok())
+                    .ok_or_else(|| anyhow::anyhow!(
+                        "No sub-bus socket: pass --socket or set DESKD_SUB_BUS"
+                    ))?;
+
+                let parent = std::env::var("DESKD_AGENT_NAME").unwrap_or_else(|_| "unknown".into());
+
+                let resolved_work_dir = work_dir.unwrap_or_else(|| ".".into());
+
+                let response = agent::spawn_ephemeral(
+                    &name,
+                    &task,
+                    &model,
+                    &resolved_work_dir,
+                    max_turns,
+                    &bus_socket,
+                    &parent,
+                ).await?;
+
+                println!("{}", response);
+            }
         },
     }
 
@@ -256,9 +308,11 @@ async fn serve(socket: String, config_path: Option<String>) -> anyhow::Result<()
             info!(agent = %name, sub_bus = %sub_bus, "started sub-bus for agent");
 
             // Worker connects to the ROOT bus (receives tasks from external world).
+            // sub_bus is injected as DESKD_SUB_BUS into the claude subprocess.
             let sock = effective_socket.clone();
+            let sub_bus_for_worker = Some(sub_bus.clone());
             tokio::spawn(async move {
-                if let Err(e) = worker::run(&name, &sock).await {
+                if let Err(e) = worker::run(&name, &sock, sub_bus_for_worker).await {
                     tracing::error!(agent = %name, error = %e, "worker exited with error");
                 }
             });

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -31,7 +31,9 @@ pub async fn bus_connect(
 }
 
 /// Run the agent worker loop: read messages from bus, execute tasks, post results.
-pub async fn run(name: &str, socket_path: &str) -> Result<()> {
+/// `sub_bus`: optional path to this agent's own sub-bus socket, injected into the
+/// claude subprocess so it can call `deskd agent spawn` for sub-agent delegation.
+pub async fn run(name: &str, socket_path: &str, sub_bus: Option<String>) -> Result<()> {
     let initial_state = agent::load_state(name)?;
     let budget_usd = initial_state.config.budget_usd;
 
@@ -87,7 +89,7 @@ pub async fn run(name: &str, socket_path: &str) -> Result<()> {
             .and_then(|t| t.as_u64())
             .map(|t| t as u32);
 
-        match agent::send(name, task, max_turns).await {
+        match agent::send(name, task, max_turns, sub_bus.as_deref()).await {
             Ok(response) => {
                 info!(agent = %name, "task completed, posting result");
 


### PR DESCRIPTION
## Summary

- Adds `deskd agent spawn <name> <task>` subcommand so a running Claude agent can delegate tasks to ephemeral sub-agents via the bash tool
- Injects `DESKD_AGENT_NAME` and `DESKD_SUB_BUS` env vars into every claude subprocess so agents always know their own identity and sub-bus path
- Threads sub-bus path through `worker::run()` → `agent::send()` → `build_command()` so it's available at process spawn time
- `agent::spawn_ephemeral()`: appends a UUID suffix to avoid name collisions, creates agent state, runs task, cleans up — even on error

## How it works

When `deskd serve` starts a persistent agent `kira`:
1. Sub-bus is created at e.g. `/tmp/deskd-kira.sock`
2. Worker starts with `sub_bus = Some("/tmp/deskd-kira.sock")`
3. Each time kira's claude process is spawned: `DESKD_SUB_BUS=/tmp/deskd-kira.sock`, `DESKD_AGENT_NAME=kira` are set in its env

When kira wants to delegate a task via bash tool:
```bash
deskd agent spawn researcher "summarize the paper at ..." --work-dir /tmp
```
The result is printed to stdout and captured by Claude's tool output.

## Test plan

- [ ] `DESKD_SUB_BUS` env var is set correctly in claude subprocess (verify with `env | grep DESKD` in system prompt)
- [ ] `deskd agent spawn` without `--socket` and without `DESKD_SUB_BUS` returns a clear error
- [ ] Ephemeral agent state file is cleaned up after task completes (success and error cases)
- [ ] UUID suffix prevents name collisions when multiple spawns happen in parallel