### PR TITLE
Auto-inject --mcp-config for sub-agents (#153)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -268,6 +268,27 @@ async fn send_inner(
     // Auto-inject required flags for stream-json operation (#151).
     inject_required_flags(&mut args, &state.config.command);
 
+    // Auto-inject --mcp-config for deskd tools when not already present (#153).
+    if !state
+        .config
+        .command
+        .iter()
+        .any(|a| a.contains("mcp-config"))
+    {
+        let deskd_bin = std::env::var("DESKD_BIN").unwrap_or_else(|_| "deskd".to_string());
+        let mcp_json = serde_json::json!({
+            "mcpServers": {
+                "deskd": {
+                    "command": deskd_bin,
+                    "args": ["mcp", "--agent", name]
+                }
+            }
+        })
+        .to_string();
+        args.push("--mcp-config".to_string());
+        args.push(mcp_json);
+    }
+
     // Inject --model from agent config (sourced from deskd.yaml) unless the command
     // array already contains --model (e.g. hardcoded in workspace.yaml).
     if !state.config.model.is_empty()
@@ -966,6 +987,28 @@ impl AgentProcess {
 
         // Auto-inject required flags for stream-json operation (#151).
         inject_required_flags(&mut args, &state.config.command);
+
+        // Auto-inject --mcp-config for deskd tools when not already present (#153).
+        // This lets sub-agents use send_message, read_inbox, etc. via MCP.
+        if !state
+            .config
+            .command
+            .iter()
+            .any(|a| a.contains("mcp-config"))
+        {
+            let deskd_bin = std::env::var("DESKD_BIN").unwrap_or_else(|_| "deskd".to_string());
+            let mcp_json = serde_json::json!({
+                "mcpServers": {
+                    "deskd": {
+                        "command": deskd_bin,
+                        "args": ["mcp", "--agent", name]
+                    }
+                }
+            })
+            .to_string();
+            args.push("--mcp-config".to_string());
+            args.push(mcp_json);
+        }
 
         if !state.config.model.is_empty()
             && !state


### PR DESCRIPTION
## Summary
- Sub-agents spawned via `add_persistent_agent` or `deskd agent run` now automatically get `--mcp-config` with a deskd MCP server config
- This gives sub-agents access to deskd tools (send_message, read_inbox, search_inbox, etc.) without manual configuration
- Injection is skipped when `--mcp-config` is already present in the command array (e.g. parent agents with explicit config in workspace.yaml)

Closes #153

## Test plan
- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` passes
- [ ] Spawn a sub-agent via MCP `add_persistent_agent` — verify it receives `--mcp-config` with deskd server
- [ ] Sub-agent can call `send_message` and `read_inbox` via its MCP tools
- [ ] Parent agents with explicit `--mcp-config` in workspace.yaml are not affected (no duplicate injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)