### PR TITLE
feat: inject Telegram channel context into agent tasks

### DIFF
--- a/src/adapters/telegram.rs
+++ b/src/adapters/telegram.rs
@@ -27,11 +27,13 @@ enum OutboundCmd {
 /// Run the Telegram adapter for a specific agent.
 /// `agent_name` is used to name the bus registration and for logging.
 /// `mention_only_chats` is a set of chat_ids where only @mentions trigger the agent.
+/// `chat_names` maps chat_id to a human-readable name shown to the agent as context.
 pub async fn run(
     token: String,
     socket_path: String,
     agent_name: String,
     mention_only_chats: Vec<i64>,
+    chat_names: std::collections::HashMap<i64, String>,
 ) -> Result<()> {
     info!(agent = %agent_name, "starting Telegram adapter");
 
@@ -75,7 +77,9 @@ pub async fn run(
         let name = agent_name.clone();
         let mention_only: std::collections::HashSet<i64> = mention_only_chats.into_iter().collect();
         tokio::spawn(async move {
-            if let Err(e) = polling_loop(bot, socket, name, bot_username, mention_only).await {
+            if let Err(e) =
+                polling_loop(bot, socket, name, bot_username, mention_only, chat_names).await
+            {
                 tracing::error!(error = %e, "telegram polling loop failed");
             }
         })
@@ -264,12 +268,14 @@ async fn polling_loop(
     agent_name: String,
     bot_username: String,
     mention_only_chats: std::collections::HashSet<i64>,
+    chat_names: std::collections::HashMap<i64, String>,
 ) -> Result<()> {
     teloxide::repl(bot, move |bot: Bot, msg: Message| {
         let socket = socket_path.clone();
         let agent = agent_name.clone();
         let bot_user = bot_username.clone();
         let mention_only = mention_only_chats.clone();
+        let names = chat_names.clone();
         async move {
             // Skip messages from the bot itself to prevent reply loops.
             if msg.from.as_ref().map(|u| u.username.as_deref() == Some(&bot_user)).unwrap_or(false) {
@@ -294,10 +300,14 @@ async fn polling_loop(
 
                 let target = format!("telegram.in:{}", chat_id);
                 let reply_to = format!("telegram.out:{}", chat_id);
+                let chat_name = names.get(&chat_id).cloned();
 
                 debug!(agent = %agent, chat_id = chat_id, "received Telegram message");
 
-                if let Err(e) = publish_to_bus(&socket, &agent, text, &target, &reply_to).await {
+                if let Err(e) =
+                    publish_to_bus(&socket, &agent, text, &target, &reply_to, chat_id, chat_name)
+                        .await
+                {
                     warn!(chat_id = chat_id, error = %e, "failed to publish message to bus");
                     let _ = bot
                         .send_message(msg.chat.id, "Internal error, please try again.")
@@ -319,6 +329,8 @@ async fn publish_to_bus(
     text: &str,
     target: &str,
     reply_to: &str,
+    chat_id: i64,
+    chat_name: Option<String>,
 ) -> Result<()> {
     let mut stream = UnixStream::connect(socket_path)
         .await
@@ -340,6 +352,8 @@ async fn publish_to_bus(
         "target": target,
         "payload": {
             "task": text,
+            "telegram_chat_id": chat_id,
+            "telegram_chat_name": chat_name,
         },
         "reply_to": reply_to,
         "metadata": {"priority": 5u8},

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,8 @@ pub struct TelegramRoute {
     /// If true, only respond when the bot is @mentioned in this chat.
     #[serde(default)]
     pub mention_only: bool,
+    /// Human-readable name for this chat, shown to the agent as context.
+    pub name: Option<String>,
 }
 
 /// A scheduled action that fires on a cron expression and posts a message to the bus.
@@ -484,6 +486,7 @@ schedules:
                 routes: vec![TelegramRoute {
                     chat_id: -1003733725513,
                     mention_only: false,
+                    name: None,
                 }],
             }),
             schedules: vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,21 +384,29 @@ async fn serve(config_path: String) -> anyhow::Result<()> {
             let token = tg.token.clone();
             let bus = bus_socket.clone();
             let agent_name = name.clone();
-            let mention_only_chats = user_cfg
+            let routes = user_cfg
                 .as_ref()
                 .and_then(|c| c.telegram.as_ref())
-                .map(|t| {
-                    t.routes
-                        .iter()
-                        .filter(|r| r.mention_only)
-                        .map(|r| r.chat_id)
-                        .collect::<Vec<_>>()
-                })
+                .map(|t| t.routes.clone())
                 .unwrap_or_default();
+            let mention_only_chats = routes
+                .iter()
+                .filter(|r| r.mention_only)
+                .map(|r| r.chat_id)
+                .collect::<Vec<_>>();
+            let chat_names = routes
+                .iter()
+                .filter_map(|r| r.name.as_ref().map(|n| (r.chat_id, n.clone())))
+                .collect::<std::collections::HashMap<_, _>>();
             tokio::spawn(async move {
-                if let Err(e) =
-                    adapters::telegram::run(token, bus, agent_name.clone(), mention_only_chats)
-                        .await
+                if let Err(e) = adapters::telegram::run(
+                    token,
+                    bus,
+                    agent_name.clone(),
+                    mention_only_chats,
+                    chat_names,
+                )
+                .await
                 {
                     tracing::error!(agent = %agent_name, error = %e, "telegram adapter failed");
                 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -104,16 +104,32 @@ pub async fn run(name: &str, socket_path: &str, bus_socket: Option<String>) -> R
             continue;
         }
 
-        let task = msg
+        let task_raw = msg
             .payload
             .get("task")
             .and_then(|t| t.as_str())
             .unwrap_or_default();
 
-        if task.is_empty() {
+        if task_raw.is_empty() {
             debug!(agent = %name, "message has no task payload, skipping");
             continue;
         }
+
+        // Prepend channel context so the agent knows where the message came from.
+        let task_owned;
+        let task =
+            if let Some(chat_id) = msg.payload.get("telegram_chat_id").and_then(|v| v.as_i64()) {
+                let label = msg
+                    .payload
+                    .get("telegram_chat_name")
+                    .and_then(|v| v.as_str())
+                    .map(|n| format!("{} ({})", n, chat_id))
+                    .unwrap_or_else(|| chat_id.to_string());
+                task_owned = format!("[Telegram: {}]\n{}", label, task_raw);
+                &task_owned as &str
+            } else {
+                task_raw
+            };
 
         info!(agent = %name, source = %msg.source, task = %truncate(task, 80), "processing task");
 


### PR DESCRIPTION
## Summary

- Incoming Telegram messages now carry `telegram_chat_id` and `telegram_chat_name` in the bus payload
- The worker prepends `[Telegram: name (id)]` to the task text, so the agent always knows which channel a message came from (e.g. `[Telegram: collab (-1003754811357)]`)
- Adds optional `name: Option<String>` field to `TelegramRoute` in `deskd.yaml` config for human-readable channel labels

## Test plan

- [ ] All 30 existing unit tests pass (`cargo test`)
- [ ] `cargo clippy -- -D warnings` passes with no errors
- [ ] Deploy with a `name` set on a route, send a message, confirm the agent task starts with `[Telegram: <name> (<id>)]`
- [ ] Deploy without a `name` on a route, send a message, confirm the task starts with `[Telegram: <id>]` (chat_id only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)