### PR TITLE
feat: telegram route_to — direct chat routing to sub-agents

### DIFF
--- a/src/adapters/telegram.rs
+++ b/src/adapters/telegram.rs
@@ -51,6 +51,11 @@ impl super::Adapter for TelegramAdapter {
             .iter()
             .filter_map(|r| r.name.as_ref().map(|n| (r.chat_id, n.clone())))
             .collect();
+        let chat_route_to: std::collections::HashMap<i64, String> = self
+            .routes
+            .iter()
+            .filter_map(|r| r.route_to.as_ref().map(|t| (r.chat_id, t.clone())))
+            .collect();
         Box::pin(run(
             self.token,
             bus_socket,
@@ -58,6 +63,7 @@ impl super::Adapter for TelegramAdapter {
             allowed_chats,
             mention_only,
             chat_names,
+            chat_route_to,
         ))
     }
 }
@@ -76,6 +82,7 @@ enum OutboundCmd {
 /// `allowed_chats` is the whitelist of chat_ids to accept messages from — all others are ignored.
 /// `mention_only_chats` is a subset where only @mentions trigger the agent.
 /// `chat_names` maps chat_id to a human-readable name shown to the agent as context.
+/// `chat_route_to` maps chat_id to a bus target override (e.g. "agent:collab").
 pub async fn run(
     token: String,
     socket_path: String,
@@ -83,6 +90,7 @@ pub async fn run(
     allowed_chats: std::collections::HashSet<i64>,
     mention_only_chats: Vec<i64>,
     chat_names: std::collections::HashMap<i64, String>,
+    chat_route_to: std::collections::HashMap<i64, String>,
 ) -> Result<()> {
     info!(agent = %agent_name, "starting Telegram adapter");
 
@@ -134,6 +142,7 @@ pub async fn run(
                 allowed_chats,
                 mention_only,
                 chat_names,
+                chat_route_to,
             )
             .await
             {
@@ -374,6 +383,7 @@ async fn download_photo_base64(bot: &Bot, file_id: &str) -> Result<String> {
 }
 
 /// Poll Telegram for incoming messages and publish them to the bus as `telegram.in:<chat_id>`.
+#[allow(clippy::too_many_arguments)]
 async fn polling_loop(
     bot: Bot,
     socket_path: String,
@@ -382,6 +392,7 @@ async fn polling_loop(
     allowed_chats: std::collections::HashSet<i64>,
     mention_only_chats: std::collections::HashSet<i64>,
     chat_names: std::collections::HashMap<i64, String>,
+    chat_route_to: std::collections::HashMap<i64, String>,
 ) -> Result<()> {
     teloxide::repl(bot, move |bot: Bot, msg: Message| {
         let socket = socket_path.clone();
@@ -390,6 +401,7 @@ async fn polling_loop(
         let allowed = allowed_chats.clone();
         let mention_only = mention_only_chats.clone();
         let names = chat_names.clone();
+        let route_to_map = chat_route_to.clone();
         async move {
             // Skip messages from the bot itself to prevent reply loops.
             if msg.from.as_ref().map(|u| u.username.as_deref() == Some(&bot_user)).unwrap_or(false) {
@@ -446,7 +458,13 @@ async fn polling_loop(
                     }
                 }
 
-                let target = format!("telegram.in:{}", chat_id);
+                // Use route_to override if configured, otherwise default to telegram.in:<chat_id>.
+                let target = if let Some(rt) = route_to_map.get(&chat_id) {
+                    rt.clone()
+                } else {
+                    format!("telegram.in:{}", chat_id)
+                };
+                // reply_to always goes back to Telegram so agent responses reach the chat.
                 let reply_to = format!("telegram.out:{}", chat_id);
                 let chat_name = names.get(&chat_id).cloned();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,6 +217,10 @@ pub struct TelegramRoute {
     pub mention_only: bool,
     /// Human-readable name for this chat, shown to the agent as context.
     pub name: Option<String>,
+    /// Bus target override. When set, incoming messages from this chat are published
+    /// to this target (e.g. "agent:collab") instead of the default "telegram.in:<chat_id>".
+    #[serde(default)]
+    pub route_to: Option<String>,
 }
 
 /// A scheduled action that fires on a cron expression and posts a message to the bus.
@@ -559,6 +563,7 @@ schedules:
                     chat_id: -1003733725513,
                     mention_only: false,
                     name: None,
+                    route_to: None,
                 }],
             }),
             discord: None,
@@ -571,5 +576,25 @@ schedules:
         assert!(desc.contains("news:ecosystem"));
         assert!(desc.contains("telegram.out:-1003733725513"));
         assert!(desc.contains("You are agent 'kira'"));
+    }
+
+    #[test]
+    fn test_telegram_route_with_route_to() {
+        let yaml = r#"
+telegram:
+  routes:
+    - chat_id: -1003733725513
+      name: "personal"
+    - chat_id: -1003754811357
+      name: "collab"
+      mention_only: true
+      route_to: "agent:collab"
+"#;
+        let cfg: UserConfig = serde_yaml::from_str(yaml).unwrap();
+        let routes = cfg.telegram.unwrap().routes;
+        assert_eq!(routes.len(), 2);
+        assert!(routes[0].route_to.is_none());
+        assert_eq!(routes[1].route_to.as_deref(), Some("agent:collab"));
+        assert!(routes[1].mention_only);
     }
 }


### PR DESCRIPTION
## Summary

Implements #54 — adds `route_to` field to Telegram routes in `deskd.yaml`, allowing specific `chat_id`s to be routed directly to sub-agents instead of the default `telegram.in:<chat_id>` bus target.

- Added `route_to: Option<String>` to `TelegramRoute` in `config.rs` (serde default, backward compatible)
- Built `chat_route_to: HashMap<i64, String>` in the adapter and passed it through to the polling loop
- When a chat has `route_to` configured, incoming messages publish to that target (e.g. `agent:collab`) instead of `telegram.in:<chat_id>`
- `reply_to` always remains `telegram.out:<chat_id>` so responses still reach Telegram

Example config:
```yaml
telegram:
  routes:
    - chat_id: -1003733725513
      name: "personal"
      # No route_to → default telegram.in:<chat_id>
    - chat_id: -1003754811357
      name: "collab"
      mention_only: true
      route_to: "agent:collab"
```

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all 49 tests pass, including new `test_telegram_route_with_route_to`
- [ ] Manual: configure `route_to` on a chat, verify messages go to the sub-agent
- [ ] Manual: verify chats without `route_to` still use default `telegram.in:<chat_id>`

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)