### PR TITLE
Fix typing indicator staying on permanently in resume sessions

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -307,9 +307,32 @@ pub async fn run(
         let writer_fwd = writer.clone();
         let name_owned = name.to_string();
         let reply_owned = reply_target.clone();
+        let fwd_chat_id = telegram_chat_id;
         let fwd_task = tokio::spawn(async move {
             let mut full_response = String::new();
+            let mut typing_stopped = false;
             while let Some(text) = progress_rx.recv().await {
+                // On first output chunk, stop typing indicator and progress message.
+                if !typing_stopped {
+                    if let Some(chat_id) = fwd_chat_id {
+                        let ctrl_target = format!("telegram.ctrl:{}", chat_id);
+                        write_bus_envelope(
+                            &writer_fwd,
+                            &name_owned,
+                            &ctrl_target,
+                            serde_json::json!({"progress_done": true}),
+                        )
+                        .await;
+                        write_bus_envelope(
+                            &writer_fwd,
+                            &name_owned,
+                            &ctrl_target,
+                            serde_json::json!({"typing": false}),
+                        )
+                        .await;
+                    }
+                    typing_stopped = true;
+                }
                 full_response.push_str(&text);
                 write_bus_envelope(
                     &writer_fwd,
@@ -352,6 +375,24 @@ pub async fn run(
                                 "injecting mid-task message"
                             );
                             let _ = process.inject_message(inject_task);
+                            // Restart typing indicator for the new message
+                            if let Some(chat_id) = telegram_chat_id {
+                                let ctrl_target = format!("telegram.ctrl:{}", chat_id);
+                                write_bus_envelope(
+                                    &writer,
+                                    name,
+                                    &ctrl_target,
+                                    serde_json::json!({"typing": true}),
+                                )
+                                .await;
+                                write_bus_envelope(
+                                    &writer,
+                                    name,
+                                    &ctrl_target,
+                                    serde_json::json!({"progress_start": true}),
+                                )
+                                .await;
+                            }
                         }
                     } else {
                         warn!(agent = %name, "invalid message from bus during task, skipping");


### PR DESCRIPTION
## Summary

- Stop the Telegram typing indicator and progress timer when the first output chunk is received, rather than waiting for the entire task to complete
- Restart typing indicator when a new mid-task message is injected
- Fixes the issue where `--resume` sessions show permanent typing because the task never fully "completes" between messages

## Problem

In long-lived `--resume` sessions, `typing: true` is sent when a task starts, but `typing: false` only fires when the task fully completes. Since the Claude process stays running waiting for new input, the typing indicator loops every 4 seconds indefinitely.

## Changes

In `src/worker.rs`:
1. **fwd_task**: On first received text chunk, send `progress_done` and `typing: false` to the Telegram ctrl target
2. **injection loop**: When a mid-task message is injected, restart `typing: true` and `progress_start` so the indicator shows again while processing the new message

## Test plan

- [ ] `cargo fmt --check` / `cargo clippy` / `cargo test` pass (verified locally)
- [ ] Deploy to VPS, send a Telegram message, verify typing stops when response starts streaming
- [ ] Send a follow-up message mid-task, verify typing restarts and stops again on output

🤖 Generated with [Claude Code](https://claude.com/claude-code)