### PR TITLE
feat: deskd status dashboard (#28)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -46,6 +46,16 @@ pub struct AgentState {
     pub total_turns: u32,
     pub total_cost: f64,
     pub created_at: String,
+    /// "idle" or "working"
+    #[serde(default = "default_status")]
+    pub status: String,
+    /// Truncated text of the task currently being processed.
+    #[serde(default)]
+    pub current_task: String,
+}
+
+fn default_status() -> String {
+    "idle".to_string()
 }
 
 fn state_path(name: &str) -> PathBuf {
@@ -71,7 +81,7 @@ fn save_state(state: &AgentState) -> Result<()> {
     Ok(())
 }
 
-pub fn _save_state_pub(state: &AgentState) -> Result<()> {
+pub fn save_state_pub(state: &AgentState) -> Result<()> {
     save_state(state)
 }
 
@@ -88,6 +98,8 @@ pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
         total_turns: 0,
         total_cost: 0.0,
         created_at: Utc::now().to_rfc3339(),
+        status: "idle".to_string(),
+        current_task: String::new(),
     };
 
     save_state(&state)?;
@@ -143,6 +155,8 @@ pub async fn create_or_recover(
         total_turns: 0,
         total_cost: 0.0,
         created_at: Utc::now().to_rfc3339(),
+        status: "idle".to_string(),
+        current_task: String::new(),
     };
     save_state(&state)?;
     info!(agent = %def.name, "agent created");
@@ -460,6 +474,8 @@ created_at: "2024-01-01T00:00:00Z"
             total_turns: 5,
             total_cost: 0.42,
             created_at: Utc::now().to_rfc3339(),
+            status: "idle".to_string(),
+            current_task: String::new(),
         };
         let yaml = serde_yaml::to_string(&state).unwrap();
         let restored: AgentState = serde_yaml::from_str(&yaml).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,12 @@ enum Commands {
         #[command(subcommand)]
         action: AgentAction,
     },
+    /// Show live status of all agents defined in workspace config.
+    Status {
+        /// Path to workspace.yaml.
+        #[arg(long)]
+        config: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -320,6 +326,39 @@ async fn main() -> anyhow::Result<()> {
                 println!("{}", response);
             }
         },
+        Commands::Status {
+            config: config_path,
+        } => {
+            let workspace = config::WorkspaceConfig::load(&config_path)?;
+            println!(
+                "{:<12} {:<9} {:<6} {:<10} CURRENT TASK",
+                "NAME", "STATUS", "TURNS", "COST"
+            );
+            println!("{}", "─".repeat(70));
+            for def in &workspace.agents {
+                let bus_socket = def.bus_socket();
+                let online = std::path::Path::new(&bus_socket).exists();
+                let state = agent::load_state(&def.name).ok();
+                let (status, turns, cost, current_task) = match &state {
+                    Some(s) if online => (
+                        s.status.as_str(),
+                        s.total_turns,
+                        s.total_cost,
+                        if s.current_task.is_empty() {
+                            "-".to_string()
+                        } else {
+                            truncate_main(&s.current_task, 40)
+                        },
+                    ),
+                    Some(s) => ("offline", s.total_turns, s.total_cost, "-".to_string()),
+                    None => ("offline", 0, 0.0, "-".to_string()),
+                };
+                println!(
+                    "{:<12} {:<9} {:<6} ${:<9.4} {}",
+                    def.name, status, turns, cost, current_task
+                );
+            }
+        }
     }
 
     Ok(())

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -117,6 +117,13 @@ pub async fn run(name: &str, socket_path: &str, bus_socket: Option<String>) -> R
 
         info!(agent = %name, source = %msg.source, task = %truncate(task, 80), "processing task");
 
+        // Mark agent as working so `deskd status` can report live state.
+        if let Ok(mut st) = agent::load_state(name) {
+            st.status = "working".to_string();
+            st.current_task = truncate(task, 80).to_string();
+            let _ = agent::save_state_pub(&st);
+        }
+
         let max_turns = msg
             .payload
             .get("max_turns")
@@ -174,6 +181,7 @@ pub async fn run(name: &str, socket_path: &str, bus_socket: Option<String>) -> R
             )
             .await;
 
+            set_idle(name);
             if let Err(e) = result {
                 warn!(agent = %name, error = %e, "task failed");
                 write_inbox(name, &msg, task, None, Some(format!("{}", e)));
@@ -191,6 +199,7 @@ pub async fn run(name: &str, socket_path: &str, bus_socket: Option<String>) -> R
             // Non-Telegram: send full response after completion
             match agent::send(name, task, max_turns, bus_socket.as_deref()).await {
                 Ok(response) => {
+                    set_idle(name);
                     info!(agent = %name, "task completed, posting result");
 
                     // Write to file-based inbox for async reading.
@@ -229,6 +238,7 @@ pub async fn run(name: &str, socket_path: &str, bus_socket: Option<String>) -> R
                     }
                 }
                 Err(e) => {
+                    set_idle(name);
                     warn!(agent = %name, error = %e, "task failed");
 
                     // Write error to inbox.
@@ -258,6 +268,15 @@ pub async fn run(name: &str, socket_path: &str, bus_socket: Option<String>) -> R
 
     info!(agent = %name, "disconnected from bus");
     Ok(())
+}
+
+/// Mark agent as idle in its state file.
+fn set_idle(name: &str) {
+    if let Ok(mut st) = agent::load_state(name) {
+        st.status = "idle".to_string();
+        st.current_task = String::new();
+        let _ = agent::save_state_pub(&st);
+    }
 }
 
 /// Send a message via the bus (connect, send, wait for one reply, disconnect).


### PR DESCRIPTION
Fixes #28.

Adds `deskd status --config workspace.yaml`:

```
NAME         STATUS    TURNS  COST       CURRENT TASK
──────────────────────────────────────────────────────────────────────
kira         working   42     $0.1234    Check open PRs in deskd...
dev          idle      13     $0.0321    -
```

**STATUS** values:
- `working` — processing a task right now
- `idle` — connected, waiting for tasks
- `offline` — bus socket not found (deskd not running for this agent)

**Implementation:**
- `AgentState` gains `status` and `current_task` fields (`#[serde(default)]` — backwards compatible)
- Worker sets `working` + stores truncated task text on task start
- Worker resets to `idle` on completion or error (both Telegram and non-Telegram paths)
- `deskd status` reads workspace config + state files, checks socket existence

🤖 Generated with [Claude Code](https://claude.com/claude-code)