### PR TITLE
test: verify agent-level schedule support (#101)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -726,4 +726,78 @@ telegram:
         assert_eq!(routes[1].route_to.as_deref(), Some("agent:collab"));
         assert!(routes[1].mention_only);
     }
+
+    #[test]
+    fn test_agent_def_config_path_uses_agent_config_when_set() {
+        // When an agent defines config_path in workspace.yaml, that path is used
+        // for loading schedules and other agent-level config.
+        let def = AgentDef {
+            name: "family".into(),
+            unix_user: Some("family".into()),
+            work_dir: "/home/family".into(),
+            config: Some("/home/family/deskd.yaml".into()),
+            telegram: None,
+            discord: None,
+            model: None,
+            command: vec!["claude".into()],
+            budget_usd: 50.0,
+            container: None,
+        };
+        assert_eq!(def.config_path(), "/home/family/deskd.yaml");
+    }
+
+    #[test]
+    fn test_agent_def_config_path_defaults_to_work_dir() {
+        // When config is not set, config_path defaults to {work_dir}/deskd.yaml.
+        let def = AgentDef {
+            name: "family".into(),
+            unix_user: Some("family".into()),
+            work_dir: "/home/family".into(),
+            config: None,
+            telegram: None,
+            discord: None,
+            model: None,
+            command: vec!["claude".into()],
+            budget_usd: 50.0,
+            container: None,
+        };
+        assert_eq!(def.config_path(), "/home/family/deskd.yaml");
+    }
+
+    #[test]
+    fn test_user_config_with_schedules() {
+        // Verify that schedules defined in an agent-level deskd.yaml are parsed
+        // correctly, supporting all three action types.
+        let yaml = r#"
+model: claude-sonnet-4-6
+system_prompt: "Family assistant"
+
+schedules:
+  - cron: "3 7 * * *"
+    target: "agent:family"
+    action: raw
+    config: "Morning brief"
+  - cron: "3 21 * * *"
+    target: "agent:family"
+    action: github_poll
+    config:
+      repos:
+        - kgatilin/deskd
+      label: agent-ready
+  - cron: "7 22 * * *"
+    target: "agent:family"
+    action: shell
+    config:
+      command: "echo receipts"
+"#;
+        let cfg: UserConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.schedules.len(), 3);
+        assert_eq!(cfg.schedules[0].cron, "3 7 * * *");
+        assert!(matches!(cfg.schedules[0].action, ScheduleAction::Raw));
+        assert!(matches!(
+            cfg.schedules[1].action,
+            ScheduleAction::GithubPoll
+        ));
+        assert!(matches!(cfg.schedules[2].action, ScheduleAction::Shell));
+    }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -872,4 +872,109 @@ mod tests {
         let state = load_since_state(&home_dir);
         assert!(state.is_empty());
     }
+
+    #[test]
+    fn test_start_creates_handles_per_schedule_def() {
+        // start() requires a tokio runtime because it calls tokio::spawn.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let defs = vec![
+                ScheduleDef {
+                    cron: "0 9 * * *".into(),
+                    target: "agent:family".into(),
+                    action: ScheduleAction::Raw,
+                    config: Some(serde_yaml::Value::String("morning brief".into())),
+                },
+                ScheduleDef {
+                    cron: "0 21 * * *".into(),
+                    target: "agent:family".into(),
+                    action: ScheduleAction::Raw,
+                    config: Some(serde_yaml::Value::String("evening check".into())),
+                },
+            ];
+
+            let handles = start(
+                defs,
+                "/tmp/nonexistent.sock".into(),
+                "family".into(),
+                "/tmp/family_test".into(),
+            );
+
+            assert_eq!(
+                handles.len(),
+                2,
+                "should create one handle per schedule def"
+            );
+
+            // Clean up: abort the spawned tasks
+            for h in handles {
+                h.abort();
+            }
+        });
+    }
+
+    #[test]
+    fn test_load_schedules_from_agent_config_file() {
+        // Verify that UserConfig::load() picks up schedules from an agent-level
+        // deskd.yaml, which is the mechanism used by watch_and_reload().
+        let dir = std::env::temp_dir().join("deskd_test_agent_schedules");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let config_path = dir.join("deskd.yaml");
+        let yaml = r#"
+model: claude-sonnet-4-6
+system_prompt: "Family assistant"
+
+schedules:
+  - cron: "3 7 * * *"
+    target: "agent:family"
+    action: raw
+    config: "Morning brief"
+  - cron: "3 21 * * *"
+    target: "agent:family"
+    action: github_poll
+    config:
+      repos:
+        - kgatilin/deskd
+      label: agent-ready
+  - cron: "7 22 * * *"
+    target: "agent:family"
+    action: shell
+    config:
+      command: "echo hello"
+"#;
+        std::fs::write(&config_path, yaml).unwrap();
+
+        let cfg = crate::config::UserConfig::load(&config_path.to_string_lossy()).unwrap();
+
+        assert_eq!(cfg.schedules.len(), 3);
+        assert_eq!(cfg.schedules[0].cron, "3 7 * * *");
+        assert_eq!(cfg.schedules[0].target, "agent:family");
+        assert!(matches!(cfg.schedules[0].action, ScheduleAction::Raw));
+        assert!(matches!(
+            cfg.schedules[1].action,
+            ScheduleAction::GithubPoll
+        ));
+        assert!(matches!(cfg.schedules[2].action, ScheduleAction::Shell));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_file_mtime_returns_none_for_missing_file() {
+        assert!(file_mtime("/tmp/definitely_nonexistent_deskd_test_file.yaml").is_none());
+    }
+
+    #[test]
+    fn test_file_mtime_returns_some_for_existing_file() {
+        let dir = std::env::temp_dir().join("deskd_test_mtime");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("test.yaml");
+        std::fs::write(&path, "test").unwrap();
+
+        assert!(file_mtime(&path.to_string_lossy()).is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
## Summary

- Agent-level schedules defined in per-agent `deskd.yaml` are **already supported** by the existing `watch_and_reload()` call in the `serve()` loop (line 1186 of main.rs). Each agent's config path is resolved via `AgentDef::config_path()` and passed to `schedule::watch_and_reload()`, which handles initial load and hot-reload on file changes.
- This PR adds **test coverage** to confirm the behavior works correctly: config path resolution, schedule parsing from agent YAML, `start()` handle creation, and `file_mtime()` detection for hot-reload.

If the family agent's schedules are not firing, the likely cause is that the deployed deskd binary predates commit `83341c7` which fixed `home_dir` threading for schedule state. Upgrading to the latest release should resolve it.

### New tests (config.rs)
- `test_agent_def_config_path_uses_agent_config_when_set`
- `test_agent_def_config_path_defaults_to_work_dir`
- `test_user_config_with_schedules`

### New tests (schedule.rs)
- `test_start_creates_handles_per_schedule_def`
- `test_load_schedules_from_agent_config_file`
- `test_file_mtime_returns_none_for_missing_file`
- `test_file_mtime_returns_some_for_existing_file`

Closes #101

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test -- --skip unified_inbox` passes (104 tests, unified_inbox tests have pre-existing /tmp permission issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)