### PR TITLE
Fix env var passthrough through sudo for unix_user agents

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -455,7 +455,10 @@ pub fn build_command(cfg: &AgentConfig, args: &[String], extra_env: &[(&str, &st
     let mut cmd = match &cfg.unix_user {
         Some(user) => {
             let mut c = Command::new("sudo");
-            c.args(["-u", user, "-H", "--"]);
+            c.args(["-u", user, "-H", "--", "env"]);
+            for (k, v) in extra_env {
+                c.arg(format!("{}={}", k, v));
+            }
             c.arg(bin);
             c.args(prefix);
             c.args(args);
@@ -470,8 +473,10 @@ pub fn build_command(cfg: &AgentConfig, args: &[String], extra_env: &[(&str, &st
             c
         }
     };
-    for (k, v) in extra_env {
-        cmd.env(k, v);
+    if cfg.unix_user.is_none() {
+        for (k, v) in extra_env {
+            cmd.env(k, v);
+        }
     }
     cmd.current_dir(&cfg.work_dir)
         .stdout(Stdio::piped())


### PR DESCRIPTION
## Summary

- When `unix_user` is set, `sudo` doesn't forward env vars set via Rust's `Command::env()` to the child process
- This means `DESKD_BUS_SOCKET`, `DESKD_AGENT_NAME`, and `DESKD_AGENT_CONFIG` never reach the claude process, breaking MCP tools that depend on `DESKD_BUS_SOCKET`
- Fix: inject env vars as `env K=V` arguments between `sudo ... --` and the binary, so they pass through to the child process

## Changes

In `src/agent.rs` `build_command()`:
- When `unix_user` is set, insert `env` command after `sudo ... --` and pass env vars as `KEY=VALUE` arguments
- Skip the `cmd.env()` loop when `unix_user` is set (env vars are already handled inline)

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (87 tests)
- [ ] Manual test: run deskd with a `unix_user` agent and verify `DESKD_BUS_SOCKET` is accessible in the claude process

🤖 Generated with [Claude Code](https://claude.com/claude-code)