### PR TITLE
fix: cargo fmt in worker.rs (#62)

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -167,13 +167,12 @@ pub async fn run(
             .map(|t| t as u32);
 
         // Determine reply target: workflow engine tasks route back to sm:<id>.
-        let reply_target = if let Some(sm_id) =
-            msg.payload.get("sm_instance_id").and_then(|v| v.as_str())
-        {
-            format!("sm:{}", sm_id)
-        } else {
-            msg.reply_to.as_deref().unwrap_or(&msg.source).to_string()
-        };
+        let reply_target =
+            if let Some(sm_id) = msg.payload.get("sm_instance_id").and_then(|v| v.as_str()) {
+                format!("sm:{}", sm_id)
+            } else {
+                msg.reply_to.as_deref().unwrap_or(&msg.source).to_string()
+            };
         let is_telegram = reply_target.starts_with("telegram.out:");
         let telegram_chat_id = if is_telegram {
             reply_target


### PR DESCRIPTION
## Summary

- Fixes a `cargo fmt` violation in `src/worker.rs` (reply_target binding indentation)

## Context

Issue #62 requests passing Telegram photo data as base64 to Claude instead of file paths. This was **already implemented** in PR #44 (merged as d7a6187), which included:

1. `download_photo_base64()` — downloads photos in-memory, base64-encodes them
2. `publish_to_bus()` — passes `image_base64` + `image_media_type` in the bus payload
3. Worker extracts these fields and passes to `agent::send_streaming()`
4. Agent constructs multimodal content blocks (image + text) for Claude

No code changes are needed for #62. This PR only fixes a pre-existing `cargo fmt` issue discovered while verifying the implementation.

Closes #62

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 70 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)