### PR TITLE
arch: fix ports::store layer violation — move ModelDef to domain

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -308,45 +308,9 @@ pub enum ScheduleAction {
     Shell,
 }
 
-/// A state machine model definition.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelDef {
-    pub name: String,
-    #[serde(default)]
-    pub description: String,
-    pub states: Vec<String>,
-    pub initial: String,
-    #[serde(default)]
-    pub terminal: Vec<String>,
-    pub transitions: Vec<TransitionDef>,
-}
-
-/// A transition between states in a model.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransitionDef {
-    pub from: String,
-    pub to: String,
-    #[serde(default)]
-    pub trigger: Option<String>,
-    #[serde(default)]
-    pub on: Option<String>,
-    #[serde(default)]
-    pub assignee: Option<String>,
-    #[serde(default)]
-    pub prompt: Option<String>,
-    #[serde(rename = "type", default)]
-    pub step_type: Option<String>,
-    #[serde(default)]
-    pub notify: Option<String>,
-    #[serde(default)]
-    pub timeout: Option<String>,
-    #[serde(default)]
-    pub timeout_goto: Option<String>,
-    /// Task queue criteria for this transition (model, labels).
-    /// When set, dispatch creates a task in the queue instead of direct bus message.
-    #[serde(default)]
-    pub criteria: Option<crate::domain::task::TaskCriteria>,
-}
+// ModelDef and TransitionDef live in domain::statemachine; re-exported for backward compat.
+#[allow(unused_imports)]
+pub use crate::domain::statemachine::{ModelDef, TransitionDef};
 
 impl UserConfig {
     /// Load and parse a deskd.yaml file, expanding ${ENV_VAR} references.

--- a/src/domain/statemachine.rs
+++ b/src/domain/statemachine.rs
@@ -4,6 +4,46 @@
 
 use serde::{Deserialize, Serialize};
 
+/// A state machine model definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelDef {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub states: Vec<String>,
+    pub initial: String,
+    #[serde(default)]
+    pub terminal: Vec<String>,
+    pub transitions: Vec<TransitionDef>,
+}
+
+/// A transition between states in a model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransitionDef {
+    pub from: String,
+    pub to: String,
+    #[serde(default)]
+    pub trigger: Option<String>,
+    #[serde(default)]
+    pub on: Option<String>,
+    #[serde(default)]
+    pub assignee: Option<String>,
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(rename = "type", default)]
+    pub step_type: Option<String>,
+    #[serde(default)]
+    pub notify: Option<String>,
+    #[serde(default)]
+    pub timeout: Option<String>,
+    #[serde(default)]
+    pub timeout_goto: Option<String>,
+    /// Task queue criteria for this transition (model, labels).
+    /// When set, dispatch creates a task in the queue instead of direct bus message.
+    #[serde(default)]
+    pub criteria: Option<crate::domain::task::TaskCriteria>,
+}
+
 /// An instance of a state machine model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Instance {

--- a/src/ports/store.rs
+++ b/src/ports/store.rs
@@ -5,8 +5,7 @@
 
 use anyhow::Result;
 
-use crate::config::ModelDef;
-use crate::domain::statemachine::Instance;
+use crate::domain::statemachine::{Instance, ModelDef};
 use crate::domain::task::{QueueSummary, Task, TaskCriteria, TaskStatus};
 
 /// Persistence operations for the task queue.

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -3,8 +3,6 @@ use chrono::Utc;
 use std::path::PathBuf;
 use tracing::info;
 
-use crate::config::{ModelDef, TransitionDef};
-
 // Re-export domain types for backward compatibility.
 pub use crate::domain::statemachine::*;
 


### PR DESCRIPTION
## Summary
- Move `ModelDef` and `TransitionDef` from `config.rs` to `domain::statemachine` (pure domain types)
- `ports::store` now imports only from `domain/`, zero config/infra imports
- Re-exports in `config.rs` preserve backward compatibility for all existing callers

Closes #170

## Test plan
- [x] `ports/store.rs` has zero imports from `config` or `infra`
- [x] All types used by store traits defined in `domain/`
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — 395 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)