### PR TITLE
fix: restart typing indicator after each streamed message

### DIFF
--- a/src/adapters/telegram.rs
+++ b/src/adapters/telegram.rs
@@ -173,6 +173,19 @@ async fn bus_loop(
     Ok(())
 }
 
+/// Spawn a background loop that sends typing action every 4 seconds.
+/// Telegram shows the indicator for ~5s, so 4s keeps it alive continuously.
+fn spawn_typing(bot: Bot, chat_id: i64) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let _ = bot
+                .send_chat_action(ChatId(chat_id), ChatAction::Typing)
+                .await;
+            tokio::time::sleep(Duration::from_secs(4)).await;
+        }
+    })
+}
+
 /// Send messages from the outbound channel to Telegram.
 /// Manages per-chat typing indicators and converts Markdown to HTML.
 async fn outbound_sender(bot: Bot, mut rx: mpsc::UnboundedReceiver<OutboundCmd>) {
@@ -181,7 +194,8 @@ async fn outbound_sender(bot: Bot, mut rx: mpsc::UnboundedReceiver<OutboundCmd>)
     while let Some(cmd) = rx.recv().await {
         match cmd {
             OutboundCmd::Text { chat_id, text } => {
-                // Cancel typing indicator for this chat when a message arrives.
+                // Abort current typing loop while sending so Telegram doesn't show
+                // typing and a new message at the same time.
                 if let Some(handle) = typing_tasks.remove(&chat_id) {
                     handle.abort();
                 }
@@ -200,24 +214,17 @@ async fn outbound_sender(bot: Bot, mut rx: mpsc::UnboundedReceiver<OutboundCmd>)
                         warn!(chat_id = chat_id, error = %e, "failed to send Telegram message");
                     }
                 }
+
+                // Restart typing loop — more streaming chunks may still be coming.
+                // Will be cancelled by TypingStop when the task finishes.
+                typing_tasks.insert(chat_id, spawn_typing(bot.clone(), chat_id));
             }
             OutboundCmd::TypingStart(chat_id) => {
                 // Cancel any existing typing task for this chat.
                 if let Some(handle) = typing_tasks.remove(&chat_id) {
                     handle.abort();
                 }
-                // Spawn a loop that sends "typing" action every 4 seconds.
-                // Telegram shows the indicator for ~5s, so 4s keeps it alive continuously.
-                let bot_clone = bot.clone();
-                let handle = tokio::spawn(async move {
-                    loop {
-                        let _ = bot_clone
-                            .send_chat_action(ChatId(chat_id), ChatAction::Typing)
-                            .await;
-                        tokio::time::sleep(Duration::from_secs(4)).await;
-                    }
-                });
-                typing_tasks.insert(chat_id, handle);
+                typing_tasks.insert(chat_id, spawn_typing(bot.clone(), chat_id));
             }
             OutboundCmd::TypingStop(chat_id) => {
                 if let Some(handle) = typing_tasks.remove(&chat_id) {


### PR DESCRIPTION
## Problem

The typing indicator disappears after the first streaming chunk is sent to Telegram.

**Root cause:** `OutboundCmd::Text` cancels the typing loop before sending the message, but never restarts it. The indicator is only alive from `TypingStart` until the first message — typically just a few seconds.

## Fix

After sending each outbound message, restart the typing loop. It will run until `TypingStop` is received (sent by the worker when the task finishes). Extracted the spawn logic into a `spawn_typing()` helper to avoid duplication.

**Flow after fix:**
1. Task starts → `TypingStart` → typing loop running
2. Streaming chunk arrives → abort loop → send message → restart loop ✅
3. More chunks → same as above
4. Task done → `TypingStop` → loop cancelled ✅

## Test plan

- [ ] Send a message that takes >5s to respond
- [ ] Confirm typing indicator stays visible throughout
- [ ] Confirm typing stops after response is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)