### PR TITLE
feat: include quoted message text in Telegram replies

### DIFF
--- a/src/adapters/telegram.rs
+++ b/src/adapters/telegram.rs
@@ -633,9 +633,12 @@ async fn polling_loop(
                 });
                 let message_id = msg.id.0;
                 let reply_to_message_id = msg.reply_to_message().map(|r| r.id.0);
+                let reply_to_text = msg
+                    .reply_to_message()
+                    .and_then(|r| r.text().or_else(|| r.caption()).map(|s| s.to_string()));
 
                 if let Err(e) =
-                    publish_to_bus(&socket, &agent, &text, &target, &reply_to, chat_id, chat_name, image_base64.as_deref(), sender_info.as_ref(), message_id, reply_to_message_id)
+                    publish_to_bus(&socket, &agent, &text, &target, &reply_to, chat_id, chat_name, image_base64.as_deref(), sender_info.as_ref(), message_id, reply_to_message_id, reply_to_text.as_deref())
                         .await
                 {
                     warn!(chat_id = chat_id, error = %e, "failed to publish message to bus");
@@ -742,6 +745,7 @@ async fn publish_to_bus(
     sender_info: Option<&SenderInfo>,
     message_id: i32,
     reply_to_message_id: Option<i32>,
+    reply_to_text: Option<&str>,
 ) -> Result<()> {
     let mut stream = UnixStream::connect(socket_path)
         .await
@@ -766,6 +770,10 @@ async fn publish_to_bus(
 
     if let Some(reply_id) = reply_to_message_id {
         payload["telegram_reply_to_message_id"] = serde_json::json!(reply_id);
+    }
+
+    if let Some(quoted) = reply_to_text {
+        payload["telegram_reply_to_text"] = serde_json::Value::String(quoted.to_string());
     }
 
     if let Some(sender) = sender_info {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -379,7 +379,15 @@ pub async fn run(
                     .and_then(|v| v.as_str())
                     .map(|n| format!("{} ({})", n, chat_id))
                     .unwrap_or_else(|| chat_id.to_string());
-                task_owned = format!("[Telegram: {}]\n{}", label, task_raw);
+                let quoted = msg
+                    .payload
+                    .get("telegram_reply_to_text")
+                    .and_then(|v| v.as_str());
+                task_owned = if let Some(q) = quoted {
+                    format!("[Telegram: {}]\n> {}\n\n{}", label, q, task_raw)
+                } else {
+                    format!("[Telegram: {}]\n{}", label, task_raw)
+                };
                 &task_owned as &str
             } else {
                 // Non-Telegram sources: tag with source so agent can distinguish


### PR DESCRIPTION
## Summary
- Extract `reply_to_message.text()` / `reply_to_message.caption()` from Telegram messages
- Add `telegram_reply_to_text` field to bus payload
- Worker prepends quoted text as blockquote in task context: `> quoted text`

When a user replies/quotes a message in Telegram, the agent now sees the full quoted text, not just the message ID.

## Test plan
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` pass
- [x] All existing tests pass
- [ ] Manual test: reply to a message in Telegram, verify agent sees quoted text

🤖 Generated with [Claude Code](https://claude.com/claude-code)