### PR TITLE
feat: github_poll events — issue_comments, since tracking (#22)

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -188,12 +188,14 @@ async fn fire_github_poll(def: &ScheduleDef, bus_socket: &str, agent_name: &str)
         });
 
         let mut count = 0;
+        let mut had_error = false;
 
         if events.contains(&"issues".to_string()) {
             match poll_issues(repo, label, &since, bus_socket, agent_name, &def.target).await {
                 Ok(n) => count += n,
                 Err(e) => {
                     warn!(agent = %agent_name, repo = %repo, error = %e, "github_poll issues failed");
+                    had_error = true;
                 }
             }
         }
@@ -203,15 +205,18 @@ async fn fire_github_poll(def: &ScheduleDef, bus_socket: &str, agent_name: &str)
                 Ok(n) => count += n,
                 Err(e) => {
                     warn!(agent = %agent_name, repo = %repo, error = %e, "github_poll issue_comments failed");
+                    had_error = true;
                 }
             }
         }
 
-        // Update since timestamp after successful poll
-        since_state.insert(
-            repo.clone(),
-            Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        );
+        // Only update since timestamp if all polls succeeded — otherwise retry next cycle.
+        if !had_error {
+            since_state.insert(
+                repo.clone(),
+                Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            );
+        }
 
         if count > 0 {
             info!(agent = %agent_name, repo = %repo, events = count, "github_poll posted events");


### PR DESCRIPTION
## Summary

- **Since tracking**: Persists last poll timestamp per repo in `~/.deskd/github_poll_since.json` to avoid duplicate events across poll cycles. First run defaults to "now - 5 minutes".
- **Events config**: Reads `events` array from config (supports `issues` and `issue_comments`). Defaults to `["issues"]` for backward compatibility.
- **Issues polling**: Switched from `gh issue list` to `gh api repos/{repo}/issues` with `since` filter. Filters out PRs (GitHub API returns them in the issues endpoint). Empty label means no label filter.
- **Issue comments polling**: New event type — fetches comments via `gh api repos/{repo}/issues/comments?since=...`, extracts issue number from `issue_url`, posts with user attribution.
- Adds 4 unit tests for config parsing and state persistence.

Closes #22

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` — all 67 tests pass
- [ ] Manual test: configure `events: [issues, issue_comments]` in deskd.yaml, verify events appear on bus
- [ ] Verify `~/.deskd/github_poll_since.json` is created and updated after each poll cycle
- [ ] Verify backward compat: config without `events` field defaults to issues-only polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)