### PR TITLE
arch: extract MessageBus trait impls — UnixBus + InMemoryBus (#139)

### DIFF
--- a/src/infra/memory_bus.rs
+++ b/src/infra/memory_bus.rs
@@ -1,0 +1,137 @@
+//! In-memory implementation of MessageBus for testing.
+//!
+//! Uses tokio mpsc channels — no Unix sockets, no filesystem.
+
+use anyhow::Result;
+use std::future::Future;
+use std::pin::Pin;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+
+use crate::domain::message::Message;
+use crate::ports::bus::MessageBus;
+
+/// Test-only bus backed by in-memory channels.
+pub struct InMemoryBus {
+    tx: mpsc::UnboundedSender<Message>,
+    rx: Mutex<mpsc::UnboundedReceiver<Message>>,
+    registered_name: Mutex<Option<String>>,
+}
+
+impl InMemoryBus {
+    /// Create a linked pair of buses for testing (client ↔ server).
+    ///
+    /// Messages sent on `a` arrive at `b.recv()` and vice versa.
+    pub fn pair() -> (Self, Self) {
+        let (tx_a, rx_b) = mpsc::unbounded_channel();
+        let (tx_b, rx_a) = mpsc::unbounded_channel();
+        (
+            Self {
+                tx: tx_a,
+                rx: Mutex::new(rx_a),
+                registered_name: Mutex::new(None),
+            },
+            Self {
+                tx: tx_b,
+                rx: Mutex::new(rx_b),
+                registered_name: Mutex::new(None),
+            },
+        )
+    }
+
+    /// Create a single bus where sent messages loop back to recv.
+    pub fn loopback() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        Self {
+            tx,
+            rx: Mutex::new(rx),
+            registered_name: Mutex::new(None),
+        }
+    }
+
+    /// Get the registered name (set by register()).
+    pub async fn registered_name(&self) -> Option<String> {
+        self.registered_name.lock().await.clone()
+    }
+}
+
+impl MessageBus for InMemoryBus {
+    fn send<'a>(
+        &'a self,
+        msg: &'a Message,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            self.tx
+                .send(msg.clone())
+                .map_err(|_| anyhow::anyhow!("bus channel closed"))?;
+            Ok(())
+        })
+    }
+
+    fn recv(&self) -> Pin<Box<dyn Future<Output = Result<Message>> + Send + '_>> {
+        Box::pin(async move {
+            let mut rx = self.rx.lock().await;
+            rx.recv()
+                .await
+                .ok_or_else(|| anyhow::anyhow!("bus channel closed"))
+        })
+    }
+
+    fn register(
+        &self,
+        name: &str,
+        _subscriptions: &[String],
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        let name = name.to_string();
+        Box::pin(async move {
+            *self.registered_name.lock().await = Some(name);
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::message::{Message, Metadata};
+
+    fn test_message(source: &str, target: &str, task: &str) -> Message {
+        Message {
+            id: uuid::Uuid::new_v4().to_string(),
+            source: source.to_string(),
+            target: target.to_string(),
+            payload: serde_json::json!({"task": task}),
+            reply_to: None,
+            metadata: Metadata::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pair_send_recv() {
+        let (a, b) = InMemoryBus::pair();
+        let msg = test_message("alice", "agent:bob", "hello");
+        a.send(&msg).await.unwrap();
+        let received = b.recv().await.unwrap();
+        assert_eq!(received.source, "alice");
+        assert_eq!(received.target, "agent:bob");
+    }
+
+    #[tokio::test]
+    async fn test_register() {
+        let bus = InMemoryBus::loopback();
+        assert!(bus.registered_name().await.is_none());
+        bus.register("test-agent", &["agent:test-agent".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(bus.registered_name().await.unwrap(), "test-agent");
+    }
+
+    #[tokio::test]
+    async fn test_loopback() {
+        let bus = InMemoryBus::loopback();
+        let msg = test_message("self", "agent:self", "echo");
+        bus.send(&msg).await.unwrap();
+        let received = bus.recv().await.unwrap();
+        assert_eq!(received.id, msg.id);
+    }
+}

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,0 +1,4 @@
+//! Infrastructure layer — concrete implementations of port traits.
+
+pub mod memory_bus;
+pub mod unix_bus;

--- a/src/infra/unix_bus.rs
+++ b/src/infra/unix_bus.rs
@@ -1,0 +1,166 @@
+//! Unix socket implementation of the MessageBus trait.
+//!
+//! Wraps a single UnixStream connection to the bus server.
+//! Handles registration, sending envelopes, and receiving messages
+//! as newline-delimited JSON.
+
+use anyhow::{Context, Result};
+use std::future::Future;
+use std::pin::Pin;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::domain::message::Message;
+use crate::ports::bus::MessageBus;
+
+/// Production bus client backed by a Unix socket connection.
+pub struct UnixBus {
+    reader: Mutex<BufReader<OwnedReadHalf>>,
+    writer: Mutex<OwnedWriteHalf>,
+    socket_path: String,
+}
+
+impl UnixBus {
+    /// Connect to the bus socket with retries (exponential backoff).
+    pub async fn connect(socket_path: &str) -> Result<Self> {
+        let max_retries = 10u32;
+        let initial_delay = std::time::Duration::from_millis(100);
+
+        let mut stream = None;
+        let mut last_err = None;
+        for attempt in 0..max_retries {
+            match UnixStream::connect(socket_path).await {
+                Ok(s) => {
+                    if attempt > 0 {
+                        info!(attempt = attempt + 1, "connected to bus after retry");
+                    }
+                    stream = Some(s);
+                    break;
+                }
+                Err(e) => {
+                    if attempt + 1 < max_retries {
+                        let delay = initial_delay * 2u32.saturating_pow(attempt);
+                        warn!(
+                            attempt = attempt + 1,
+                            delay_ms = delay.as_millis() as u64,
+                            "bus not ready, retrying"
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        let stream = match stream {
+            Some(s) => s,
+            None => {
+                return Err(last_err.unwrap()).with_context(|| {
+                    format!(
+                        "Failed to connect to bus at {} after {} attempts",
+                        socket_path, max_retries
+                    )
+                });
+            }
+        };
+
+        let (reader, writer) = stream.into_split();
+        Ok(Self {
+            reader: Mutex::new(BufReader::new(reader)),
+            writer: Mutex::new(writer),
+            socket_path: socket_path.to_string(),
+        })
+    }
+
+    /// The socket path this bus is connected to.
+    pub fn socket_path(&self) -> &str {
+        &self.socket_path
+    }
+
+    /// Build a message envelope JSON for the bus protocol.
+    pub fn build_envelope(source: &str, target: &str, payload: serde_json::Value) -> String {
+        let envelope = serde_json::json!({
+            "type": "message",
+            "id": Uuid::new_v4().to_string(),
+            "source": source,
+            "target": target,
+            "payload": payload,
+            "metadata": {"priority": 5u8},
+        });
+        serde_json::to_string(&envelope).unwrap_or_default()
+    }
+}
+
+impl MessageBus for UnixBus {
+    fn send<'a>(
+        &'a self,
+        msg: &'a Message,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            let envelope = serde_json::json!({
+                "type": "message",
+                "id": &msg.id,
+                "source": &msg.source,
+                "target": &msg.target,
+                "payload": &msg.payload,
+                "reply_to": &msg.reply_to,
+                "metadata": &msg.metadata,
+            });
+            let mut line = serde_json::to_string(&envelope)?;
+            line.push('\n');
+            let mut writer = self.writer.lock().await;
+            writer.write_all(line.as_bytes()).await?;
+            Ok(())
+        })
+    }
+
+    fn recv(&self) -> Pin<Box<dyn Future<Output = Result<Message>> + Send + '_>> {
+        Box::pin(async move {
+            let mut reader = self.reader.lock().await;
+            loop {
+                let mut line = String::new();
+                let n = reader.read_line(&mut line).await?;
+                if n == 0 {
+                    anyhow::bail!("bus connection closed");
+                }
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<Message>(trimmed) {
+                    Ok(msg) => return Ok(msg),
+                    Err(e) => {
+                        warn!(error = %e, "invalid message from bus, skipping");
+                        continue;
+                    }
+                }
+            }
+        })
+    }
+
+    fn register(
+        &self,
+        name: &str,
+        subscriptions: &[String],
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        let name = name.to_string();
+        let subs = subscriptions.to_vec();
+        Box::pin(async move {
+            let envelope = serde_json::json!({
+                "type": "register",
+                "name": name,
+                "subscriptions": subs,
+            });
+            let mut line = serde_json::to_string(&envelope)?;
+            line.push('\n');
+            let mut writer = self.writer.lock().await;
+            writer.write_all(line.as_bytes()).await?;
+            info!(agent = %name, "registered on bus");
+            Ok(())
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! deskd library — exposes modules for integration testing.
 
 pub mod domain;
+pub mod infra;
 pub mod ports;
 
 pub mod agent;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ pub mod context;
 mod domain;
 pub mod graph;
 mod inbox;
+#[allow(dead_code)]
+mod infra;
 mod mcp;
 mod message;
 #[allow(dead_code)]

--- a/src/ports/bus.rs
+++ b/src/ports/bus.rs
@@ -5,25 +5,29 @@
 //! network transports.
 
 use anyhow::Result;
+use std::future::Future;
+use std::pin::Pin;
 
 use crate::domain::message::Message;
 
-/// Abstraction over message transport.
+/// Abstraction over message transport (object-safe).
 ///
 /// Workers and adapters interact with the bus through this trait.
-/// The Unix socket implementation lives in `bus.rs`; tests can use
-/// an in-memory implementation.
+/// Implementations: `UnixBus` (production), `InMemoryBus` (testing).
 pub trait MessageBus: Send + Sync {
     /// Send a message to the bus for routing.
-    fn send(&self, msg: &Message) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn send<'a>(
+        &'a self,
+        msg: &'a Message,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 
     /// Receive the next message addressed to this client.
-    fn recv(&self) -> impl std::future::Future<Output = Result<Message>> + Send;
+    fn recv(&self) -> Pin<Box<dyn Future<Output = Result<Message>> + Send + '_>>;
 
     /// Register this client on the bus with the given subscriptions.
     fn register(
         &self,
         name: &str,
         subscriptions: &[String],
-    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
 }

--- a/tests/message_bus_trait.rs
+++ b/tests/message_bus_trait.rs
@@ -1,0 +1,127 @@
+//! Integration tests for the MessageBus trait implementations.
+//!
+//! Tests UnixBus against the real bus server and InMemoryBus standalone.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use deskd::domain::message::{Message, Metadata};
+use deskd::infra::unix_bus::UnixBus;
+use deskd::ports::bus::MessageBus;
+
+fn temp_socket() -> String {
+    format!("/tmp/deskd-test-mbtrait-{}.sock", uuid::Uuid::new_v4())
+}
+
+fn test_message(source: &str, target: &str, task: &str) -> Message {
+    Message {
+        id: uuid::Uuid::new_v4().to_string(),
+        source: source.to_string(),
+        target: target.to_string(),
+        payload: serde_json::json!({"task": task}),
+        reply_to: None,
+        metadata: Metadata::default(),
+    }
+}
+
+/// UnixBus: register + send + recv through the real bus server.
+#[tokio::test]
+async fn test_unix_bus_send_recv() {
+    let socket = temp_socket();
+
+    // Start bus server.
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Connect two clients via UnixBus trait.
+    let alice: Arc<dyn MessageBus> = Arc::new(UnixBus::connect(&socket).await.unwrap());
+    let bob: Arc<dyn MessageBus> = Arc::new(UnixBus::connect(&socket).await.unwrap());
+
+    alice
+        .register("alice", &["agent:alice".to_string()])
+        .await
+        .unwrap();
+    bob.register("bob", &["agent:bob".to_string()])
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Alice sends to bob via trait.
+    let msg = test_message("alice", "agent:bob", "hello via trait");
+    alice.send(&msg).await.unwrap();
+
+    // Bob receives via trait.
+    let received = tokio::time::timeout(Duration::from_secs(2), bob.recv())
+        .await
+        .expect("timeout waiting for message")
+        .expect("recv failed");
+
+    assert_eq!(received.source, "alice");
+    assert_eq!(received.target, "agent:bob");
+    assert_eq!(received.payload["task"], "hello via trait");
+
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// UnixBus: subscription-based routing through trait.
+#[tokio::test]
+async fn test_unix_bus_subscription_routing() {
+    let socket = temp_socket();
+
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let sender: Arc<dyn MessageBus> = Arc::new(UnixBus::connect(&socket).await.unwrap());
+    let subscriber: Arc<dyn MessageBus> = Arc::new(UnixBus::connect(&socket).await.unwrap());
+
+    sender.register("sender", &[]).await.unwrap();
+    subscriber
+        .register("subscriber", &["queue:work".to_string()])
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let msg = test_message("sender", "queue:work", "queued task");
+    sender.send(&msg).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(2), subscriber.recv())
+        .await
+        .expect("timeout")
+        .expect("recv failed");
+
+    assert_eq!(received.payload["task"], "queued task");
+
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// UnixBus used as Arc<dyn MessageBus> — proves object safety.
+#[tokio::test]
+async fn test_unix_bus_as_dyn_trait() {
+    let socket = temp_socket();
+
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // This function accepts the trait object — proves it's object-safe.
+    async fn use_bus(bus: &dyn MessageBus, name: &str) {
+        bus.register(name, &[format!("agent:{}", name)])
+            .await
+            .unwrap();
+    }
+
+    let bus = UnixBus::connect(&socket).await.unwrap();
+    use_bus(&bus, "trait-test").await;
+
+    let _ = std::fs::remove_file(&socket);
+}


### PR DESCRIPTION
## Summary
- **Object-safe MessageBus trait**: Changed return types to `Pin<Box<dyn Future>>` so the trait can be used as `Arc<dyn MessageBus>` for dependency injection
- **UnixBus**: Production client wrapping a Unix socket connection with exponential-backoff retry (extracted from worker.rs `bus_connect` pattern)
- **InMemoryBus**: Test-only implementation using tokio mpsc channels — supports `pair()` (bidirectional) and `loopback()` modes
- **infra/ layer**: New directory for concrete trait implementations (clean architecture)
- **3 integration tests**: Prove UnixBus works with real bus server for direct routing, subscription routing, and `dyn` trait dispatch

This is Phase 2 of the architecture roadmap: trait implementations building on the port definitions from PR #146. Consumer migration (worker, schedule, workflow accepting `Arc<dyn MessageBus>`) is the next step.

Closes #139 (partially — trait + impls + tests done; consumer injection is follow-up)

## Test plan
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` all pass
- [x] `test_unix_bus_send_recv` — register + send + recv through real bus
- [x] `test_unix_bus_subscription_routing` — queue subscription delivery
- [x] `test_unix_bus_as_dyn_trait` — proves `Arc<dyn MessageBus>` works (object safety)
- [x] InMemoryBus unit tests: pair send/recv, register, loopback

🤖 Generated with [Claude Code](https://claude.com/claude-code)