### PR TITLE
Bump Cargo.toml version to 0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deskd"
-version = "0.1.0"
+version = "0.6.2"
 edition = "2024"
 description = "Agent orchestration runtime — spawn, route, and manage AI agents"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Update `version` in `Cargo.toml` from `"0.1.0"` to `"0.6.2"` to match the latest git tag `v0.6.2`
- All quality gates pass: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (87 tests)

## Test plan
- [x] `cargo check` compiles successfully with new version
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 87 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)