### PR TITLE
Auto-start sub-agent workers defined in deskd.yaml

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -107,6 +107,33 @@ pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
     Ok(state)
 }
 
+/// Create or update agent state from an AgentConfig.
+/// If state already exists, updates the config fields but preserves session/cost/turns.
+/// Used for sub-agents spawned from deskd.yaml.
+pub async fn create_or_update_from_config(cfg: &AgentConfig) -> Result<AgentState> {
+    let path = state_path(&cfg.name);
+    if path.exists() {
+        let mut state = load_state(&cfg.name)?;
+        state.config = cfg.clone();
+        save_state(&state)?;
+        info!(agent = %cfg.name, "sub-agent state updated");
+        return Ok(state);
+    }
+    let state = AgentState {
+        config: cfg.clone(),
+        pid: 0,
+        session_id: String::new(),
+        total_turns: 0,
+        total_cost: 0.0,
+        created_at: Utc::now().to_rfc3339(),
+        status: "idle".to_string(),
+        current_task: String::new(),
+    };
+    save_state(&state)?;
+    info!(agent = %cfg.name, "sub-agent created");
+    Ok(state)
+}
+
 /// Create or recover agent state from workspace AgentDef + optional UserConfig.
 /// If state already exists, returns it with config fields updated from current def.
 /// Model priority: workspace def.model override > user_cfg.model > default.

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,9 @@ enum AgentAction {
         name: String,
         #[arg(long, default_value = DEFAULT_SOCKET)]
         socket: String,
+        /// Custom subscriptions (overrides defaults). Can be repeated.
+        #[arg(long)]
+        subscribe: Vec<String>,
     },
     /// List registered agents with live status.
     List {
@@ -194,11 +197,20 @@ async fn main() -> anyhow::Result<()> {
                     println!("{}", response);
                 }
             }
-            AgentAction::Run { name, socket } => {
+            AgentAction::Run {
+                name,
+                socket,
+                subscribe,
+            } => {
                 agent::load_state(&name)?;
+                let subs = if subscribe.is_empty() {
+                    None
+                } else {
+                    Some(subscribe)
+                };
                 info!(agent = %name, "starting worker");
                 tokio::select! {
-                    result = worker::run(&name, &socket, Some(socket.clone())) => { result?; }
+                    result = worker::run(&name, &socket, Some(socket.clone()), subs) => { result?; }
                     _ = tokio::signal::ctrl_c() => {
                         info!(agent = %name, "shutting down");
                     }
@@ -466,10 +478,62 @@ async fn serve(config_path: String) -> anyhow::Result<()> {
         // Start worker on the agent's bus.
         let bus = bus_socket.clone();
         tokio::spawn(async move {
-            if let Err(e) = worker::run(&name, &bus, Some(bus.clone())).await {
+            if let Err(e) = worker::run(&name, &bus, Some(bus.clone()), None).await {
                 tracing::error!(agent = %name, error = %e, "worker exited with error");
             }
         });
+
+        // Start sub-agent workers defined in the agent's deskd.yaml.
+        if let Some(ref ucfg) = user_cfg {
+            for sub in &ucfg.agents {
+                let mcp_json = serde_json::json!({
+                    "mcpServers": {
+                        "deskd": {
+                            "command": "deskd",
+                            "args": ["mcp", "--agent", &sub.name]
+                        }
+                    }
+                })
+                .to_string();
+
+                let sub_cfg = agent::AgentConfig {
+                    name: sub.name.clone(),
+                    model: sub.model.clone(),
+                    system_prompt: sub.system_prompt.clone(),
+                    work_dir: def.work_dir.clone(),
+                    max_turns: ucfg.max_turns,
+                    unix_user: def.unix_user.clone(),
+                    budget_usd: def.budget_usd,
+                    command: vec![
+                        "claude".into(),
+                        "--output-format".into(),
+                        "stream-json".into(),
+                        "--verbose".into(),
+                        "--dangerously-skip-permissions".into(),
+                        "--model".into(),
+                        sub.model.clone(),
+                        "--max-turns".into(),
+                        ucfg.max_turns.to_string(),
+                        "--mcp-config".into(),
+                        mcp_json,
+                    ],
+                    config_path: Some(cfg_path.clone()),
+                };
+                agent::create_or_update_from_config(&sub_cfg).await?;
+
+                let sub_name = sub.name.clone();
+                let bus = bus_socket.clone();
+                let subs = sub.subscribe.clone();
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        worker::run(&sub_name, &bus, Some(bus.clone()), Some(subs)).await
+                    {
+                        tracing::error!(agent = %sub_name, error = %e, "sub-agent worker exited");
+                    }
+                });
+                info!(agent = %def.name, sub_agent = %sub.name, "started sub-agent worker");
+            }
+        }
     }
 
     info!("all agents started — press Ctrl-C to stop");

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -381,8 +381,19 @@ async fn call_add_persistent_agent(
     }
 
     // Start the worker as a background process connected to the parent's bus.
+    let mut run_args = vec![
+        "agent".to_string(),
+        "run".to_string(),
+        name.to_string(),
+        "--socket".to_string(),
+        bus_socket.to_string(),
+    ];
+    for sub in &subscribe {
+        run_args.push("--subscribe".to_string());
+        run_args.push(sub.clone());
+    }
     let _child = tokio::process::Command::new(&deskd_bin)
-        .args(["agent", "run", name, "--socket", bus_socket])
+        .args(&run_args)
         .env("DESKD_BUS_SOCKET", bus_socket)
         .env("DESKD_AGENT_NAME", name)
         .spawn()

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -58,19 +58,27 @@ fn write_inbox(
 /// Run the agent worker loop: read messages from bus, execute tasks, post results.
 /// `bus_socket`: the agent's bus socket path, injected as DESKD_BUS_SOCKET into
 /// the claude subprocess so the MCP server can connect to the bus.
-pub async fn run(name: &str, socket_path: &str, bus_socket: Option<String>) -> Result<()> {
+pub async fn run(
+    name: &str,
+    socket_path: &str,
+    bus_socket: Option<String>,
+    subscriptions: Option<Vec<String>>,
+) -> Result<()> {
     let initial_state = agent::load_state(name)?;
     let budget_usd = initial_state.config.budget_usd;
 
-    // Default subscriptions. Workers receive:
+    // Use custom subscriptions if provided, otherwise default.
+    // Default subscriptions: Workers receive:
     //   agent:<name>     — direct messages (from MCP send_message, other agents, CLI)
     //   queue:tasks      — shared task queue
     //   telegram.in:*    — messages arriving from Telegram adapter
-    let subscriptions = vec![
-        format!("agent:{}", name),
-        "queue:tasks".to_string(),
-        "telegram.in:*".to_string(),
-    ];
+    let subscriptions = subscriptions.unwrap_or_else(|| {
+        vec![
+            format!("agent:{}", name),
+            "queue:tasks".to_string(),
+            "telegram.in:*".to_string(),
+        ]
+    });
 
     let stream = bus_connect(socket_path, name, subscriptions).await?;
     let (reader, writer) = stream.into_split();


### PR DESCRIPTION
## Summary

Closes #45.

- `deskd serve` now auto-spawns workers for each sub-agent defined in `agents:` section of the agent's `deskd.yaml`
- Sub-agent workers connect to the parent's bus with their configured `subscribe` targets
- Each sub-agent gets its own `AgentState` (created or updated idempotently via new `create_or_update_from_config`)
- Also fixes `add_persistent_agent` MCP tool which previously ignored the `subscribe` parameter
- `deskd agent run` gains a `--subscribe` CLI flag for custom subscriptions

## Changes

| File | What |
|------|------|
| `worker.rs` | `run()` accepts optional `subscriptions` param |
| `agent.rs` | New `create_or_update_from_config()` for idempotent sub-agent state |
| `main.rs` | Sub-agent spawn loop in `serve()`, `--subscribe` flag on `agent run` |
| `mcp.rs` | `add_persistent_agent` passes `--subscribe` to spawned worker |

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 30/30 pass
- [ ] Manual: run `deskd serve` with a config that has sub-agents, verify workers connect to bus
- [ ] Manual: send message to `agent:haiku` via MCP, verify response arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)