### PR TITLE
Sub-agent session control: persistent vs ephemeral (#88)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -7,7 +7,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
-use crate::config::{self, ContainerConfig, UserConfig};
+use crate::config::{self, ContainerConfig, SessionMode, UserConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentConfig {
@@ -31,6 +31,9 @@ pub struct AgentConfig {
     /// Container config. When set, the agent runs inside a container.
     #[serde(default)]
     pub container: Option<ContainerConfig>,
+    /// Session mode: persistent (default) or ephemeral.
+    #[serde(default)]
+    pub session: SessionMode,
 }
 
 fn default_budget_usd() -> f64 {
@@ -167,6 +170,7 @@ pub async fn create_or_recover(
         command: def.command.clone(),
         config_path: Some(def.config_path()),
         container: def.container.clone(),
+        session: SessionMode::default(),
     };
 
     let path = state_path(&def.name);
@@ -237,12 +241,16 @@ async fn send_inner(
     // Always use stream-json input so we can keep stdin open for mid-task injection.
     let mut args: Vec<String> = Vec::new();
 
-    if !state.session_id.is_empty() {
+    // Use --resume only when session is persistent and session_id exists.
+    let use_resume =
+        state.config.session == SessionMode::Persistent && !state.session_id.is_empty();
+
+    if use_resume {
         args.push("--resume".to_string());
         args.push(state.session_id.clone());
     }
 
-    if !state.config.system_prompt.is_empty() && state.session_id.is_empty() {
+    if !state.config.system_prompt.is_empty() && !use_resume {
         args.push("--system-prompt".to_string());
         args.push(state.config.system_prompt.clone());
     }
@@ -408,7 +416,8 @@ async fn send_inner(
     let _ = child.wait().await;
     let stderr_str = stderr_task.await.unwrap_or_default();
 
-    if !new_session_id.is_empty() {
+    // Only save session_id for persistent agents.
+    if state.config.session == SessionMode::Persistent && !new_session_id.is_empty() {
         state.session_id = new_session_id;
     }
     state.total_cost += task_cost;
@@ -641,6 +650,7 @@ pub async fn spawn_ephemeral(
         command: default_agent_command(),
         config_path: None,
         container: None,
+        session: SessionMode::default(),
     };
 
     create(&cfg).await?;
@@ -747,7 +757,21 @@ pub struct AgentProcess {
 impl AgentProcess {
     /// Spawn a persistent Claude process for the named agent.
     pub async fn start(name: &str, bus_socket: &str) -> Result<Self> {
-        let (stdin_tx, event_rx, child) = Self::spawn_process(name, bus_socket).await?;
+        let (stdin_tx, event_rx, child) = Self::spawn_process(name, bus_socket, false).await?;
+
+        Ok(Self {
+            stdin_tx,
+            event_rx: tokio::sync::Mutex::new(event_rx),
+            child: tokio::sync::Mutex::new(Some(child)),
+            name: name.to_string(),
+            last_reported_cost: tokio::sync::Mutex::new(0.0),
+            last_reported_turns: tokio::sync::Mutex::new(0),
+        })
+    }
+
+    /// Spawn a persistent Claude process with a fresh session (no --resume).
+    pub async fn start_fresh(name: &str, bus_socket: &str) -> Result<Self> {
+        let (stdin_tx, event_rx, child) = Self::spawn_process(name, bus_socket, true).await?;
 
         Ok(Self {
             stdin_tx,
@@ -760,9 +784,11 @@ impl AgentProcess {
     }
 
     /// Core spawn logic — builds args, starts child, wires stdin/stdout tasks.
+    /// When  is true, skip --resume regardless of session mode/state.
     async fn spawn_process(
         name: &str,
         bus_socket: &str,
+        fresh: bool,
     ) -> Result<(
         tokio::sync::mpsc::UnboundedSender<String>,
         tokio::sync::mpsc::UnboundedReceiver<StdoutEvent>,
@@ -772,12 +798,17 @@ impl AgentProcess {
 
         let mut args: Vec<String> = Vec::new();
 
-        if !state.session_id.is_empty() {
+        // Use --resume only when session is persistent and fresh is not requested.
+        let use_resume = !fresh
+            && state.config.session == SessionMode::Persistent
+            && !state.session_id.is_empty();
+
+        if use_resume {
             args.push("--resume".to_string());
             args.push(state.session_id.clone());
         }
 
-        if !state.config.system_prompt.is_empty() && state.session_id.is_empty() {
+        if !state.config.system_prompt.is_empty() && !use_resume {
             args.push("--system-prompt".to_string());
             args.push(state.config.system_prompt.clone());
         }
@@ -997,7 +1028,10 @@ impl AgentProcess {
 
                     // Update state file with deltas.
                     if let Ok(mut state) = load_state(&self.name) {
-                        if !result.session_id.is_empty() {
+                        // Only save session_id for persistent agents.
+                        if state.config.session == SessionMode::Persistent
+                            && !result.session_id.is_empty()
+                        {
                             state.session_id = result.session_id.clone();
                         }
                         state.total_cost += cost_delta;
@@ -1094,6 +1128,7 @@ created_at: "2024-01-01T00:00:00Z"
             command: vec!["claude".to_string()],
             config_path: Some("/home/agent1/deskd.yaml".to_string()),
             container: None,
+            session: SessionMode::default(),
         };
         let state = AgentState {
             config: cfg,
@@ -1208,6 +1243,7 @@ created_at: "2024-01-01T00:00:00Z"
             ],
             config_path: Some("/home/test/deskd.yaml".to_string()),
             container: Some(container),
+            session: SessionMode::default(),
         };
 
         let extra_env = [("DESKD_BUS_SOCKET", "/home/test/.deskd/bus.sock")];
@@ -1256,6 +1292,7 @@ created_at: "2024-01-01T00:00:00Z"
             command: vec!["claude".to_string()],
             config_path: None,
             container: None,
+            session: SessionMode::default(),
         };
         let cmd = build_command(&cfg, &[], &[]);
         let program = cmd.as_std().get_program().to_string_lossy().to_string();

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,6 +233,17 @@ pub struct ChannelDef {
     pub description: String,
 }
 
+/// Session mode for an agent: persistent (default) or ephemeral.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionMode {
+    /// Continue existing session across tasks (uses --resume).
+    #[default]
+    Persistent,
+    /// Start a fresh session for each task (no --resume).
+    Ephemeral,
+}
+
 /// A sub-agent running within a parent agent's bus scope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubAgentDef {
@@ -246,6 +257,10 @@ pub struct SubAgentDef {
     /// Optional allow-list of targets this agent can publish to.
     /// If None, publish to any target is allowed.
     pub publish: Option<Vec<String>>,
+    /// Session mode: persistent (default) or ephemeral.
+    /// Ephemeral agents start a fresh session for each task.
+    #[serde(default)]
+    pub session: SessionMode,
 }
 
 /// Telegram channel routing config in the per-user deskd.yaml.
@@ -591,6 +606,31 @@ schedules:
     }
 
     #[test]
+    fn test_sub_agent_session_mode() {
+        let yaml = r#"
+model: claude-sonnet-4-6
+system_prompt: "Test"
+
+agents:
+  - name: worker
+    model: claude-haiku-4-5
+    system_prompt: "Worker"
+    subscribe:
+      - "agent:worker"
+    session: ephemeral
+
+  - name: researcher
+    model: claude-sonnet-4-6
+    system_prompt: "Researcher"
+    subscribe:
+      - "agent:researcher"
+"#;
+        let cfg: UserConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.agents[0].session, SessionMode::Ephemeral);
+        assert_eq!(cfg.agents[1].session, SessionMode::Persistent); // default
+    }
+
+    #[test]
     fn test_send_message_description() {
         let cfg = UserConfig {
             model: "claude-opus-4-6".into(),
@@ -606,6 +646,7 @@ schedules:
                 system_prompt: "Implements code changes.".into(),
                 subscribe: vec!["agent:dev".into()],
                 publish: None,
+                session: SessionMode::default(),
             }],
             telegram: Some(TelegramRoutesConfig {
                 routes: vec![TelegramRoute {

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,7 @@ async fn main() -> anyhow::Result<()> {
                     },
                     config_path: None,
                     container: None,
+                    session: config::SessionMode::default(),
                 };
                 let state = agent::create(&cfg).await?;
                 println!("Agent {} created", state.config.name);
@@ -1237,6 +1238,7 @@ async fn serve(config_path: String) -> anyhow::Result<()> {
                     ],
                     config_path: Some(cfg_path.clone()),
                     container: def.container.clone(),
+                    session: sub.session.clone(),
                 };
                 agent::create_or_update_from_config(&sub_cfg).await?;
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -221,6 +221,10 @@ fn handle_tools_list(
                     "text": {
                         "type": "string",
                         "description": "Message content"
+                    },
+                    "fresh": {
+                        "type": "boolean",
+                        "description": "When true, the target agent starts a fresh session for this task (no --resume), regardless of its default session config."
                     }
                 },
                 "required": ["target", "text"]
@@ -363,6 +367,7 @@ async fn call_send_message(
         .get("text")
         .and_then(|t| t.as_str())
         .context("missing text")?;
+    let fresh = args.get("fresh").and_then(|f| f.as_bool()).unwrap_or(false);
 
     // Enforce publish allow-list if the calling agent is a sub-agent in config.
     if let Some(cfg) = user_config
@@ -396,7 +401,7 @@ async fn call_send_message(
         "source": agent_name,
         "target": target,
         "payload": {"task": text},
-        "metadata": {"priority": 5u8}
+        "metadata": {"priority": 5u8, "fresh": fresh}
     });
     let mut msg_line = serde_json::to_string(&msg)?;
     msg_line.push('\n');

--- a/src/message.rs
+++ b/src/message.rs
@@ -23,6 +23,10 @@ pub struct Message {
 pub struct Metadata {
     #[serde(default = "default_priority")]
     pub priority: u8,
+    /// When true, the worker should start a fresh session for this task
+    /// (no --resume), regardless of the agent's default session config.
+    #[serde(default)]
+    pub fresh: bool,
 }
 
 fn default_priority() -> u8 {
@@ -92,6 +96,29 @@ mod tests {
                 assert_eq!(msg.source, "agent1");
                 assert_eq!(msg.target, "telegram:-123");
                 assert_eq!(msg.payload["result"], "task done");
+            }
+            _ => panic!("expected Message variant"),
+        }
+    }
+    #[test]
+    fn test_metadata_fresh_flag() {
+        let json = r#"{"type":"message","id":"abc","source":"cli","target":"agent:dev","payload":{"task":"hello"},"metadata":{"priority":5,"fresh":true}}"#;
+        let env: Envelope = serde_json::from_str(json).unwrap();
+        match env {
+            Envelope::Message(msg) => {
+                assert!(msg.metadata.fresh);
+            }
+            _ => panic!("expected Message variant"),
+        }
+    }
+
+    #[test]
+    fn test_metadata_fresh_default() {
+        let json = r#"{"type":"message","id":"abc","source":"cli","target":"agent:dev","payload":{"task":"hello"},"metadata":{"priority":5}}"#;
+        let env: Envelope = serde_json::from_str(json).unwrap();
+        match env {
+            Envelope::Message(msg) => {
+                assert!(!msg.metadata.fresh);
             }
             _ => panic!("expected Message variant"),
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,6 +5,7 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::agent;
+use crate::config::SessionMode;
 use crate::inbox;
 use crate::message::Message;
 
@@ -192,6 +193,16 @@ pub async fn run(
         if task_raw.is_empty() {
             debug!(agent = %name, "message has no task payload, skipping");
             continue;
+        }
+
+        // Check if this task requests a fresh session (via metadata.fresh flag).
+        // Also check if the agent's session mode is ephemeral.
+        let needs_fresh =
+            msg.metadata.fresh || initial_state.config.session == SessionMode::Ephemeral;
+        if needs_fresh {
+            info!(agent = %name, fresh = msg.metadata.fresh, "fresh session requested, restarting process");
+            process.stop().await;
+            process = agent::AgentProcess::start_fresh(name, &effective_bus).await?;
         }
 
         // Extract optional image data from payload (sent by Telegram adapter for photos).


### PR DESCRIPTION
## Summary

Implements #88: sub-agent session control with persistent vs ephemeral sessions.

- **`session` field in deskd.yaml**: Adds `session: persistent | ephemeral` option to `SubAgentDef` (default: `persistent` for backward compat). Ephemeral agents skip `--resume` and start a fresh Claude session for each task.
- **`fresh` parameter on `send_message` MCP tool**: When `fresh: true` is passed, the target agent starts a new session for that specific task, regardless of its default session config.

### Behavior matrix

| Config session | fresh param | Result |
|---|---|---|
| persistent | false/omitted | Continue existing session (--resume) |
| persistent | true | Start new session (no --resume) |
| ephemeral | false/omitted | Start new session (no --resume) |
| ephemeral | true | Start new session (no --resume) |

### Files changed
- `src/config.rs` — `SessionMode` enum, `session` field on `SubAgentDef`
- `src/agent.rs` — `session` field on `AgentConfig`, session-aware `--resume` logic, `start_fresh()` method
- `src/message.rs` — `fresh` field on `Metadata`
- `src/mcp.rs` — `fresh` param in `send_message` tool schema, propagated in bus message metadata
- `src/worker.rs` — checks `fresh` flag and ephemeral mode, restarts process when needed
- `src/main.rs` — propagates `session` from `SubAgentDef` to `AgentConfig`

## Test plan
- [x] New test: `test_sub_agent_session_mode` — verifies YAML parsing of ephemeral/persistent
- [x] New tests: `test_metadata_fresh_flag`, `test_metadata_fresh_default` — verifies fresh field deserialization
- [x] All 90 existing + new tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)