### PR TITLE
refactor: StateMachineStore struct replaces global env var state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -519,6 +519,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 fn handle_sm(action: SmAction, user_cfg: &config::UserConfig) -> anyhow::Result<()> {
+    let store = statemachine::StateMachineStore::default_for_home();
     match action {
         SmAction::Models => {
             if user_cfg.models.is_empty() {
@@ -579,14 +580,14 @@ fn handle_sm(action: SmAction, user_cfg: &config::UserConfig) -> anyhow::Result<
                 .find(|m| m.name == model)
                 .ok_or_else(|| anyhow::anyhow!("Model '{}' not found", model))?;
             let creator = std::env::var("DESKD_AGENT_NAME").unwrap_or_else(|_| "cli".to_string());
-            let inst = statemachine::create(m, &title, body.as_deref().unwrap_or(""), &creator)?;
+            let inst = store.create(m, &title, body.as_deref().unwrap_or(""), &creator)?;
             println!(
                 "Created {} (model={}, state={})",
                 inst.id, inst.model, inst.state
             );
         }
         SmAction::Move { id, state, note } => {
-            let mut inst = statemachine::load(&id)?;
+            let mut inst = store.load(&id)?;
             let m = user_cfg
                 .models
                 .iter()
@@ -594,11 +595,11 @@ fn handle_sm(action: SmAction, user_cfg: &config::UserConfig) -> anyhow::Result<
                 .ok_or_else(|| anyhow::anyhow!("Model '{}' not found in config", inst.model))?;
             let trigger =
                 std::env::var("DESKD_AGENT_NAME").unwrap_or_else(|_| "manual".to_string());
-            statemachine::move_to(&mut inst, m, &state, &trigger, note.as_deref())?;
+            store.move_to(&mut inst, m, &state, &trigger, note.as_deref())?;
             println!("{} -> {} ({})", id, inst.state, inst.model);
         }
         SmAction::Status { id } => {
-            let inst = statemachine::load(&id)?;
+            let inst = store.load(&id)?;
             println!("ID:        {}", inst.id);
             println!("Model:     {}", inst.model);
             println!("Title:     {}", inst.title);
@@ -631,7 +632,7 @@ fn handle_sm(action: SmAction, user_cfg: &config::UserConfig) -> anyhow::Result<
             state,
             limit,
         } => {
-            let mut instances = statemachine::list_all()?;
+            let mut instances = store.list_all()?;
             if let Some(ref m) = model {
                 instances.retain(|i| i.model == *m);
             }
@@ -659,7 +660,7 @@ fn handle_sm(action: SmAction, user_cfg: &config::UserConfig) -> anyhow::Result<
             }
         }
         SmAction::Cancel { id } => {
-            let mut inst = statemachine::load(&id)?;
+            let mut inst = store.load(&id)?;
             let m = user_cfg
                 .models
                 .iter()
@@ -682,7 +683,7 @@ fn handle_sm(action: SmAction, user_cfg: &config::UserConfig) -> anyhow::Result<
                     )
                 })?;
             let target = cancel_target.to.clone();
-            statemachine::move_to(&mut inst, m, &target, "cancel", Some("Cancelled via CLI"))?;
+            store.move_to(&mut inst, m, &target, "cancel", Some("Cancelled via CLI"))?;
             println!("{} cancelled -> {}", id, inst.state);
         }
     }

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -39,95 +39,167 @@ pub struct Transition {
     pub note: Option<String>,
 }
 
-fn instances_dir() -> PathBuf {
-    let dir = if let Ok(custom) = std::env::var("DESKD_INSTANCES_DIR") {
-        PathBuf::from(custom)
-    } else {
+/// Persistent store for state machine instances, backed by a directory of JSON files.
+pub struct StateMachineStore {
+    dir: PathBuf,
+}
+
+impl StateMachineStore {
+    /// Create a store at the given directory, ensuring it exists.
+    pub fn new(dir: PathBuf) -> Self {
+        std::fs::create_dir_all(&dir).ok();
+        Self { dir }
+    }
+
+    /// Default store location: `$HOME/.deskd/instances`.
+    pub fn default_for_home() -> Self {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        PathBuf::from(home).join(".deskd").join("instances")
-    };
-    std::fs::create_dir_all(&dir).ok();
-    dir
-}
+        Self::new(PathBuf::from(home).join(".deskd").join("instances"))
+    }
 
-fn instance_path(id: &str) -> PathBuf {
-    instances_dir().join(format!("{id}.json"))
-}
+    fn instance_path(&self, id: &str) -> PathBuf {
+        self.dir.join(format!("{id}.json"))
+    }
 
-pub fn save(inst: &Instance) -> Result<()> {
-    let path = instance_path(&inst.id);
-    let tmp = path.with_extension("tmp");
-    let content = serde_json::to_string_pretty(inst)?;
-    std::fs::write(&tmp, &content)?;
-    std::fs::rename(&tmp, &path)?;
-    Ok(())
-}
+    pub fn save(&self, inst: &Instance) -> Result<()> {
+        let path = self.instance_path(&inst.id);
+        let tmp = path.with_extension("tmp");
+        let content = serde_json::to_string_pretty(inst)?;
+        std::fs::write(&tmp, &content)?;
+        std::fs::rename(&tmp, &path)?;
+        Ok(())
+    }
 
-pub fn load(id: &str) -> Result<Instance> {
-    let path = instance_path(id);
-    let content =
-        std::fs::read_to_string(&path).with_context(|| format!("Instance '{id}' not found"))?;
-    let inst: Instance = serde_json::from_str(&content)?;
-    Ok(inst)
-}
+    pub fn load(&self, id: &str) -> Result<Instance> {
+        let path = self.instance_path(id);
+        let content =
+            std::fs::read_to_string(&path).with_context(|| format!("Instance '{id}' not found"))?;
+        let inst: Instance = serde_json::from_str(&content)?;
+        Ok(inst)
+    }
 
-pub fn list_all() -> Result<Vec<Instance>> {
-    let dir = instances_dir();
-    let mut instances = Vec::new();
-    if dir.exists() {
-        for entry in std::fs::read_dir(&dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.extension().map(|e| e == "json").unwrap_or(false)
-                && let Ok(content) = std::fs::read_to_string(&path)
-                && let Ok(inst) = serde_json::from_str::<Instance>(&content)
-            {
-                instances.push(inst);
+    pub fn list_all(&self) -> Result<Vec<Instance>> {
+        let mut instances = Vec::new();
+        if self.dir.exists() {
+            for entry in std::fs::read_dir(&self.dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.extension().map(|e| e == "json").unwrap_or(false)
+                    && let Ok(content) = std::fs::read_to_string(&path)
+                    && let Ok(inst) = serde_json::from_str::<Instance>(&content)
+                {
+                    instances.push(inst);
+                }
             }
         }
+        instances.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(instances)
     }
-    instances.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-    Ok(instances)
-}
 
-#[allow(dead_code)]
-pub fn delete(id: &str) -> Result<()> {
-    let path = instance_path(id);
-    std::fs::remove_file(&path).with_context(|| format!("Instance '{id}' not found"))?;
-    Ok(())
-}
+    #[allow(dead_code)]
+    pub fn delete(&self, id: &str) -> Result<()> {
+        let path = self.instance_path(id);
+        std::fs::remove_file(&path).with_context(|| format!("Instance '{id}' not found"))?;
+        Ok(())
+    }
 
-/// Create a new instance from a model definition.
-pub fn create(model: &ModelDef, title: &str, body: &str, created_by: &str) -> Result<Instance> {
-    let id = format!("sm-{}", &uuid::Uuid::new_v4().to_string()[..8]);
-    let now = Utc::now().to_rfc3339();
+    /// Create a new instance from a model definition.
+    pub fn create(
+        &self,
+        model: &ModelDef,
+        title: &str,
+        body: &str,
+        created_by: &str,
+    ) -> Result<Instance> {
+        let id = format!("sm-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let now = Utc::now().to_rfc3339();
 
-    // Find assignee for initial state (from first matching transition).
-    let assignee = model
-        .transitions
-        .iter()
-        .find(|t| t.from == model.initial || t.from == "*")
-        .and_then(|t| t.assignee.clone())
-        .unwrap_or_default();
+        // Find assignee for initial state (from first matching transition).
+        let assignee = model
+            .transitions
+            .iter()
+            .find(|t| t.from == model.initial || t.from == "*")
+            .and_then(|t| t.assignee.clone())
+            .unwrap_or_default();
 
-    let inst = Instance {
-        id,
-        model: model.name.clone(),
-        title: title.to_string(),
-        body: body.to_string(),
-        state: model.initial.clone(),
-        assignee,
-        result: None,
-        error: None,
-        created_by: created_by.to_string(),
-        created_at: now.clone(),
-        updated_at: now,
-        history: Vec::new(),
-        metadata: serde_json::Value::Null,
-    };
-    save(&inst)?;
-    info!(id = %inst.id, model = %inst.model, state = %inst.state, "instance created");
-    Ok(inst)
+        let inst = Instance {
+            id,
+            model: model.name.clone(),
+            title: title.to_string(),
+            body: body.to_string(),
+            state: model.initial.clone(),
+            assignee,
+            result: None,
+            error: None,
+            created_by: created_by.to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+            history: Vec::new(),
+            metadata: serde_json::Value::Null,
+        };
+        self.save(&inst)?;
+        info!(id = %inst.id, model = %inst.model, state = %inst.state, "instance created");
+        Ok(inst)
+    }
+
+    /// Move an instance to a new state. Validates that the transition is allowed.
+    pub fn move_to(
+        &self,
+        inst: &mut Instance,
+        model: &ModelDef,
+        target_state: &str,
+        trigger: &str,
+        note: Option<&str>,
+    ) -> Result<()> {
+        // Validate target state exists.
+        if !model.states.contains(&target_state.to_string()) {
+            bail!(
+                "State '{}' not defined in model '{}'",
+                target_state,
+                model.name
+            );
+        }
+
+        // Validate transition exists from current state.
+        let from_state = inst.state.clone();
+        let transition_def = model
+            .transitions
+            .iter()
+            .find(|t| (t.from == from_state || t.from == "*") && t.to == target_state);
+
+        if transition_def.is_none() {
+            bail!(
+                "No transition from '{}' to '{}' in model '{}'",
+                from_state,
+                target_state,
+                model.name
+            );
+        }
+
+        let now = Utc::now().to_rfc3339();
+        let transition = Transition {
+            from: from_state.clone(),
+            to: target_state.to_string(),
+            trigger: trigger.to_string(),
+            timestamp: now.clone(),
+            note: note.map(|s| s.to_string()),
+        };
+
+        inst.history.push(transition);
+        inst.state = target_state.to_string();
+        inst.updated_at = now;
+
+        // Update assignee from the transition definition (looked up BEFORE state mutation).
+        if let Some(td) = transition_def
+            && let Some(ref a) = td.assignee
+        {
+            inst.assignee = a.clone();
+        }
+
+        self.save(inst)?;
+        info!(id = %inst.id, from = %from_state, to = %target_state, "state transition");
+        Ok(())
+    }
 }
 
 /// Find valid transitions from the current state.
@@ -139,64 +211,6 @@ pub fn valid_transitions<'a>(model: &'a ModelDef, current_state: &str) -> Vec<&'
         .collect()
 }
 
-/// Move an instance to a new state. Validates that the transition is allowed.
-pub fn move_to(
-    inst: &mut Instance,
-    model: &ModelDef,
-    target_state: &str,
-    trigger: &str,
-    note: Option<&str>,
-) -> Result<()> {
-    // Validate target state exists.
-    if !model.states.contains(&target_state.to_string()) {
-        bail!(
-            "State '{}' not defined in model '{}'",
-            target_state,
-            model.name
-        );
-    }
-
-    // Validate transition exists from current state.
-    let from_state = inst.state.clone();
-    let transition_def = model
-        .transitions
-        .iter()
-        .find(|t| (t.from == from_state || t.from == "*") && t.to == target_state);
-
-    if transition_def.is_none() {
-        bail!(
-            "No transition from '{}' to '{}' in model '{}'",
-            from_state,
-            target_state,
-            model.name
-        );
-    }
-
-    let now = Utc::now().to_rfc3339();
-    let transition = Transition {
-        from: from_state.clone(),
-        to: target_state.to_string(),
-        trigger: trigger.to_string(),
-        timestamp: now.clone(),
-        note: note.map(|s| s.to_string()),
-    };
-
-    inst.history.push(transition);
-    inst.state = target_state.to_string();
-    inst.updated_at = now;
-
-    // Update assignee from the transition definition (looked up BEFORE state mutation).
-    if let Some(td) = transition_def
-        && let Some(ref a) = td.assignee
-    {
-        inst.assignee = a.clone();
-    }
-
-    save(inst)?;
-    info!(id = %inst.id, from = %from_state, to = %target_state, "state transition");
-    Ok(())
-}
-
 /// Check if an instance is in a terminal state.
 pub fn is_terminal(model: &ModelDef, inst: &Instance) -> bool {
     model.terminal.contains(&inst.state)
@@ -206,39 +220,10 @@ pub fn is_terminal(model: &ModelDef, inst: &Instance) -> bool {
 mod tests {
     use super::*;
     use crate::config::{ModelDef, TransitionDef};
-    use std::sync::Mutex;
 
-    /// Global lock to serialise tests that mutate DESKD_INSTANCES_DIR.
-    /// Required because std::env::set_var is not thread-safe when tests run in parallel.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    /// Set up a unique temp directory for instance storage during a test.
-    /// Returns a guard that cleans up on drop.
-    struct TestDir(PathBuf, std::sync::MutexGuard<'static, ()>);
-
-    impl TestDir {
-        fn new(name: &str) -> Self {
-            let guard = ENV_LOCK.lock().unwrap();
-            let dir = std::env::temp_dir().join("deskd-test").join(format!(
-                "{}-{}",
-                name,
-                uuid::Uuid::new_v4()
-            ));
-            std::fs::create_dir_all(&dir).unwrap();
-            unsafe {
-                std::env::set_var("DESKD_INSTANCES_DIR", &dir);
-            }
-            TestDir(dir, guard)
-        }
-    }
-
-    impl Drop for TestDir {
-        fn drop(&mut self) {
-            std::fs::remove_dir_all(&self.0).ok();
-            unsafe {
-                std::env::remove_var("DESKD_INSTANCES_DIR");
-            }
-        }
+    fn temp_store() -> StateMachineStore {
+        let dir = std::env::temp_dir().join(format!("deskd-test-{}", uuid::Uuid::new_v4()));
+        StateMachineStore::new(dir)
     }
 
     fn test_model() -> ModelDef {
@@ -308,53 +293,54 @@ mod tests {
 
     #[test]
     fn test_create_instance() {
-        let _dir = TestDir::new("create");
+        let store = temp_store();
         let model = test_model();
-        let inst = create(&model, "Fix bug #42", "Details here", "kira").unwrap();
+        let inst = store
+            .create(&model, "Fix bug #42", "Details here", "kira")
+            .unwrap();
         assert!(inst.id.starts_with("sm-"));
         assert_eq!(inst.model, "review");
         assert_eq!(inst.state, "open");
         assert_eq!(inst.assignee, "agent:reviewer");
         assert!(inst.history.is_empty());
-        // Clean up.
-        delete(&inst.id).ok();
     }
 
     #[test]
     fn test_move_to_valid() {
-        let _dir = TestDir::new("move_valid");
+        let store = temp_store();
         let model = test_model();
-        let mut inst = create(&model, "Test move", "", "kira").unwrap();
+        let mut inst = store.create(&model, "Test move", "", "kira").unwrap();
         assert_eq!(inst.state, "open");
 
-        move_to(&mut inst, &model, "in_review", "manual", None).unwrap();
+        store
+            .move_to(&mut inst, &model, "in_review", "manual", None)
+            .unwrap();
         assert_eq!(inst.state, "in_review");
         assert_eq!(inst.history.len(), 1);
         assert_eq!(inst.history[0].from, "open");
         assert_eq!(inst.history[0].to, "in_review");
 
-        move_to(
-            &mut inst,
-            &model,
-            "approved",
-            "keyword:approve",
-            Some("LGTM"),
-        )
-        .unwrap();
+        store
+            .move_to(
+                &mut inst,
+                &model,
+                "approved",
+                "keyword:approve",
+                Some("LGTM"),
+            )
+            .unwrap();
         assert_eq!(inst.state, "approved");
         assert_eq!(inst.history.len(), 2);
         assert!(is_terminal(&model, &inst));
-        // Clean up.
-        delete(&inst.id).ok();
     }
 
     #[test]
     fn test_move_to_invalid_transition() {
-        let _dir = TestDir::new("move_invalid");
+        let store = temp_store();
         let model = test_model();
-        let mut inst = create(&model, "Test invalid", "", "kira").unwrap();
+        let mut inst = store.create(&model, "Test invalid", "", "kira").unwrap();
         // Cannot go directly from open to approved.
-        let result = move_to(&mut inst, &model, "approved", "manual", None);
+        let result = store.move_to(&mut inst, &model, "approved", "manual", None);
         assert!(result.is_err());
         assert!(
             result
@@ -362,18 +348,16 @@ mod tests {
                 .to_string()
                 .contains("No transition from")
         );
-        delete(&inst.id).ok();
     }
 
     #[test]
     fn test_move_to_invalid_state() {
-        let _dir = TestDir::new("move_bad_state");
+        let store = temp_store();
         let model = test_model();
-        let mut inst = create(&model, "Test bad state", "", "kira").unwrap();
-        let result = move_to(&mut inst, &model, "nonexistent", "manual", None);
+        let mut inst = store.create(&model, "Test bad state", "", "kira").unwrap();
+        let result = store.move_to(&mut inst, &model, "nonexistent", "manual", None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not defined"));
-        delete(&inst.id).ok();
     }
 
     #[test]
@@ -388,26 +372,47 @@ mod tests {
 
     #[test]
     fn test_wildcard_cancel() {
-        let _dir = TestDir::new("wildcard_cancel");
+        let store = temp_store();
         let model = test_model();
-        let mut inst = create(&model, "Test cancel", "", "kira").unwrap();
+        let mut inst = store.create(&model, "Test cancel", "", "kira").unwrap();
         // Wildcard transition allows cancel from any state.
-        move_to(&mut inst, &model, "rejected", "cancel", Some("Cancelled")).unwrap();
+        store
+            .move_to(&mut inst, &model, "rejected", "cancel", Some("Cancelled"))
+            .unwrap();
         assert_eq!(inst.state, "rejected");
         assert!(is_terminal(&model, &inst));
-        delete(&inst.id).ok();
     }
 
     #[test]
     fn test_save_load_roundtrip() {
-        let _dir = TestDir::new("roundtrip");
+        let store = temp_store();
         let model = test_model();
-        let inst = create(&model, "Roundtrip test", "body text", "kira").unwrap();
-        let loaded = load(&inst.id).unwrap();
+        let inst = store
+            .create(&model, "Roundtrip test", "body text", "kira")
+            .unwrap();
+        let loaded = store.load(&inst.id).unwrap();
         assert_eq!(loaded.id, inst.id);
         assert_eq!(loaded.title, "Roundtrip test");
         assert_eq!(loaded.body, "body text");
-        delete(&inst.id).ok();
+    }
+
+    #[test]
+    fn test_list_all() {
+        let store = temp_store();
+        let model = test_model();
+        store.create(&model, "First", "", "kira").unwrap();
+        store.create(&model, "Second", "", "kira").unwrap();
+        let all = store.list_all().unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn test_delete() {
+        let store = temp_store();
+        let model = test_model();
+        let inst = store.create(&model, "To delete", "", "kira").unwrap();
+        store.delete(&inst.id).unwrap();
+        assert!(store.load(&inst.id).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replaces free functions in `statemachine.rs` with a `StateMachineStore` struct that owns its directory path
- Eliminates the global `DESKD_INSTANCES_DIR` env var — the store is created via `StateMachineStore::new(dir)` or `StateMachineStore::default_for_home()`
- Moves `move_to` into the store (it needs `save()` internally)
- Keeps `valid_transitions`, `is_terminal` as free functions (they operate on data, not storage)
- Updates `handle_sm()` in `main.rs` to create a single store instance and use it throughout
- Tests now use isolated temp directories per test — no mutex, no env var manipulation, fully parallel

Addresses review feedback from PR #51: eliminate global state, enable parallel tests.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 48 tests pass in parallel (no `--test-threads=1` needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)