### PR TITLE
fix: include result text in SM completion message (#197)

### DIFF
--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -845,7 +845,7 @@ async fn handle_task_success(
             }
             format!("{}...", &response[..end])
         } else {
-            response
+            response.clone()
         };
         if let Err(e) = store.complete(tq_id, &result_text) {
             warn!(agent = %name, task_id = %tq_id, error = %e, "failed to mark queue task done");
@@ -856,7 +856,7 @@ async fn handle_task_success(
         writer,
         name,
         &ctx.reply_target,
-        serde_json::json!({"final": true, "in_reply_to": msg.id}),
+        serde_json::json!({"result": response, "final": true, "in_reply_to": msg.id}),
     )
     .await;
 }


### PR DESCRIPTION
## Summary
- Worker's completion message to `sm:{id}` now includes `"result": response` in the payload
- Previously the payload only had `{"final": true, "in_reply_to": msg_id}` — the agent's response text was missing
- `handle_completion()` already reads `payload.result`, so this one-line fix completes the data flow

Fixes #197

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` — all pass
- [ ] Manual: create SM instance with assignee → agent processes → `deskd sm status <id>` shows result text

🤖 Generated with [Claude Code](https://claude.com/claude-code)