### PR TITLE
Send error reply when budget exceeded (#71)

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -109,6 +109,21 @@ pub async fn run(
                 budget = budget_usd,
                 "budget exceeded, rejecting task"
             );
+
+            // Notify the sender so they get a visible error instead of silence.
+            let budget_error = format!(
+                "Budget limit reached (${:.2} / ${:.2}). Task not processed.",
+                current_state.total_cost, budget_usd,
+            );
+            let reply_target = msg.reply_to.as_deref().unwrap_or(&msg.source);
+            write_bus_envelope(
+                &writer,
+                name,
+                reply_target,
+                serde_json::json!({"error": budget_error, "in_reply_to": msg.id}),
+            )
+            .await;
+
             continue;
         }
 


### PR DESCRIPTION
## Summary
- When budget is exceeded, the worker now sends an error reply back through the bus to the `reply_to` target (or `source` as fallback)
- The error message includes current cost and budget cap: "Budget limit reached ($X.XX / $Y.XX). Task not processed."
- The warning log is preserved alongside the new notification

Fixes #71

## Test plan
- [ ] Send a task when budget is exceeded and verify Telegram user receives the error message
- [ ] Verify the reply routes correctly for both Telegram (`reply_to = telegram.out:<chat_id>`) and non-Telegram sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)