### PR TITLE
feat: inject --model from agent deskd.yaml config

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -277,7 +277,20 @@ async fn send_inner(
     // Always use stream-json input — needed for both multimodal content and mid-task injection.
     args.push("--input-format=stream-json".to_string());
 
-    debug!(agent = %name, turns, multimodal = image.is_some(), "spawning claude");
+    // Inject --model from agent config (sourced from deskd.yaml) unless the command
+    // array already contains --model (e.g. hardcoded in workspace.yaml).
+    if !state.config.model.is_empty()
+        && !state
+            .config
+            .command
+            .iter()
+            .any(|a| a == "--model" || a.starts_with("--model="))
+    {
+        args.push("--model".to_string());
+        args.push(state.config.model.clone());
+    }
+
+    debug!(agent = %name, turns, model = %state.config.model, multimodal = image.is_some(), "spawning claude");
 
     // Env vars injected into the claude process:
     //   DESKD_BUS_SOCKET  — bus socket for MCP send_message tool


### PR DESCRIPTION
## Summary
- When spawning Claude, deskd now reads the `model` field from the agent's config (sourced from `deskd.yaml`) and injects `--model <value>` into the CLI args automatically
- Skips injection if `--model` is already present in the workspace.yaml `command:` array, avoiding duplicates
- This removes the need to hardcode the model in both `workspace.yaml` `command:` and the agent's `deskd.yaml`

Closes #64

## Test plan
- [ ] Verify agent spawns with correct model from deskd.yaml when workspace.yaml command has no `--model`
- [ ] Verify no duplicate `--model` when workspace.yaml command already includes it
- [ ] Run `cargo test` to confirm existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)