### PR TITLE
fix: add in_reply_to to streaming progress chunks (#109)

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -420,6 +420,7 @@ pub async fn run(
         let writer_fwd = writer.clone();
         let name_owned = name.to_string();
         let reply_owned = reply_target.clone();
+        let msg_id_owned = msg.id.clone();
         let fwd_chat_id = telegram_chat_id;
         let fwd_task = tokio::spawn(async move {
             let mut full_response = String::new();
@@ -454,7 +455,7 @@ pub async fn run(
                         &writer_fwd,
                         &name_owned,
                         &reply_owned,
-                        serde_json::json!({"result": text}),
+                        serde_json::json!({"result": text, "in_reply_to": msg_id_owned}),
                     )
                     .await;
                 }


### PR DESCRIPTION
## Summary

- Streaming progress chunks sent via `write_bus_envelope` now include `in_reply_to` field
- Previously only the final completion marker had `in_reply_to`, making it impossible to correlate streaming responses with the originating message
- This fixes out-of-order response delivery in Telegram when messages arrive in quick succession

## Changes

`src/worker.rs`: Pass `msg.id` into the `fwd_task` closure and include it in streaming chunk JSON payload.

Closes #109

## Test plan

- [ ] Send rapid messages to agent via Telegram, verify responses correlate correctly
- [ ] Check bus message format includes `in_reply_to` on streaming chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)