### PR TITLE
arch: reduce main.rs fan-out from 29 to 5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,26 @@
-//! deskd library — exposes modules for integration testing.
+//! deskd library — all modules exposed for the binary and integration tests.
 
 pub mod domain;
 pub mod infra;
 pub mod ports;
 
+pub mod acp;
+pub mod adapters;
 pub mod agent;
 pub mod bus;
+pub mod cli;
+pub mod commands;
 pub mod config;
-#[allow(dead_code)]
-mod context;
+pub mod context;
+pub mod graph;
+pub mod mcp;
 pub mod message;
 pub mod paths;
+pub mod schedule;
+pub mod serve;
 pub mod statemachine;
 pub mod task;
 pub mod tasklog;
+pub mod unified_inbox;
+pub mod worker;
+pub mod workflow;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,7 @@
-mod acp;
-mod adapters;
-mod agent;
-mod bus;
-mod cli;
-mod commands;
-mod config;
-pub mod context;
-mod domain;
-pub mod graph;
-#[allow(dead_code)]
-mod infra;
-mod mcp;
-mod message;
-mod paths;
-#[allow(dead_code)]
-mod ports;
-mod schedule;
-mod serve;
-mod statemachine;
-mod task;
-mod tasklog;
-mod unified_inbox;
-mod worker;
-mod workflow;
-
 use clap::Parser;
 
-use cli::{Cli, Commands};
+use deskd::cli::{Cli, Commands};
+use deskd::{commands, config, mcp, serve};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -98,8 +73,8 @@ async fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::{parse_duration_secs, remind};
-    use crate::config;
+    use deskd::commands::{parse_duration_secs, remind};
+    use deskd::config;
 
     #[test]
     fn test_handle_remind_writes_file() {
@@ -178,8 +153,8 @@ schedules:
         assert_eq!(user_cfg.schedules[0].target, "agent:dev");
         assert_eq!(user_cfg.schedules[1].cron, "0 0 9 * * *");
 
-        use crate::cli::ScheduleSubcommand;
-        crate::commands::schedule::handle(ScheduleSubcommand::List, cfg_path.to_str().unwrap())
+        use deskd::cli::ScheduleSubcommand;
+        deskd::commands::schedule::handle(ScheduleSubcommand::List, cfg_path.to_str().unwrap())
             .unwrap();
 
         let _ = std::fs::remove_dir_all(&tmp);
@@ -200,9 +175,9 @@ schedules:
 
         let path_str = cfg_path.to_str().unwrap();
 
-        use crate::cli::ScheduleSubcommand;
+        use deskd::cli::ScheduleSubcommand;
 
-        crate::commands::schedule::handle(
+        deskd::commands::schedule::handle(
             ScheduleSubcommand::Add {
                 cron: "0 0 9 * * *".to_string(),
                 action: "raw".to_string(),
@@ -218,7 +193,7 @@ schedules:
         assert_eq!(cfg.schedules[0].cron, "0 0 9 * * *");
         assert_eq!(cfg.schedules[0].target, "agent:dev");
 
-        crate::commands::schedule::handle(
+        deskd::commands::schedule::handle(
             ScheduleSubcommand::Add {
                 cron: "0 */5 * * * *".to_string(),
                 action: "github_poll".to_string(),
@@ -232,14 +207,14 @@ schedules:
         let cfg = config::UserConfig::load(path_str).unwrap();
         assert_eq!(cfg.schedules.len(), 2);
 
-        crate::commands::schedule::handle(ScheduleSubcommand::Rm { index: 0 }, path_str).unwrap();
+        deskd::commands::schedule::handle(ScheduleSubcommand::Rm { index: 0 }, path_str).unwrap();
 
         let cfg = config::UserConfig::load(path_str).unwrap();
         assert_eq!(cfg.schedules.len(), 1);
         assert_eq!(cfg.schedules[0].cron, "0 */5 * * * *");
 
         assert!(
-            crate::commands::schedule::handle(ScheduleSubcommand::Rm { index: 5 }, path_str)
+            deskd::commands::schedule::handle(ScheduleSubcommand::Rm { index: 5 }, path_str)
                 .is_err()
         );
 


### PR DESCRIPTION
## Summary
- Move all `mod` declarations from `main.rs` to `lib.rs`
- `main.rs` now only imports 5 modules it directly uses: `cli`, `commands`, `config`, `mcp`, `serve`
- Fan-out reduced from 29 → 5 (target was ≤10)
- No functional changes — same runtime behavior

Closes #171

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all 282 tests pass
- [x] main.rs fan-out ≤ 10 (actual: 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)