### PR TITLE
feat: workflow engine — bus-integrated state machine with MCP tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +97,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,10 +147,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -241,6 +282,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cron"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +308,16 @@ dependencies = [
  "chrono",
  "nom",
  "once_cell",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -287,6 +356,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,11 +397,22 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serenity",
  "teloxide",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -391,6 +487,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -517,6 +623,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,7 +667,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -587,13 +714,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -620,7 +757,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -631,6 +768,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -935,6 +1086,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1141,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1127,6 +1294,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1367,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "rc-box"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,9 +1443,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1244,6 +1457,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1252,6 +1466,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -1259,7 +1474,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1285,12 +1515,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1319,6 +1605,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -1366,6 +1672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cow"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7bbbec7196bfde255ab54b65e34087c0849629280028238e67ee25d6a4b7da"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1440,6 +1755,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "serenity"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bde37f42765dfdc34e2a039e0c84afbf79a3101c1941763b0beb816c2f17541"
+dependencies = [
+ "arrayvec",
+ "async-trait",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "bytes",
+ "flate2",
+ "futures",
+ "mime_guess",
+ "percent-encoding",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_cow",
+ "serde_json",
+ "time",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "typemap_rev",
+ "url",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1817,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1513,6 +1873,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1661,7 +2027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1694,6 +2060,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1745,6 +2142,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +2171,22 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1780,6 +2214,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1842,6 +2277,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typemap_rev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +2334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +2351,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -1896,7 +2376,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2066,6 +2546,30 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2403,6 +2907,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,6 +2946,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod message;
 mod schedule;
 mod statemachine;
 mod worker;
+mod workflow;
 
 use clap::{Parser, Subcommand};
 use tracing::info;
@@ -1051,6 +1052,21 @@ async fn serve(config_path: String) -> anyhow::Result<()> {
                 });
                 info!(agent = %def.name, sub_agent = %sub.name, "started sub-agent worker");
             }
+        }
+
+        // Start workflow engine if models are defined.
+        if let Some(ref ucfg) = user_cfg
+            && !ucfg.models.is_empty()
+        {
+            let bus = bus_socket.clone();
+            let models = ucfg.models.clone();
+            let agent_name = def.name.clone();
+            tokio::spawn(async move {
+                if let Err(e) = workflow::run(&bus, models).await {
+                    tracing::error!(agent = %agent_name, error = %e, "workflow engine exited");
+                }
+            });
+            info!(agent = %def.name, models = ucfg.models.len(), "started workflow engine");
         }
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -19,6 +19,7 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::config::UserConfig;
+use crate::statemachine;
 
 // ─── MCP Protocol types ───────────────────────────────────────────────────────
 
@@ -183,8 +184,31 @@ fn handle_tools_list(
         .map(|c| c.send_message_description(agent_name))
         .unwrap_or_else(|| "Send a message to a target on the bus.".to_string());
 
-    let tools = json!([
-        {
+    // Build sm_create description dynamically listing available models.
+    let sm_create_desc = if let Some(cfg) = user_config
+        && !cfg.models.is_empty()
+    {
+        let model_list: Vec<String> = cfg
+            .models
+            .iter()
+            .map(|m| {
+                if m.description.is_empty() {
+                    format!("  {} ({} states)", m.name, m.states.len())
+                } else {
+                    format!("  {} — {}", m.name, m.description)
+                }
+            })
+            .collect();
+        format!(
+            "Create a new state machine instance. Available models:\n{}",
+            model_list.join("\n")
+        )
+    } else {
+        "Create a new state machine instance.".to_string()
+    };
+
+    let mut tools = vec![
+        json!({
             "name": "send_message",
             "description": send_message_desc,
             "inputSchema": {
@@ -201,8 +225,8 @@ fn handle_tools_list(
                 },
                 "required": ["target", "text"]
             }
-        },
-        {
+        }),
+        json!({
             "name": "add_persistent_agent",
             "description": "Launch a new persistent sub-agent on this agent's bus. The agent starts immediately and remains connected until the bus shuts down.",
             "inputSchema": {
@@ -228,8 +252,50 @@ fn handle_tools_list(
                 },
                 "required": ["name", "model", "system_prompt", "subscribe"]
             }
-        }
-    ]);
+        }),
+    ];
+
+    // Add state machine tools if models are defined.
+    if user_config.map(|c| !c.models.is_empty()).unwrap_or(false) {
+        tools.push(json!({
+            "name": "sm_create",
+            "description": sm_create_desc,
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "model": {"type": "string", "description": "Model name (e.g. 'feature', 'bugfix')"},
+                    "title": {"type": "string", "description": "Instance title"},
+                    "body": {"type": "string", "description": "Instance body/description"}
+                },
+                "required": ["model", "title"]
+            }
+        }));
+        tools.push(json!({
+            "name": "sm_move",
+            "description": "Move a state machine instance to a new state.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Instance ID (e.g. sm-a1b2c3d4)"},
+                    "state": {"type": "string", "description": "Target state name"},
+                    "note": {"type": "string", "description": "Optional note/reason"}
+                },
+                "required": ["id", "state"]
+            }
+        }));
+        tools.push(json!({
+            "name": "sm_query",
+            "description": "Query state machine instances. Returns JSON list of matching instances.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "model": {"type": "string", "description": "Filter by model name"},
+                    "state": {"type": "string", "description": "Filter by current state"},
+                    "id": {"type": "string", "description": "Get specific instance by ID"}
+                }
+            }
+        }));
+    }
 
     Response::ok(id, json!({ "tools": tools }))
 }
@@ -250,6 +316,9 @@ async fn handle_tools_call(
     match name {
         "send_message" => call_send_message(args, agent_name, bus_socket, user_config).await,
         "add_persistent_agent" => call_add_persistent_agent(args, agent_name, bus_socket).await,
+        "sm_create" => call_sm_create(args, agent_name, bus_socket, user_config).await,
+        "sm_move" => call_sm_move(args, agent_name, bus_socket, user_config).await,
+        "sm_query" => call_sm_query(args).await,
         other => bail!("Unknown tool: {}", other),
     }
 }
@@ -411,6 +480,196 @@ async fn call_add_persistent_agent(
                 name, bus_socket, subscribe_display
             )
         }],
+        "isError": false
+    }))
+}
+
+// ─── State machine tool implementations ───────────────────────────────────────
+
+async fn call_sm_create(
+    args: &Value,
+    agent_name: &str,
+    bus_socket: &str,
+    user_config: Option<&UserConfig>,
+) -> Result<Value> {
+    let model_name = args
+        .get("model")
+        .and_then(|m| m.as_str())
+        .context("missing model")?;
+    let title = args
+        .get("title")
+        .and_then(|t| t.as_str())
+        .context("missing title")?;
+    let body = args.get("body").and_then(|b| b.as_str()).unwrap_or("");
+
+    let cfg = user_config.context("no user config loaded — models not available")?;
+    let model = cfg
+        .models
+        .iter()
+        .find(|m| m.name == model_name)
+        .ok_or_else(|| anyhow::anyhow!("model '{}' not found", model_name))?;
+
+    let store = statemachine::StateMachineStore::default_for_home();
+    let inst = store.create(model, title, body, agent_name)?;
+    info!(agent = %agent_name, instance = %inst.id, model = %model_name, "sm_create via MCP");
+
+    // If the initial state has an assignee, dispatch the first task via the bus.
+    if !inst.assignee.is_empty() {
+        let task_text = format!(
+            "---\n## Task: {}\n\n{}\n\n---\n## Metadata\ninstance_id: {}\nmodel: {}\nstate: {}",
+            inst.title, inst.body, inst.id, inst.model, inst.state
+        );
+
+        let mut stream = UnixStream::connect(bus_socket)
+            .await
+            .with_context(|| format!("failed to connect to bus at {}", bus_socket))?;
+
+        let reg = serde_json::json!({
+            "type": "register",
+            "name": format!("{}-mcp-sm", agent_name),
+            "subscriptions": []
+        });
+        let mut line = serde_json::to_string(&reg)?;
+        line.push('\n');
+        stream.write_all(line.as_bytes()).await?;
+
+        let msg = serde_json::json!({
+            "type": "message",
+            "id": Uuid::new_v4().to_string(),
+            "source": "workflow-engine",
+            "target": &inst.assignee,
+            "payload": {
+                "task": task_text,
+                "sm_instance_id": inst.id,
+            },
+            "reply_to": format!("sm:{}", inst.id),
+            "metadata": {"priority": 5u8},
+        });
+        let mut msg_line = serde_json::to_string(&msg)?;
+        msg_line.push('\n');
+        stream.write_all(msg_line.as_bytes()).await?;
+        info!(instance = %inst.id, assignee = %inst.assignee, "dispatched initial task");
+    }
+
+    Ok(json!({
+        "content": [{"type": "text", "text": format!(
+            "Created instance {} (model={}, state={}, assignee={})",
+            inst.id, inst.model, inst.state, inst.assignee
+        )}],
+        "isError": false
+    }))
+}
+
+async fn call_sm_move(
+    args: &Value,
+    agent_name: &str,
+    bus_socket: &str,
+    user_config: Option<&UserConfig>,
+) -> Result<Value> {
+    let id = args
+        .get("id")
+        .and_then(|i| i.as_str())
+        .context("missing id")?;
+    let state = args
+        .get("state")
+        .and_then(|s| s.as_str())
+        .context("missing state")?;
+    let note = args.get("note").and_then(|n| n.as_str());
+
+    let store = statemachine::StateMachineStore::default_for_home();
+    let mut inst = store.load(id)?;
+    let cfg = user_config.context("no user config loaded — models not available")?;
+    let model = cfg
+        .models
+        .iter()
+        .find(|m| m.name == inst.model)
+        .ok_or_else(|| anyhow::anyhow!("model '{}' not found in config", inst.model))?;
+
+    let from = inst.state.clone();
+    store.move_to(&mut inst, model, state, agent_name, note)?;
+    info!(agent = %agent_name, instance = %id, from = %from, to = %state, "sm_move via MCP");
+
+    // If the new state has an assignee, dispatch via bus.
+    if !inst.assignee.is_empty() && !statemachine::is_terminal(model, &inst) {
+        let task_text = format!(
+            "---\n## Task: {}\n\n{}\n\n---\n## Metadata\ninstance_id: {}\nmodel: {}\nstate: {}",
+            inst.title, inst.body, inst.id, inst.model, inst.state
+        );
+
+        let mut stream = UnixStream::connect(bus_socket)
+            .await
+            .with_context(|| format!("failed to connect to bus at {}", bus_socket))?;
+
+        let reg = serde_json::json!({
+            "type": "register",
+            "name": format!("{}-mcp-sm", agent_name),
+            "subscriptions": []
+        });
+        let mut line = serde_json::to_string(&reg)?;
+        line.push('\n');
+        stream.write_all(line.as_bytes()).await?;
+
+        let msg = serde_json::json!({
+            "type": "message",
+            "id": Uuid::new_v4().to_string(),
+            "source": "workflow-engine",
+            "target": &inst.assignee,
+            "payload": {
+                "task": task_text,
+                "sm_instance_id": inst.id,
+            },
+            "reply_to": format!("sm:{}", inst.id),
+            "metadata": {"priority": 5u8},
+        });
+        let mut msg_line = serde_json::to_string(&msg)?;
+        msg_line.push('\n');
+        stream.write_all(msg_line.as_bytes()).await?;
+    }
+
+    Ok(json!({
+        "content": [{"type": "text", "text": format!("{} → {} (model={})", id, inst.state, inst.model)}],
+        "isError": false
+    }))
+}
+
+async fn call_sm_query(args: &Value) -> Result<Value> {
+    // If a specific ID is requested, return just that instance.
+    if let Some(id) = args.get("id").and_then(|i| i.as_str()) {
+        let store = statemachine::StateMachineStore::default_for_home();
+        let inst = store.load(id)?;
+        let inst_json = serde_json::to_value(&inst)?;
+        return Ok(json!({
+            "content": [{"type": "text", "text": serde_json::to_string_pretty(&inst_json)?}],
+            "isError": false
+        }));
+    }
+
+    let store = statemachine::StateMachineStore::default_for_home();
+    let mut instances = store.list_all()?;
+
+    if let Some(model_filter) = args.get("model").and_then(|m| m.as_str()) {
+        instances.retain(|i| i.model == model_filter);
+    }
+    if let Some(state_filter) = args.get("state").and_then(|s| s.as_str()) {
+        instances.retain(|i| i.state == state_filter);
+    }
+
+    let summary: Vec<Value> = instances
+        .iter()
+        .map(|i| {
+            json!({
+                "id": i.id,
+                "model": i.model,
+                "title": i.title,
+                "state": i.state,
+                "assignee": i.assignee,
+                "updated_at": i.updated_at,
+            })
+        })
+        .collect();
+
+    Ok(json!({
+        "content": [{"type": "text", "text": serde_json::to_string_pretty(&summary)?}],
         "isError": false
     }))
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -337,7 +337,15 @@ pub async fn run(
                     // Write to file-based inbox for async reading.
                     write_inbox(name, &msg, task, Some(response.clone()), None);
 
-                    let target = msg.reply_to.as_deref().unwrap_or(&msg.source);
+                    // If this task was dispatched by the workflow engine, route the
+                    // result back to sm:<instance_id> so the engine processes it.
+                    let target = if let Some(sm_id) =
+                        msg.payload.get("sm_instance_id").and_then(|v| v.as_str())
+                    {
+                        format!("sm:{}", sm_id)
+                    } else {
+                        msg.reply_to.as_deref().unwrap_or(&msg.source).to_string()
+                    };
 
                     let reply = Message {
                         id: Uuid::new_v4().to_string(),

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,0 +1,487 @@
+use anyhow::Result;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::config::ModelDef;
+use crate::message::Message;
+use crate::statemachine;
+
+type Writer = std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>;
+
+/// Run the workflow engine on the given bus.
+/// Registers as `workflow-engine`, subscribes to `sm:*`.
+/// On startup, dispatches pending instances. Then listens for completion messages.
+pub async fn run(socket_path: &str, models: Vec<ModelDef>) -> Result<()> {
+    let store = statemachine::StateMachineStore::default_for_home();
+
+    let stream = UnixStream::connect(socket_path).await?;
+    let reg = serde_json::json!({
+        "type": "register",
+        "name": "workflow-engine",
+        "subscriptions": ["sm:*"]
+    });
+    let mut line = serde_json::to_string(&reg)?;
+    line.push('\n');
+
+    let (reader, mut writer_half) = stream.into_split();
+    writer_half.write_all(line.as_bytes()).await?;
+
+    let writer: Writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer_half));
+    let mut lines = BufReader::new(reader).lines();
+
+    info!("workflow engine started, subscribed to sm:*");
+
+    // On startup: check for pending instances and dispatch them.
+    dispatch_pending(&writer, &models, &store).await;
+
+    // Main loop: listen for completion messages.
+    while let Some(line) = lines.next_line().await? {
+        if line.is_empty() {
+            continue;
+        }
+
+        let msg: Message = match serde_json::from_str(&line) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        // Extract instance ID from target: "sm:sm-a1b2c3d4"
+        let instance_id = match msg.target.strip_prefix("sm:") {
+            Some(id) => id.to_string(),
+            None => continue,
+        };
+
+        // Extract result from payload.
+        let result = msg
+            .payload
+            .get("result")
+            .and_then(|r| r.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let error = msg
+            .payload
+            .get("error")
+            .and_then(|e| e.as_str())
+            .map(|s| s.to_string());
+
+        info!(instance = %instance_id, "received completion");
+
+        if let Err(e) = handle_completion(
+            &writer,
+            &models,
+            &store,
+            &instance_id,
+            &result,
+            error.as_deref(),
+        )
+        .await
+        {
+            warn!(instance = %instance_id, error = %e, "failed to process completion");
+        }
+    }
+
+    Ok(())
+}
+
+/// Handle a task completion: apply transitions and dispatch next step.
+async fn handle_completion(
+    writer: &Writer,
+    models: &[ModelDef],
+    store: &statemachine::StateMachineStore,
+    instance_id: &str,
+    result: &str,
+    error: Option<&str>,
+) -> Result<()> {
+    let mut inst = store.load(instance_id)?;
+    let model = models
+        .iter()
+        .find(|m| m.name == inst.model)
+        .ok_or_else(|| anyhow::anyhow!("model '{}' not found", inst.model))?;
+
+    // Store result.
+    inst.result = Some(result.to_string());
+    if let Some(err) = error {
+        inst.error = Some(err.to_string());
+    }
+    inst.updated_at = chrono::Utc::now().to_rfc3339();
+    store.save(&inst)?;
+
+    // Find matching transition.
+    let current_state = inst.state.clone();
+    let target_state = find_next_state(model, &current_state, result);
+
+    if let Some(target) = target_state {
+        store.move_to(&mut inst, model, &target, "auto", Some(result))?;
+
+        info!(
+            instance = %instance_id,
+            from = %current_state,
+            to = %target,
+            "transition applied"
+        );
+
+        // If not terminal and has assignee, dispatch.
+        if !statemachine::is_terminal(model, &inst) {
+            dispatch_instance(writer, model, &inst).await?;
+        }
+    } else {
+        info!(instance = %instance_id, state = %inst.state, "no matching transition, awaiting manual move");
+    }
+
+    Ok(())
+}
+
+/// Find the next state based on transition rules.
+/// Priority: 1) keyword match (`on:`), 2) auto trigger, 3) none.
+fn find_next_state(model: &ModelDef, current_state: &str, result: &str) -> Option<String> {
+    let transitions = statemachine::valid_transitions(model, current_state);
+    let result_upper = result.trim().to_uppercase();
+
+    // 1. Check keyword matches first.
+    for t in &transitions {
+        if let Some(ref keyword) = t.on
+            && result_upper.starts_with(&keyword.to_uppercase())
+        {
+            return Some(t.to.clone());
+        }
+    }
+
+    // 2. Check auto triggers.
+    for t in &transitions {
+        if t.trigger.as_deref() == Some("auto") {
+            return Some(t.to.clone());
+        }
+    }
+
+    None
+}
+
+/// Dispatch a task to the instance's current assignee.
+async fn dispatch_instance(
+    writer: &Writer,
+    model: &ModelDef,
+    inst: &statemachine::Instance,
+) -> Result<()> {
+    if inst.assignee.is_empty() {
+        debug!(instance = %inst.id, state = %inst.state, "no assignee, skipping dispatch");
+        return Ok(());
+    }
+
+    // Find the prompt for the transition that leads to the current state.
+    let prompt = inst
+        .history
+        .last()
+        .and_then(|h| {
+            model
+                .transitions
+                .iter()
+                .find(|t| t.to == inst.state && (t.from == h.from || t.from == "*"))
+        })
+        .and_then(|t| t.prompt.as_ref())
+        .cloned()
+        .unwrap_or_default();
+
+    // Check if this is a human step.
+    let transition_def = model.transitions.iter().find(|t| t.to == inst.state);
+    let is_human = transition_def
+        .and_then(|t| t.step_type.as_deref())
+        .map(|s| s == "human")
+        == Some(true);
+
+    if is_human {
+        // Send notification instead of dispatching to agent.
+        if let Some(notify_target) = transition_def.and_then(|t| t.notify.as_ref()) {
+            let task_text = build_task_text(&prompt, inst);
+            let msg = serde_json::json!({
+                "type": "message",
+                "id": Uuid::new_v4().to_string(),
+                "source": "workflow-engine",
+                "target": notify_target,
+                "payload": {
+                    "task": task_text,
+                    "sm_instance_id": inst.id,
+                },
+                "reply_to": format!("sm:{}", inst.id),
+                "metadata": {"priority": 5u8},
+            });
+            let mut line = serde_json::to_string(&msg)?;
+            line.push('\n');
+            let mut w = writer.lock().await;
+            w.write_all(line.as_bytes()).await?;
+            info!(instance = %inst.id, target = %notify_target, "human notification sent");
+        }
+        return Ok(());
+    }
+
+    // Build task text with prompt injection.
+    let task_text = build_task_text(&prompt, inst);
+
+    let msg = serde_json::json!({
+        "type": "message",
+        "id": Uuid::new_v4().to_string(),
+        "source": "workflow-engine",
+        "target": &inst.assignee,
+        "payload": {
+            "task": task_text,
+            "sm_instance_id": inst.id,
+        },
+        "reply_to": format!("sm:{}", inst.id),
+        "metadata": {"priority": 5u8},
+    });
+
+    let mut line = serde_json::to_string(&msg)?;
+    line.push('\n');
+    let mut w = writer.lock().await;
+    w.write_all(line.as_bytes()).await?;
+
+    info!(instance = %inst.id, assignee = %inst.assignee, "task dispatched");
+    Ok(())
+}
+
+/// Build the full task text with prompt and context.
+fn build_task_text(prompt: &str, inst: &statemachine::Instance) -> String {
+    let mut parts = Vec::new();
+
+    if !prompt.is_empty() {
+        parts.push(prompt.to_string());
+    }
+
+    parts.push(format!("---\n## Task: {}\n\n{}", inst.title, inst.body));
+
+    if let Some(ref result) = inst.result
+        && !result.is_empty()
+    {
+        parts.push(format!("---\n## Previous step result\n\n{}", result));
+    }
+
+    parts.push(format!(
+        "---\n## Metadata\ninstance_id: {}\nmodel: {}\nstate: {}",
+        inst.id, inst.model, inst.state
+    ));
+
+    parts.join("\n\n")
+}
+
+/// On startup, find non-terminal instances and dispatch them.
+async fn dispatch_pending(
+    writer: &Writer,
+    models: &[ModelDef],
+    store: &statemachine::StateMachineStore,
+) {
+    let instances = match store.list_all() {
+        Ok(list) => list,
+        Err(_) => return,
+    };
+
+    for inst in &instances {
+        let model = match models.iter().find(|m| m.name == inst.model) {
+            Some(m) => m,
+            None => continue,
+        };
+
+        // Skip terminal instances.
+        if statemachine::is_terminal(model, inst) {
+            continue;
+        }
+
+        // Dispatch if has assignee (pending work).
+        if !inst.assignee.is_empty()
+            && let Err(e) = dispatch_instance(writer, model, inst).await
+        {
+            warn!(instance = %inst.id, error = %e, "failed to dispatch pending instance");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TransitionDef;
+
+    fn test_model() -> ModelDef {
+        ModelDef {
+            name: "pipeline".into(),
+            description: "Test pipeline".into(),
+            states: vec![
+                "draft".into(),
+                "review".into(),
+                "approved".into(),
+                "rejected".into(),
+            ],
+            initial: "draft".into(),
+            terminal: vec!["approved".into(), "rejected".into()],
+            transitions: vec![
+                TransitionDef {
+                    from: "draft".into(),
+                    to: "review".into(),
+                    trigger: Some("auto".into()),
+                    on: None,
+                    assignee: Some("agent:reviewer".into()),
+                    prompt: Some("Review this.".into()),
+                    step_type: None,
+                    notify: None,
+                    timeout: None,
+                    timeout_goto: None,
+                },
+                TransitionDef {
+                    from: "review".into(),
+                    to: "approved".into(),
+                    trigger: None,
+                    on: Some("LGTM".into()),
+                    assignee: None,
+                    prompt: None,
+                    step_type: None,
+                    notify: None,
+                    timeout: None,
+                    timeout_goto: None,
+                },
+                TransitionDef {
+                    from: "review".into(),
+                    to: "rejected".into(),
+                    trigger: None,
+                    on: Some("REJECT".into()),
+                    assignee: None,
+                    prompt: None,
+                    step_type: None,
+                    notify: None,
+                    timeout: None,
+                    timeout_goto: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn test_find_next_state_keyword_match() {
+        let model = test_model();
+        // "LGTM looks good" starts with "LGTM" -> approved
+        assert_eq!(
+            find_next_state(&model, "review", "LGTM looks good"),
+            Some("approved".into())
+        );
+        // Case-insensitive
+        assert_eq!(
+            find_next_state(&model, "review", "lgtm"),
+            Some("approved".into())
+        );
+    }
+
+    #[test]
+    fn test_find_next_state_reject_keyword() {
+        let model = test_model();
+        assert_eq!(
+            find_next_state(&model, "review", "REJECT: needs work"),
+            Some("rejected".into())
+        );
+    }
+
+    #[test]
+    fn test_find_next_state_auto_trigger() {
+        let model = test_model();
+        // From "draft" there's an auto trigger to "review"
+        assert_eq!(
+            find_next_state(&model, "draft", "anything"),
+            Some("review".into())
+        );
+    }
+
+    #[test]
+    fn test_find_next_state_no_match() {
+        let model = test_model();
+        // From "review" with result that doesn't match any keyword and no auto trigger
+        assert_eq!(find_next_state(&model, "review", "not sure"), None);
+    }
+
+    #[test]
+    fn test_find_next_state_keyword_priority_over_auto() {
+        // Keywords should be checked before auto triggers
+        let model = ModelDef {
+            name: "test".into(),
+            description: String::new(),
+            states: vec!["a".into(), "b".into(), "c".into()],
+            initial: "a".into(),
+            terminal: vec!["c".into()],
+            transitions: vec![
+                TransitionDef {
+                    from: "a".into(),
+                    to: "b".into(),
+                    trigger: Some("auto".into()),
+                    on: None,
+                    assignee: None,
+                    prompt: None,
+                    step_type: None,
+                    notify: None,
+                    timeout: None,
+                    timeout_goto: None,
+                },
+                TransitionDef {
+                    from: "a".into(),
+                    to: "c".into(),
+                    trigger: None,
+                    on: Some("DONE".into()),
+                    assignee: None,
+                    prompt: None,
+                    step_type: None,
+                    notify: None,
+                    timeout: None,
+                    timeout_goto: None,
+                },
+            ],
+        };
+        // Keyword match should take priority over auto
+        assert_eq!(find_next_state(&model, "a", "DONE"), Some("c".into()));
+        // No keyword match -> auto
+        assert_eq!(
+            find_next_state(&model, "a", "something else"),
+            Some("b".into())
+        );
+    }
+
+    #[test]
+    fn test_build_task_text_basic() {
+        let inst = statemachine::Instance {
+            id: "sm-test123".into(),
+            model: "pipeline".into(),
+            title: "Fix bug".into(),
+            body: "Details here".into(),
+            state: "review".into(),
+            assignee: "agent:reviewer".into(),
+            result: None,
+            error: None,
+            created_by: "kira".into(),
+            created_at: String::new(),
+            updated_at: String::new(),
+            history: vec![],
+            metadata: serde_json::Value::Null,
+        };
+        let text = build_task_text("Review this code.", &inst);
+        assert!(text.contains("Review this code."));
+        assert!(text.contains("Fix bug"));
+        assert!(text.contains("Details here"));
+        assert!(text.contains("sm-test123"));
+    }
+
+    #[test]
+    fn test_build_task_text_with_previous_result() {
+        let inst = statemachine::Instance {
+            id: "sm-test456".into(),
+            model: "pipeline".into(),
+            title: "Task".into(),
+            body: String::new(),
+            state: "review".into(),
+            assignee: "agent:reviewer".into(),
+            result: Some("Previous output here".into()),
+            error: None,
+            created_by: "kira".into(),
+            created_at: String::new(),
+            updated_at: String::new(),
+            history: vec![],
+            metadata: serde_json::Value::Null,
+        };
+        let text = build_task_text("", &inst);
+        assert!(text.contains("Previous output here"));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the state machine system — adds the automation layer on top of Phase 1 (PR #51).

> **Depends on PR #51** (`feat/state-machine`). That PR must be merged first, or this PR should be rebased after merge.

- **`src/workflow.rs`** — New workflow engine bus client: registers as `workflow-engine` on the bus, subscribes to `sm:*`, processes completions, applies transition logic (keyword matching + auto triggers), dispatches tasks to assignees, handles human steps with notifications, and dispatches pending instances on startup
- **`src/mcp.rs`** — Three new MCP tools: `sm_create` (create instance + dispatch first task), `sm_move` (manual state transition + dispatch), `sm_query` (list/filter/get instances)
- **`src/worker.rs`** — Routes task results back to `sm:<instance_id>` when the message payload contains `sm_instance_id`, closing the workflow loop
- **`src/main.rs`** — Starts workflow engine in `serve()` when models are defined in agent config

### How it works

```
Agent creates instance via sm_create MCP tool
  → first task dispatched to assignee agent
  → worker completes task, routes result to sm:<id>
  → workflow engine receives completion
  → applies transition rules (keyword match > auto trigger)
  → dispatches next step to next assignee
  → repeat until terminal state
```

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all 45 tests pass (2 pre-existing flaky tests in statemachine module pass with `--test-threads=1`)
- [ ] Integration test: create instance via MCP, verify workflow engine dispatches and advances states
- [ ] Test keyword matching (case-insensitive prefix)
- [ ] Test auto trigger fallback
- [ ] Test human step notification routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)