### PR TITLE
fix: drain stale stdout events between persistent session turns

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -916,6 +916,38 @@ impl AgentProcess {
         image: Option<(&str, &str)>,
         limits: &TaskLimits,
     ) -> Result<TurnResult> {
+        // Drain any stale events from the previous turn before starting a new one.
+        // Between turns, the stdout reader may have queued TextBlock events (e.g.,
+        // from output that arrived after the previous send_task saw the Result event
+        // but before it returned). If we don't drain these, the next turn picks up
+        // stale output and sends it as the response to the wrong message (#102).
+        {
+            let mut event_rx = self.event_rx.lock().await;
+            let mut drained = 0u32;
+            loop {
+                match event_rx.try_recv() {
+                    Ok(StdoutEvent::ProcessExited) => {
+                        bail!("persistent process exited between turns");
+                    }
+                    Ok(_) => {
+                        drained += 1;
+                    }
+                    Err(_) => break,
+                }
+            }
+            if drained > 0 {
+                info!(
+                    agent = %self.name,
+                    drained_events = drained,
+                    "flushed stale stdout events between turns"
+                );
+            }
+            // Yield to let the stdout reader task process any in-flight data
+            // before we check the channel again.
+            drop(event_rx);
+            tokio::task::yield_now().await;
+        }
+
         // Build the user message.
         let user_msg = if let Some((b64_data, media_type)) = image {
             let msg = serde_json::json!({


### PR DESCRIPTION
## Summary

Fixes #102 — persistent sessions produce off-by-one responses where user gets the response to the previous message.

- **Root cause**: After `send_task` returns (upon receiving the `Result` event), the stdout reader task may still queue additional `TextBlock` events into the `event_rx` channel. The next `send_task` call picks up these stale events and forwards them as the response to the wrong message.
- **Fix**: At the start of each `send_task`, drain any queued events from `event_rx` using `try_recv()` before writing the new user message to stdin. If a `ProcessExited` event is found during drain, bail immediately. A `yield_now()` after draining gives the stdout reader task a chance to flush any in-flight data.

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (8 pre-existing `unified_inbox` permission failures unrelated)
- [ ] Manual test: send multiple rapid messages to a persistent-session agent, verify each response matches its corresponding input

🤖 Generated with [Claude Code](https://claude.com/claude-code)