### PR TITLE
arch: fix config module — extract paths, move MCP description (#144)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,29 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// Where agent state files are stored (relative to $HOME).
-pub fn state_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    let dir = PathBuf::from(home).join(".deskd").join("agents");
-    std::fs::create_dir_all(&dir).ok();
-    dir
-}
-
-/// Where agent logs are stored (relative to $HOME).
-pub fn log_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    let dir = PathBuf::from(home).join(".deskd").join("logs");
-    std::fs::create_dir_all(&dir).ok();
-    dir
-}
-
-/// Where one-shot reminder JSON files are stored.
-pub fn reminders_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    let dir = PathBuf::from(home).join(".deskd").join("reminders");
-    std::fs::create_dir_all(&dir).ok();
-    dir
-}
+// Re-export path helpers for backward compatibility.
+pub use crate::paths::{agent_bus_socket, log_dir, reminders_dir, state_dir};
 
 /// A one-shot reminder that fires at a specific time and posts a message to the bus.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,16 +16,6 @@ pub struct RemindDef {
     pub target: String,
     /// Payload text to post.
     pub message: String,
-}
-
-/// Derive the bus socket path for an agent from its work directory.
-/// Convention: {work_dir}/.deskd/bus.sock
-pub fn agent_bus_socket(work_dir: &str) -> String {
-    PathBuf::from(work_dir)
-        .join(".deskd")
-        .join("bus.sock")
-        .to_string_lossy()
-        .into_owned()
 }
 
 fn default_max_turns() -> u32 {
@@ -376,7 +345,7 @@ pub struct TransitionDef {
     /// Task queue criteria for this transition (model, labels).
     /// When set, dispatch creates a task in the queue instead of direct bus message.
     #[serde(default)]
-    pub criteria: Option<crate::task::TaskCriteria>,
+    pub criteria: Option<crate::domain::task::TaskCriteria>,
 }
 
 impl UserConfig {
@@ -388,47 +357,6 @@ impl UserConfig {
         let cfg: UserConfig =
             serde_yaml::from_str(&expanded).context("failed to parse user config")?;
         Ok(cfg)
-    }
-
-    /// Build the MCP tool description for `send_message` based on available
-    /// channels, sub-agents, and telegram routes.
-    pub fn send_message_description(&self, agent_name: &str) -> String {
-        let mut lines = vec![
-            "Send a message to a target on the bus.".to_string(),
-            String::new(),
-            "Available targets:".to_string(),
-        ];
-
-        // Sub-agents
-        for a in &self.agents {
-            lines.push(format!(
-                "  agent:{}  — {} ({}). {}",
-                a.name,
-                a.name,
-                a.model,
-                a.system_prompt.lines().next().unwrap_or("")
-            ));
-        }
-
-        // Named channels
-        for ch in &self.channels {
-            lines.push(format!("  {}  — {}", ch.name, ch.description));
-        }
-
-        // Telegram outbound routes
-        if let Some(tg) = &self.telegram {
-            for route in &tg.routes {
-                lines.push(format!(
-                    "  telegram.out:{}  — Telegram chat {}",
-                    route.chat_id, route.chat_id
-                ));
-            }
-        }
-
-        lines.push(String::new());
-        lines.push(format!("You are agent '{}'.", agent_name));
-
-        lines.join("\n")
     }
 }
 
@@ -687,46 +615,6 @@ agents:
         let cfg: UserConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(cfg.agents[0].session, SessionMode::Ephemeral);
         assert_eq!(cfg.agents[1].session, SessionMode::Persistent); // default
-    }
-
-    #[test]
-    fn test_send_message_description() {
-        let cfg = UserConfig {
-            model: "claude-opus-4-6".into(),
-            system_prompt: String::new(),
-            max_turns: 100,
-            channels: vec![ChannelDef {
-                name: "news:ecosystem".into(),
-                description: "Ecosystem updates".into(),
-            }],
-            agents: vec![SubAgentDef {
-                name: "dev".into(),
-                model: "claude-sonnet-4-6".into(),
-                system_prompt: "Implements code changes.".into(),
-                subscribe: vec!["agent:dev".into()],
-                publish: None,
-                session: SessionMode::default(),
-                runtime: AgentRuntime::default(),
-            }],
-            telegram: Some(TelegramRoutesConfig {
-                routes: vec![TelegramRoute {
-                    chat_id: -1003733725513,
-                    mention_only: false,
-                    name: None,
-                    route_to: None,
-                }],
-            }),
-            discord: None,
-            schedules: vec![],
-            mcp_config: None,
-            models: vec![],
-            context: None,
-        };
-        let desc = cfg.send_message_description("kira");
-        assert!(desc.contains("agent:dev"));
-        assert!(desc.contains("news:ecosystem"));
-        assert!(desc.contains("telegram.out:-1003733725513"));
-        assert!(desc.contains("You are agent 'kira'"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 #[allow(dead_code)]
 mod context;
 pub mod message;
+pub mod paths;
 pub mod statemachine;
 pub mod task;
 pub mod tasklog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ pub mod graph;
 mod infra;
 mod mcp;
 mod message;
+mod paths;
 #[allow(dead_code)]
 mod ports;
 mod schedule;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -266,7 +266,7 @@ fn handle_tools_list(
     user_config: Option<&UserConfig>,
 ) -> Response {
     let send_message_desc = user_config
-        .map(|c| c.send_message_description(agent_name))
+        .map(|c| build_send_message_description(c, agent_name))
         .unwrap_or_else(|| "Send a message to a target on the bus.".to_string());
 
     // Build sm_create description dynamically listing available models.
@@ -1496,6 +1496,44 @@ fn glob_match(pattern: &str, value: &str) -> bool {
     }
 }
 
+/// Build the MCP tool description for `send_message` based on available
+/// channels, sub-agents, and telegram routes defined in the user config.
+fn build_send_message_description(cfg: &UserConfig, agent_name: &str) -> String {
+    let mut lines = vec![
+        "Send a message to a target on the bus.".to_string(),
+        String::new(),
+        "Available targets:".to_string(),
+    ];
+
+    for a in &cfg.agents {
+        lines.push(format!(
+            "  agent:{}  — {} ({}). {}",
+            a.name,
+            a.name,
+            a.model,
+            a.system_prompt.lines().next().unwrap_or("")
+        ));
+    }
+
+    for ch in &cfg.channels {
+        lines.push(format!("  {}  — {}", ch.name, ch.description));
+    }
+
+    if let Some(tg) = &cfg.telegram {
+        for route in &tg.routes {
+            lines.push(format!(
+                "  telegram.out:{}  — Telegram chat {}",
+                route.chat_id, route.chat_id
+            ));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push(format!("You are agent '{}'.", agent_name));
+
+    lines.join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1508,5 +1546,47 @@ mod tests {
         assert!(glob_match("agent:dev", "agent:dev"));
         assert!(!glob_match("agent:dev", "agent:researcher"));
         assert!(!glob_match("telegram.out:*", "telegram.in:-1234"));
+    }
+
+    #[test]
+    fn test_send_message_description() {
+        use crate::config::*;
+
+        let cfg = UserConfig {
+            model: "claude-opus-4-6".into(),
+            system_prompt: String::new(),
+            max_turns: 100,
+            channels: vec![ChannelDef {
+                name: "news:ecosystem".into(),
+                description: "Ecosystem updates".into(),
+            }],
+            agents: vec![SubAgentDef {
+                name: "dev".into(),
+                model: "claude-sonnet-4-6".into(),
+                system_prompt: "Implements code changes.".into(),
+                subscribe: vec!["agent:dev".into()],
+                publish: None,
+                session: SessionMode::default(),
+                runtime: AgentRuntime::default(),
+            }],
+            telegram: Some(TelegramRoutesConfig {
+                routes: vec![TelegramRoute {
+                    chat_id: -1003733725513,
+                    mention_only: false,
+                    name: None,
+                    route_to: None,
+                }],
+            }),
+            discord: None,
+            schedules: vec![],
+            mcp_config: None,
+            models: vec![],
+            context: None,
+        };
+        let desc = build_send_message_description(&cfg, "kira");
+        assert!(desc.contains("agent:dev"));
+        assert!(desc.contains("news:ecosystem"));
+        assert!(desc.contains("telegram.out:-1003733725513"));
+        assert!(desc.contains("You are agent 'kira'"));
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,39 @@
+//! Infrastructure path helpers — deskd filesystem layout.
+//!
+//! All paths are relative to `$HOME/.deskd/`.
+
+use std::path::PathBuf;
+
+/// Where agent state files are stored: `~/.deskd/agents/`.
+pub fn state_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let dir = PathBuf::from(home).join(".deskd").join("agents");
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+/// Where agent logs are stored: `~/.deskd/logs/`.
+pub fn log_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let dir = PathBuf::from(home).join(".deskd").join("logs");
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+/// Where one-shot reminder JSON files are stored: `~/.deskd/reminders/`.
+pub fn reminders_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let dir = PathBuf::from(home).join(".deskd").join("reminders");
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+/// Derive the bus socket path for an agent from its work directory.
+/// Convention: `{work_dir}/.deskd/bus.sock`
+pub fn agent_bus_socket(work_dir: &str) -> String {
+    PathBuf::from(work_dir)
+        .join(".deskd")
+        .join("bus.sock")
+        .to_string_lossy()
+        .into_owned()
+}


### PR DESCRIPTION
## Summary
- Extracted path helpers (`state_dir`, `log_dir`, `reminders_dir`, `agent_bus_socket`) to new `paths.rs` module
- Moved `send_message_description()` from `config::UserConfig` to `mcp.rs` as `build_send_message_description()` — MCP presentation logic now lives in MCP module
- Fixed `TaskCriteria` import: config → `crate::domain::task` (explicit layer dependency instead of `crate::task`)
- config.rs: 866 → 754 lines

Closes #144

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 352 tests pass
- [x] Path helpers in `paths.rs` module
- [x] `send_message_description()` in mcp module (with test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)