### PR TITLE
arch: split config module — reduce fan-in from 17 to 12

### DIFF
--- a/src/app/acp.rs
+++ b/src/app/acp.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
 
 use crate::app::agent::{self, AgentConfig, TaskLimits, TokenUsage, TurnResult, build_command};
-use crate::config::SessionMode;
+use crate::domain::agent::SessionMode;
 
 // ─── JSON-RPC 2.0 types ─────────────────────────────────────────────────────
 

--- a/src/app/agent.rs
+++ b/src/app/agent.rs
@@ -7,7 +7,8 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
-use crate::config::{self, AgentRuntime, ContainerConfig, SessionMode, UserConfig};
+use crate::config::{self, ContainerConfig, UserConfig};
+use crate::domain::agent::{AgentRuntime, SessionMode};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentConfig {

--- a/src/app/statemachine.rs
+++ b/src/app/statemachine.rs
@@ -220,7 +220,7 @@ impl crate::ports::store::StateMachineRepository for StateMachineStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ModelDef, TransitionDef};
+    use crate::domain::statemachine::{ModelDef, TransitionDef};
 
     fn temp_store() -> StateMachineStore {
         let dir = std::env::temp_dir().join(format!("deskd-test-{}", uuid::Uuid::new_v4()));

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -10,7 +10,7 @@ use crate::app::agent::{self, TokenUsage};
 use crate::app::message::Message;
 use crate::app::tasklog;
 use crate::app::unified_inbox;
-use crate::config::{AgentRuntime, SessionMode};
+use crate::domain::agent::{AgentRuntime, SessionMode};
 
 /// Wrapper for either a Claude or ACP agent process.
 enum RuntimeProcess {

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::app::message::Message;
 use crate::app::statemachine;
-use crate::config::ModelDef;
+use crate::domain::statemachine::ModelDef;
 
 type Writer = std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>;
 
@@ -315,7 +315,7 @@ async fn dispatch_pending(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::TransitionDef;
+    use crate::domain::statemachine::TransitionDef;
 
     fn test_model() -> ModelDef {
         ModelDef {

--- a/src/config.rs
+++ b/src/config.rs
@@ -212,27 +212,9 @@ pub struct ChannelDef {
     pub description: String,
 }
 
-/// Session mode for an agent: persistent (default) or ephemeral.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum SessionMode {
-    /// Continue existing session across tasks (uses --resume).
-    #[default]
-    Persistent,
-    /// Start a fresh session for each task (no --resume).
-    Ephemeral,
-}
-
-/// Agent runtime protocol: claude (default) or acp.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum AgentRuntime {
-    /// Claude stream-json protocol (default).
-    #[default]
-    Claude,
-    /// Agent Client Protocol (ACP) — JSON-RPC 2.0 over stdin/stdout.
-    Acp,
-}
+// SessionMode and AgentRuntime live in domain::agent; re-exported for backward compat.
+#[allow(unused_imports)]
+pub use crate::domain::agent::{AgentRuntime, SessionMode};
 
 /// A sub-agent running within a parent agent's bus scope.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -1,0 +1,25 @@
+//! Agent domain types — pure enums and structs, no I/O.
+
+use serde::{Deserialize, Serialize};
+
+/// Session mode for an agent: persistent (default) or ephemeral.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionMode {
+    /// Continue existing session across tasks (uses --resume).
+    #[default]
+    Persistent,
+    /// Start a fresh session for each task (no --resume).
+    Ephemeral,
+}
+
+/// Agent runtime protocol: claude (default) or acp.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentRuntime {
+    /// Claude stream-json protocol (default).
+    #[default]
+    Claude,
+    /// Agent Client Protocol (ACP) — JSON-RPC 2.0 over stdin/stdout.
+    Acp,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -3,6 +3,7 @@
 //! This module depends only on `std` and `serde`. It must never import from
 //! `infra`, `app`, `adapters`, or any other outer layer.
 
+pub mod agent;
 pub mod message;
 pub mod statemachine;
 pub mod task;

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -6,8 +6,7 @@ use anyhow::{Result, bail};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use crate::config::ModelDef;
-use crate::domain::statemachine::{Instance, Transition};
+use crate::domain::statemachine::{Instance, ModelDef, Transition};
 use crate::domain::task::{QueueSummary, Task, TaskCriteria, TaskStatus, matches_criteria};
 use crate::ports::store::{StateMachineRepository, TaskRepository};
 
@@ -338,7 +337,7 @@ impl StateMachineRepository for InMemoryStateMachineStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ModelDef, TransitionDef};
+    use crate::domain::statemachine::{ModelDef, TransitionDef};
     use crate::domain::task::TaskCriteria;
 
     #[test]


### PR DESCRIPTION
## Summary
- Move `ModelDef`/`TransitionDef` imports to `domain::statemachine` (3 files still imported from config)
- Extract `SessionMode`/`AgentRuntime` to new `domain::agent` module
- Re-exports in `config.rs` preserve backward compatibility
- Config fan-in reduced from 17 → 12 (target was ≤15)

Closes #172

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all 286 tests pass
- [x] Config fan-in ≤ 15 (actual: 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)