### PR TITLE
feat: per-agent adapters — telegram and worker scoped to agent's sub-bus

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -42,6 +42,10 @@ pub struct AgentState {
     pub total_turns: u32,
     pub total_cost: f64,
     pub created_at: String,
+    /// The Unix socket path of this agent's own sub-bus.
+    /// Set at serve time; used by `deskd agent send` to route without specifying --socket.
+    #[serde(default)]
+    pub sub_bus: Option<String>,
 }
 
 fn state_path(name: &str) -> PathBuf {
@@ -84,6 +88,7 @@ pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
         total_turns: 0,
         total_cost: 0.0,
         created_at: Utc::now().to_rfc3339(),
+        sub_bus: None,
     };
 
     save_state(&state)?;
@@ -92,12 +97,15 @@ pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
 }
 
 /// Create or recover agent state from a workspace AgentDef.
-/// If state already exists on disk, returns existing state (preserving session_id + costs).
-pub async fn create_or_recover(def: &config::AgentDef) -> Result<AgentState> {
+/// If state already exists on disk, returns existing state and updates sub_bus path.
+pub async fn create_or_recover(def: &config::AgentDef, sub_bus: &str) -> Result<AgentState> {
     let path = state_path(&def.name);
     if path.exists() {
-        let state = load_state(&def.name)?;
-        info!(agent = %def.name, session_id = %state.session_id, "recovered existing agent state");
+        let mut state = load_state(&def.name)?;
+        // Always update sub_bus — socket paths can change between runs.
+        state.sub_bus = Some(sub_bus.to_string());
+        save_state(&state)?;
+        info!(agent = %def.name, session_id = %state.session_id, sub_bus = %sub_bus, "recovered existing agent state");
         return Ok(state);
     }
 
@@ -111,7 +119,19 @@ pub async fn create_or_recover(def: &config::AgentDef) -> Result<AgentState> {
         budget_usd: def.budget_usd,
         command: def.command.clone(),
     };
-    create(&cfg).await
+    let mut state = AgentState {
+        config: cfg,
+        pid: 0,
+        session_id: String::new(),
+        total_turns: 0,
+        total_cost: 0.0,
+        created_at: Utc::now().to_rfc3339(),
+        sub_bus: Some(sub_bus.to_string()),
+    };
+    save_state(&state)?;
+    info!(agent = %def.name, sub_bus = %sub_bus, "agent created");
+    state.config.name = def.name.clone(); // ensure
+    Ok(state)
 }
 
 /// Send a message to an agent — runs claude CLI and returns the full response text.
@@ -402,6 +422,7 @@ created_at: "2026-01-01T00:00:00Z"
             total_turns: 5,
             total_cost: 0.42,
             created_at: Utc::now().to_rfc3339(),
+            sub_bus: Some("/run/deskd/root-test-agent.sock".to_string()),
         };
         let yaml = serde_yaml::to_string(&state).unwrap();
         let restored: AgentState = serde_yaml::from_str(&yaml).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,8 +32,6 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub bus: BusConfig,
     #[serde(default)]
-    pub adapters: AdaptersConfig,
-    #[serde(default)]
     pub agents: Vec<AgentDef>,
 }
 
@@ -55,13 +53,10 @@ impl Default for BusConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct AdaptersConfig {
-    pub telegram: Option<TelegramConfig>,
-}
-
+/// Telegram bot adapter config. Defined per-agent — each agent can have its own bot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelegramConfig {
+    /// Bot token from @BotFather. Typically set via ${TELEGRAM_BOT_TOKEN}.
     pub token: String,
 }
 
@@ -87,9 +82,13 @@ pub struct AgentDef {
     #[serde(default = "default_persistent")]
     pub persistent: bool,
     /// Socket path for this agent's own sub-bus.
-    /// Sub-agents spawned by this agent connect here, not to the root bus.
-    /// If None, auto-derived as `{bus_dir}/{name}.sock`.
+    /// The agent's worker, Telegram adapter, and sub-agents all connect here.
+    /// If None, auto-derived as `{bus_dir}/{root_stem}-{name}.sock`.
     pub sub_bus_socket: Option<String>,
+    /// Optional Telegram bot for this agent.
+    /// When set, a Telegram adapter is started on this agent's sub-bus.
+    /// Messages arrive as queue:tasks; replies go back to the sender chat.
+    pub telegram: Option<TelegramConfig>,
 }
 
 fn default_command() -> Vec<String> {
@@ -202,6 +201,7 @@ agents:
         assert_eq!(cfg.agents[0].max_turns, 100);
         assert_eq!(cfg.agents[0].budget_usd, 50.0);
         assert!(cfg.agents[0].unix_user.is_none());
+        assert!(cfg.agents[0].telegram.is_none());
         assert_eq!(cfg.bus.socket, "/tmp/deskd.sock");
     }
 
@@ -247,6 +247,25 @@ agents:
     }
 
     #[test]
+    fn test_workspace_config_per_agent_telegram() {
+        let yaml = r#"
+agents:
+  - name: kira
+    model: claude-opus-4-6
+    work_dir: /tmp
+    telegram:
+      token: "bot-token-123"
+  - name: assistant
+    model: claude-sonnet-4-6
+    work_dir: /tmp
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.agents[0].telegram.is_some());
+        assert_eq!(cfg.agents[0].telegram.as_ref().unwrap().token, "bot-token-123");
+        assert!(cfg.agents[1].telegram.is_none());
+    }
+
+    #[test]
     fn test_sub_bus_path_auto_derived() {
         let def = AgentDef {
             name: "kira".to_string(),
@@ -259,6 +278,7 @@ agents:
             command: vec!["claude".to_string()],
             persistent: true,
             sub_bus_socket: None,
+            telegram: None,
         };
         assert_eq!(def.sub_bus_path("/run/deskd/root.sock"), "/run/deskd/root-kira.sock");
         assert_eq!(def.sub_bus_path("/tmp/deskd.sock"), "/tmp/deskd-kira.sock");
@@ -277,6 +297,7 @@ agents:
             command: vec!["claude".to_string()],
             persistent: true,
             sub_bus_socket: Some("/custom/kira.sock".to_string()),
+            telegram: None,
         };
         assert_eq!(def.sub_bus_path("/run/deskd/root.sock"), "/custom/kira.sock");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,9 +168,17 @@ async fn main() -> anyhow::Result<()> {
                 max_turns,
                 socket,
             } => {
-                if std::path::Path::new(&socket).exists() {
+                // Socket priority: explicit --socket flag > agent's sub_bus from state > direct exec.
+                let effective_socket = if std::path::Path::new(&socket).exists() {
+                    Some(socket)
+                } else {
+                    // Try to find the agent's sub-bus from its state file.
+                    agent::load_state(&name).ok().and_then(|s| s.sub_bus).filter(|p| std::path::Path::new(p).exists())
+                };
+
+                if let Some(sock) = effective_socket {
                     let target = format!("agent:{}", name);
-                    worker::send_via_bus(&socket, "cli", &target, &message, max_turns).await?;
+                    worker::send_via_bus(&sock, "cli", &target, &message, max_turns).await?;
                 } else {
                     let response = agent::send(&name, &message, max_turns, None).await?;
                     println!("{}", response);
@@ -291,11 +299,15 @@ async fn serve(socket: String, config_path: Option<String>) -> anyhow::Result<()
                 continue;
             }
 
-            let state = agent::create_or_recover(def).await?;
+            // Derive agent's sub-bus path before creating state (sub_bus is stored in state).
+            let sub_bus = def.sub_bus_path(&effective_socket);
+            let state = agent::create_or_recover(def, &sub_bus).await?;
             let name = state.config.name.clone();
 
-            // Each persistent agent gets its own sub-bus for scoped sub-agent spawning.
-            let sub_bus = def.sub_bus_path(&effective_socket);
+            // Start the agent's sub-bus. This is the agent's primary bus:
+            //   - worker subscribes here for tasks
+            //   - Telegram adapter (if configured) posts here
+            //   - sub-agents spawned by this agent connect here
             {
                 let sub = sub_bus.clone();
                 let agent_name = name.clone();
@@ -307,12 +319,20 @@ async fn serve(socket: String, config_path: Option<String>) -> anyhow::Result<()
             }
             info!(agent = %name, sub_bus = %sub_bus, "started sub-bus for agent");
 
-            // Worker connects to the ROOT bus (receives tasks from external world).
-            // sub_bus is injected as DESKD_SUB_BUS into the claude subprocess.
-            let sock = effective_socket.clone();
-            let sub_bus_for_worker = Some(sub_bus.clone());
+            // Start Telegram adapter on the agent's sub-bus if configured.
+            // The adapter posts inbound messages as queue:tasks and subscribes to telegram:*
+            // for outbound replies. Wired up when feat/telegram-adapter is merged.
+            if let Some(ref tg) = def.telegram {
+                info!(agent = %name, "telegram adapter configured (token present), will start on sub-bus");
+                let _ = tg; // adapter startup: adapters::telegram::run(tg.clone(), &sub_bus)
+                //           will be activated once the telegram module is available on this branch.
+            }
+
+            // Worker subscribes to agent's sub-bus (agent's primary bus).
+            // DESKD_SUB_BUS is still passed for sub-agent spawning (same path here).
+            let sub = sub_bus.clone();
             tokio::spawn(async move {
-                if let Err(e) = worker::run(&name, &sock, sub_bus_for_worker).await {
+                if let Err(e) = worker::run(&name, &sub, Some(sub.clone())).await {
                     tracing::error!(agent = %name, error = %e, "worker exited with error");
                 }
             });


### PR DESCRIPTION
## Summary

Implements the correct bus topology: each persistent agent has its own sub-bus as its **primary bus**. Workers, Telegram adapters, and sub-agents all operate within this scope.

### Architecture change

```
BEFORE:
  root bus ← worker (all agents)
  root bus ← Telegram (global)
  sub-bus ← sub-agents only

AFTER:
  root bus ← admin/CLI only
  agent's sub-bus ← worker
  agent's sub-bus ← Telegram adapter (agent's own bot)
  agent's sub-bus ← sub-agents
```

### Config change: `telegram` moves into `AgentDef`

```yaml
agents:
  - name: kira
    model: claude-opus-4-6
    unix_user: kira
    work_dir: /home/agent-kira
    telegram:
      token: ${KIRA_BOT_TOKEN}   # kira's own bot

  - name: assistant
    model: claude-sonnet-4-6
    unix_user: assistant
    work_dir: /home/agent-assistant
    # no telegram
```

Global `adapters` section removed from `WorkspaceConfig`.

### Other changes

- `AgentState.sub_bus: Option<String>` — bus socket path written at serve time
- `deskd agent send kira "task"` auto-resolves socket from state (no `--socket` needed)
- `create_or_recover(def, sub_bus)` updates sub_bus on every restart (path can change)
- Telegram startup in `serve()` stubbed — active once `feat/telegram-adapter` is merged

## Test plan

- [ ] `deskd agent send kira "task"` finds sub-bus from state, no `--socket` flag needed
- [ ] `deskd agent send kira "task" --socket /custom.sock` overrides state lookup
- [ ] Agent state file contains correct `sub_bus` path after `deskd serve`
- [ ] Agent with `telegram: {token: ...}` logs "telegram adapter configured" at serve time
- [ ] Agent without `telegram` starts worker only, no telegram log