### PR TITLE
feat: deskd agent tasks — show completed tasks from inbox

### DIFF
--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -73,6 +73,47 @@ pub fn read(agent: &str) -> Result<Vec<(PathBuf, InboxEntry)>> {
     Ok(entries)
 }
 
+/// Read all inbox entries across all source directories, sorted by filename (oldest first).
+pub fn read_all() -> Result<Vec<InboxEntry>> {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let base = PathBuf::from(home).join(".deskd").join("inbox");
+    if !base.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut entries: Vec<InboxEntry> = Vec::new();
+    let mut all_paths: Vec<PathBuf> = Vec::new();
+
+    for dir_entry in std::fs::read_dir(&base)? {
+        let dir_entry = dir_entry?;
+        if !dir_entry.file_type()?.is_dir() {
+            continue;
+        }
+        let dir = dir_entry.path();
+        for file_entry in std::fs::read_dir(&dir)? {
+            let file_entry = file_entry?;
+            let path = file_entry.path();
+            if path.extension().map(|e| e == "json").unwrap_or(false) {
+                all_paths.push(path);
+            }
+        }
+    }
+
+    all_paths.sort();
+
+    for path in all_paths {
+        let content = std::fs::read_to_string(&path)?;
+        match serde_json::from_str::<InboxEntry>(&content) {
+            Ok(entry) => entries.push(entry),
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping malformed inbox entry");
+            }
+        }
+    }
+
+    Ok(entries)
+}
+
 /// Remove specific inbox files (after reading).
 pub fn clear(paths: &[PathBuf]) -> Result<()> {
     for path in paths {

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,14 @@ enum AgentAction {
         #[arg(long, default_value = "false")]
         clear: bool,
     },
+    /// Show recent completed tasks for an agent (from inbox files).
+    Tasks {
+        /// Agent name, or "all" to show tasks for all agents.
+        name: String,
+        /// Show last N tasks (default 20).
+        #[arg(long, default_value = "20")]
+        limit: usize,
+    },
     /// Remove an agent (state file + log).
     Rm { name: String },
     /// Spawn an ephemeral sub-agent, run a task, print result, clean up.
@@ -303,6 +311,69 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
             }
+            AgentAction::Tasks { name, limit } => {
+                let all_entries = inbox::read_all()?;
+                let show_all = name == "all";
+                let mut filtered: Vec<_> = if show_all {
+                    all_entries
+                } else {
+                    all_entries
+                        .into_iter()
+                        .filter(|e| e.agent == name)
+                        .collect()
+                };
+                // Sort by timestamp descending (newest first).
+                filtered.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+                filtered.truncate(limit);
+
+                if filtered.is_empty() {
+                    if show_all {
+                        println!("No completed tasks found");
+                    } else {
+                        println!("No completed tasks for {}", name);
+                    }
+                } else {
+                    println!("COMPLETED ({}):", filtered.len());
+                    let now = chrono::Utc::now();
+                    for entry in &filtered {
+                        let age = if let Ok(ts) =
+                            chrono::DateTime::parse_from_rfc3339(&entry.timestamp)
+                        {
+                            let dur = now.signed_duration_since(ts);
+                            format_relative_time(dur)
+                        } else {
+                            "??".to_string()
+                        };
+                        let id_short = if entry.id.len() > 6 {
+                            &entry.id[..6]
+                        } else {
+                            &entry.id
+                        };
+                        let task_excerpt = truncate_main(&entry.task, 36);
+                        let status = if entry.error.is_some() { "err" } else { "done" };
+                        if show_all {
+                            println!(
+                                "  {:<8} {:<12} from:{:<6} {:38} {} {} ago",
+                                id_short,
+                                entry.agent,
+                                entry.source,
+                                format!("\"{}\"", task_excerpt),
+                                status,
+                                age,
+                            );
+                        } else {
+                            println!(
+                                "  {:<8} from:{:<6} {:38} {} {} ago",
+                                id_short,
+                                entry.source,
+                                format!("\"{}\"", task_excerpt),
+                                status,
+                                age,
+                            );
+                        }
+                    }
+                }
+            }
             AgentAction::Rm { name } => {
                 agent::remove(&name).await?;
                 println!("Agent {} removed", name);
@@ -385,6 +456,23 @@ fn truncate_main(s: &str, max: usize) -> String {
             end -= 1;
         }
         format!("{}…", &s[..end])
+    }
+}
+
+/// Format a chrono::Duration as a human-readable relative time string (e.g. "5m", "2h", "3d").
+fn format_relative_time(dur: chrono::Duration) -> String {
+    let secs = dur.num_seconds();
+    if secs < 0 {
+        return "now".to_string();
+    }
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h", secs / 3600)
+    } else {
+        format!("{}d", secs / 86400)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `deskd agent tasks <name>` CLI command that reads all inbox directories and displays recent completed tasks for a given agent
- Supports `--limit N` flag (default 20) to control how many tasks to show
- Pass name `all` to show tasks across all agents
- Shows task ID, source, task excerpt, status (done/err), and relative time

Closes #30

## Changes
- `src/inbox.rs`: Added `read_all()` function that scans all subdirectories under `~/.deskd/inbox/` and returns all entries
- `src/main.rs`: Added `Tasks` variant to `AgentAction` enum with `name` and `--limit` args; implemented handler that filters by agent, sorts by timestamp descending, and formats output with relative time

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (37 tests)
- [ ] Manual: `deskd agent tasks <name>` with inbox entries present
- [ ] Manual: `deskd agent tasks all` shows entries from all agents
- [ ] Manual: `deskd agent tasks nonexistent` shows "No completed tasks" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)