### PR TITLE
arch: decouple context module — move types to domain layer

### DIFF
--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -1,66 +1,12 @@
-use serde::{Deserialize, Serialize};
+//! Context application layer — I/O operations on context types.
+//!
+//! Pure domain types live in `domain::context`. This module adds
+//! persistence (load/save) and materialization (execute live nodes).
 
-/// Node kinds in the context graph
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind")]
-pub enum NodeKind {
-    /// Injected as-is into the session
-    Static {
-        role: String, // "system", "user", "assistant"
-        content: String,
-    },
-    /// Executed at fork time, result injected
-    Live {
-        command: String, // shell command to execute
-        #[serde(default)]
-        args: Vec<String>,
-        max_age_secs: Option<u64>, // cache result for N seconds
-        inject_as: String,         // role to inject result as
-        #[serde(skip)]
-        cached_result: Option<CachedResult>,
-    },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CachedResult {
-    pub content: String,
-    pub fetched_at: String, // RFC3339
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Node {
-    pub id: String,
-    pub kind: NodeKind,
-    pub label: String,        // human-readable description
-    pub tokens_estimate: u32, // approximate token count
-}
-
-/// The main branch — persistent context for an agent
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MainBranch {
-    pub agent: String,
-    pub budget_tokens: u32, // target size for main
-    pub nodes: Vec<Node>,   // ordered: stable first, dynamic last
-}
-
-/// Configuration for context system
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ContextConfig {
-    pub enabled: bool,
-    pub main_budget_tokens: Option<u32>,       // default 10000
-    pub compact_threshold_tokens: Option<u32>, // trigger compaction at this session size, default 80000
-    pub main_path: Option<String>,             // path to main branch file
-}
+// Re-export all domain types for backward compatibility.
+pub use crate::domain::context::*;
 
 impl MainBranch {
-    pub fn new(agent: &str, budget: u32) -> Self {
-        Self {
-            agent: agent.to_string(),
-            budget_tokens: budget,
-            nodes: Vec::new(),
-        }
-    }
-
     /// Load from YAML file
     pub fn load(path: &std::path::Path) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(path)?;
@@ -75,11 +21,6 @@ impl MainBranch {
         let content = serde_yaml::to_string(self)?;
         std::fs::write(path, content)?;
         Ok(())
-    }
-
-    /// Total estimated tokens across all nodes
-    pub fn total_tokens(&self) -> u32 {
-        self.nodes.iter().map(|n| n.tokens_estimate).sum()
     }
 
     /// Materialize: execute live nodes and produce message list for session injection
@@ -142,25 +83,6 @@ impl MainBranch {
         }
         Ok(messages)
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MaterializedMessage {
-    pub role: String,
-    pub content: String,
-}
-
-/// Check if session should be compacted based on cumulative token usage
-pub fn should_compact(total_tokens_used: u64, threshold: u64) -> bool {
-    total_tokens_used >= threshold
-}
-
-/// Default path for the main branch file relative to an agent's work_dir.
-pub fn default_main_path(work_dir: &str) -> std::path::PathBuf {
-    std::path::PathBuf::from(work_dir)
-        .join(".deskd")
-        .join("context")
-        .join("main.yaml")
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::app::context::ContextConfig;
+use crate::domain::context::ContextConfig;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/domain/context.rs
+++ b/src/domain/context.rs
@@ -1,0 +1,89 @@
+//! Context domain types — pure data, no I/O.
+
+use serde::{Deserialize, Serialize};
+
+/// Node kinds in the context graph
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum NodeKind {
+    /// Injected as-is into the session
+    Static {
+        role: String, // "system", "user", "assistant"
+        content: String,
+    },
+    /// Executed at fork time, result injected
+    Live {
+        command: String, // shell command to execute
+        #[serde(default)]
+        args: Vec<String>,
+        max_age_secs: Option<u64>, // cache result for N seconds
+        inject_as: String,         // role to inject result as
+        #[serde(skip)]
+        cached_result: Option<CachedResult>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedResult {
+    pub content: String,
+    pub fetched_at: String, // RFC3339
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    pub id: String,
+    pub kind: NodeKind,
+    pub label: String,        // human-readable description
+    pub tokens_estimate: u32, // approximate token count
+}
+
+/// The main branch — persistent context for an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MainBranch {
+    pub agent: String,
+    pub budget_tokens: u32, // target size for main
+    pub nodes: Vec<Node>,   // ordered: stable first, dynamic last
+}
+
+/// Configuration for context system
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ContextConfig {
+    pub enabled: bool,
+    pub main_budget_tokens: Option<u32>,       // default 10000
+    pub compact_threshold_tokens: Option<u32>, // trigger compaction at this session size, default 80000
+    pub main_path: Option<String>,             // path to main branch file
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaterializedMessage {
+    pub role: String,
+    pub content: String,
+}
+
+impl MainBranch {
+    pub fn new(agent: &str, budget: u32) -> Self {
+        Self {
+            agent: agent.to_string(),
+            budget_tokens: budget,
+            nodes: Vec::new(),
+        }
+    }
+
+    /// Total estimated tokens across all nodes
+    pub fn total_tokens(&self) -> u32 {
+        self.nodes.iter().map(|n| n.tokens_estimate).sum()
+    }
+}
+
+/// Check if session should be compacted based on cumulative token usage
+pub fn should_compact(total_tokens_used: u64, threshold: u64) -> bool {
+    total_tokens_used >= threshold
+}
+
+/// Default path for the main branch file relative to an agent's work_dir.
+pub fn default_main_path(work_dir: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(work_dir)
+        .join(".deskd")
+        .join("context")
+        .join("main.yaml")
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -4,6 +4,7 @@
 //! `infra`, `app`, `adapters`, or any other outer layer.
 
 pub mod agent;
+pub mod context;
 pub mod message;
 pub mod statemachine;
 pub mod task;


### PR DESCRIPTION
## Summary
- Split `context.rs` into domain and app layers
- `domain/context.rs`: pure types (`NodeKind`, `Node`, `MainBranch`, `ContextConfig`, `MaterializedMessage`), pure functions (`should_compact`, `default_main_path`) — zero infra imports
- `app/context.rs`: I/O operations (`load`, `save`, `materialize`) + re-exports domain types
- Config now imports `ContextConfig` from `domain::context` instead of `app::context`

Closes #178

## Test plan
- [x] `domain/context.rs` has zero `crate::` imports
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all 286 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)