### PR TITLE
fix: recover from stale session_id on container restart

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -810,8 +810,76 @@ pub struct AgentProcess {
 
 impl AgentProcess {
     /// Spawn a persistent Claude process for the named agent.
+    ///
+    /// If a stale session_id causes an immediate exit (e.g. container restart
+    /// cleared the session), automatically retries with a fresh session and
+    /// clears the stale session_id from state. See #149.
     pub async fn start(name: &str, bus_socket: &str) -> Result<Self> {
+        let state = load_state(name)?;
+        let will_resume =
+            state.config.session == SessionMode::Persistent && !state.session_id.is_empty();
+
         let (stdin_tx, event_rx, child) = Self::spawn_process(name, bus_socket, false).await?;
+
+        if will_resume {
+            // Check if the process exits immediately (stale session).
+            // Give it up to 5 seconds — a healthy process stays alive.
+            let mut event_rx_guard = event_rx;
+            let exited_immediately =
+                tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                    // Peek: if we get ProcessExited quickly, session was stale.
+                    loop {
+                        match event_rx_guard.try_recv() {
+                            Ok(StdoutEvent::ProcessExited) => return true,
+                            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                            }
+                            _ => {
+                                // Got a real event (TextBlock, Result) — process is alive.
+                                return false;
+                            }
+                        }
+                    }
+                })
+                .await
+                .unwrap_or(false); // timeout = process is alive
+
+            if exited_immediately {
+                warn!(
+                    agent = %name,
+                    session_id = %state.session_id,
+                    "process exited immediately with --resume (stale session), retrying fresh"
+                );
+
+                // Clear stale session_id from state.
+                if let Ok(mut s) = load_state(name) {
+                    s.session_id.clear();
+                    save_state_pub(&s).ok();
+                }
+
+                // Retry with fresh session.
+                let (stdin_tx2, event_rx2, child2) =
+                    Self::spawn_process(name, bus_socket, true).await?;
+                return Ok(Self {
+                    stdin_tx: stdin_tx2,
+                    event_rx: tokio::sync::Mutex::new(event_rx2),
+                    child: tokio::sync::Mutex::new(Some(child2)),
+                    name: name.to_string(),
+                    last_reported_cost: tokio::sync::Mutex::new(0.0),
+                    last_reported_turns: tokio::sync::Mutex::new(0),
+                });
+            }
+
+            // Process is alive — use the original channels.
+            return Ok(Self {
+                stdin_tx,
+                event_rx: tokio::sync::Mutex::new(event_rx_guard),
+                child: tokio::sync::Mutex::new(Some(child)),
+                name: name.to_string(),
+                last_reported_cost: tokio::sync::Mutex::new(0.0),
+                last_reported_turns: tokio::sync::Mutex::new(0),
+            });
+        }
 
         Ok(Self {
             stdin_tx,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -782,11 +782,12 @@ pub async fn run(
 
                 // If the persistent process died, try to restart it.
                 if err_str.contains("process exited") || err_str.contains("stdin closed") {
-                    warn!(agent = %name, "agent process crashed, restarting");
-                    match RuntimeProcess::start(name, &effective_bus, &agent_runtime).await {
+                    warn!(agent = %name, "agent process crashed, restarting with fresh session");
+                    // Use start_fresh to avoid retrying a stale session_id (#149).
+                    match RuntimeProcess::start_fresh(name, &effective_bus, &agent_runtime).await {
                         Ok(new_proc) => {
                             process = new_proc;
-                            info!(agent = %name, "agent process restarted");
+                            info!(agent = %name, "agent process restarted (fresh session)");
                         }
                         Err(re) => {
                             warn!(agent = %name, error = %re, "failed to restart agent process");


### PR DESCRIPTION
## Summary
- **Stale session detection**: `AgentProcess::start()` monitors for immediate process exit (within 5s) after `--resume`. If detected, clears the stale `session_id` from state and retries with a fresh session — before any task is sent, so no task is lost.
- **Worker crash recovery**: Uses `start_fresh` instead of `start` after a process crash, preventing infinite restart loops with the same stale session_id.

Closes #149

## How it works

```
start(name, bus) with session_id="abc123"
  → spawn_process(fresh=false) → --resume abc123
  → monitor event_rx for 5 seconds
    → ProcessExited received? (stale session)
      → clear session_id from state
      → spawn_process(fresh=true) → new session
    → timeout/real event? (process alive)
      → continue normally
```

## Test plan
- [x] All 339 tests pass, 0 failures
- [x] Quality gate: `cargo fmt` + `cargo clippy -D warnings` + `cargo test`
- [ ] Manual: start agent with persistent session, kill container, restart — should auto-recover
- [ ] Manual: verify normal --resume still works when session is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)