### PR TITLE
fix: drain stale stdout events before each persistent session turn

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1010,6 +1010,61 @@ impl AgentProcess {
         image: Option<(&str, &str)>,
         limits: &TaskLimits,
     ) -> Result<TurnResult> {
+        // Drain any stale events left over from the previous turn before
+        // starting a new one. The post-result drain (below) catches most
+        // trailing TextBlock events, but there is a race window: if the
+        // stdout reader task has not yet queued events when try_recv()
+        // runs after the result, those events survive into the next turn.
+        // Draining here, before writing to stdin, ensures each turn
+        // starts with a clean channel. (#102)
+        {
+            let mut event_rx = self.event_rx.lock().await;
+            let mut drained = 0u32;
+            loop {
+                match event_rx.try_recv() {
+                    Ok(StdoutEvent::ProcessExited) => {
+                        bail!("persistent process exited between turns");
+                    }
+                    Ok(_) => {
+                        drained += 1;
+                    }
+                    Err(_) => break,
+                }
+            }
+            if drained > 0 {
+                info!(
+                    agent = %self.name,
+                    drained_events = drained,
+                    "flushed stale stdout events before new turn"
+                );
+            }
+            drop(event_rx);
+            // Yield to let the stdout reader task push any in-flight
+            // data before we proceed.
+            tokio::task::yield_now().await;
+            // Second drain pass after yielding — catches events that were
+            // being processed during the first pass.
+            let mut event_rx = self.event_rx.lock().await;
+            loop {
+                match event_rx.try_recv() {
+                    Ok(StdoutEvent::ProcessExited) => {
+                        bail!("persistent process exited between turns");
+                    }
+                    Ok(_) => {
+                        drained += 1;
+                    }
+                    Err(_) => break,
+                }
+            }
+            if drained > 0 {
+                info!(
+                    agent = %self.name,
+                    total_drained = drained,
+                    "pre-turn drain complete"
+                );
+            }
+        }
+
         // Build the user message.
         let user_msg = if let Some((b64_data, media_type)) = image {
             let msg = serde_json::json!({


### PR DESCRIPTION
## Summary

- Fixes #102: off-by-one responses in persistent sessions caused by stale stdout events leaking between turns
- Adds a pre-turn drain at the start of `send_task()` that complements the existing post-result drain (5cab510)
- Uses a drain-yield-drain pattern: drain queued events, yield to let the stdout reader task flush in-flight data, then drain again to close the race window

## How it works

The existing post-result drain (`try_recv()` after the Result event) catches events already in the channel, but misses events the stdout reader task is still processing. By the time the next `send_task()` is called, those late events are in the channel and get treated as the new turn's response.

The pre-turn drain ensures the channel is clean before writing the new message to stdin. The yield between drain passes gives the stdout reader task a chance to push any in-flight data.

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test --bin deskd` passes (8 pre-existing unified_inbox failures on main, unrelated)
- [ ] Manual test: send multiple messages in quick succession to a persistent-session agent, verify responses match the correct messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)