### PR TITLE
fix: auto-clear stale session_id and retry (#25)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -295,6 +295,21 @@ async fn send_inner(
         if !stderr_str.is_empty() {
             bail!("Claude error: {}", stderr_str.trim());
         }
+        // If we used --resume and got no response, the session_id is stale.
+        // Clear it and retry once with a fresh session.
+        if !state.session_id.is_empty() {
+            warn!(agent = %name, session_id = %state.session_id, "stale session_id — retrying without --resume");
+            state.session_id = String::new();
+            save_state(&state)?;
+            return Box::pin(send_inner(
+                name,
+                message,
+                max_turns,
+                bus_socket,
+                progress_tx,
+            ))
+            .await;
+        }
         bail!("No response from claude");
     }
 


### PR DESCRIPTION
Fixes #25.

When `--resume <session_id>` returns no output (stale session from another machine or expired), deskd now automatically:
1. Logs a warning with the stale session_id
2. Clears `session_id` in agent state
3. Retries the task once with a fresh session

No more manual editing of `~/.deskd/agents/<name>.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)