### PR TITLE
feat: agent stderr logs and status CLI (#199, #200)

### DIFF
--- a/src/app/agent.rs
+++ b/src/app/agent.rs
@@ -79,6 +79,11 @@ fn log_path(name: &str) -> PathBuf {
     config::log_dir().join(format!("{}.log", name))
 }
 
+/// Path to the agent's stderr log file.
+pub fn stderr_log_path(name: &str) -> PathBuf {
+    config::log_dir().join(format!("{}.stderr.log", name))
+}
+
 pub fn load_state(name: &str) -> Result<AgentState> {
     let path = state_path(name);
     let content =
@@ -760,6 +765,12 @@ pub async fn remove(name: &str) -> Result<()> {
     {
         warn!(agent = %name, error = %e, "failed to remove log file");
     }
+    let stderr_log = stderr_log_path(name);
+    if stderr_log.exists()
+        && let Err(e) = std::fs::remove_file(&stderr_log)
+    {
+        warn!(agent = %name, error = %e, "failed to remove stderr log file");
+    }
     info!(agent = %name, "agent removed");
     Ok(())
 }
@@ -1065,22 +1076,39 @@ impl AgentProcess {
         let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
         let stderr_buf_writer = stderr_buf.clone();
 
-        // Drain stderr in background into shared buffer.
+        // Drain stderr in background: persist to file + keep in-memory buffer for exit diagnostics.
         let agent_name = name.to_string();
         tokio::spawn(async move {
-            let mut buf = String::new();
+            use tokio::io::AsyncBufReadExt;
+
             let mut reader = tokio::io::BufReader::new(stderr);
-            let _ = reader.read_to_string(&mut buf).await;
-            if !buf.is_empty() {
-                warn!(agent = %agent_name, stderr = %buf.trim(), "persistent process stderr");
+            let log_file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(stderr_log_path(&agent_name));
+            let mut file_writer = log_file.ok().map(std::io::BufWriter::new);
+
+            let mut line = String::new();
+            while let Ok(n) = reader.read_line(&mut line).await {
+                if n == 0 {
+                    break;
+                }
+                // Persist to file with timestamp.
+                if let Some(ref mut f) = file_writer {
+                    use std::io::Write;
+                    let ts = chrono::Utc::now().format("%H:%M:%S");
+                    let _ = write!(f, "[{}] {}", ts, line);
+                    let _ = f.flush();
+                }
+                // Keep in-memory buffer (capped) for exit diagnostics.
                 if let Ok(mut shared) = stderr_buf_writer.lock() {
-                    if buf.len() > STDERR_CAP {
-                        // Keep the tail (most relevant for crash diagnostics).
-                        *shared = buf[buf.len() - STDERR_CAP..].to_string();
-                    } else {
-                        *shared = buf;
+                    shared.push_str(&line);
+                    if shared.len() > STDERR_CAP {
+                        let excess = shared.len() - STDERR_CAP;
+                        shared.drain(..excess);
                     }
                 }
+                line.clear();
             }
         });
 

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -213,6 +213,22 @@ pub enum AgentAction {
         #[arg(long, default_value = "false")]
         by_pr: bool,
     },
+    /// Show agent status: all agents (no name) or detail for one agent.
+    Status {
+        /// Agent name. Omit to show all agents.
+        name: Option<String>,
+    },
+    /// Show stderr output from the agent's process.
+    Stderr {
+        /// Agent name.
+        name: String,
+        /// Show last N lines (default 50).
+        #[arg(long, default_value = "50")]
+        tail: usize,
+        /// Keep watching for new output.
+        #[arg(long, default_value = "false")]
+        follow: bool,
+    },
     /// Remove an agent (state file + log).
     Rm { name: String },
     /// Spawn an ephemeral sub-agent, run a task, print result, clean up.

--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -304,6 +304,111 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 tasklog::print_table(&entries);
             }
         }
+        AgentAction::Status { name } => match name {
+            Some(name) => {
+                let s = agent::load_state(&name)?;
+                let pid_alive =
+                    s.pid > 0 && std::path::Path::new(&format!("/proc/{}", s.pid)).exists();
+                let status_str = if pid_alive { &s.status } else { "offline" };
+                println!("Agent:       {}", s.config.name);
+                println!("Status:      {}", status_str);
+                println!(
+                    "PID:         {}",
+                    if pid_alive {
+                        s.pid.to_string()
+                    } else {
+                        "-".into()
+                    }
+                );
+                println!("Model:       {}", s.config.model);
+                println!("Turns:       {}", s.total_turns);
+                println!("Cost:        ${:.4}", s.total_cost);
+                println!("Budget:      ${:.2}", s.config.budget_usd);
+                println!("Created:     {}", s.created_at);
+                println!("Work dir:    {}", s.config.work_dir);
+                if !s.current_task.is_empty() {
+                    println!("Current:     {}", truncate(&s.current_task, 60));
+                }
+                if let Some(ref parent) = s.parent {
+                    println!("Parent:      {}", parent);
+                }
+                // Show stderr tail if available.
+                let stderr_path = agent::stderr_log_path(&name);
+                if stderr_path.exists() {
+                    let content = std::fs::read_to_string(&stderr_path).unwrap_or_default();
+                    let lines: Vec<&str> = content.lines().collect();
+                    if !lines.is_empty() {
+                        let start = lines.len().saturating_sub(5);
+                        println!("Stderr (last {}):", lines.len().min(5));
+                        for line in &lines[start..] {
+                            println!("  {}", line);
+                        }
+                    }
+                }
+            }
+            None => {
+                let agents = agent::list().await?;
+                if agents.is_empty() {
+                    println!("No agents registered");
+                } else {
+                    println!(
+                        "{:<15} {:<9} {:<6} {:<10} {:<20} MODEL",
+                        "NAME", "STATUS", "TURNS", "COST", "CREATED"
+                    );
+                    println!("{}", "─".repeat(75));
+                    for a in &agents {
+                        let pid_alive =
+                            a.pid > 0 && std::path::Path::new(&format!("/proc/{}", a.pid)).exists();
+                        let status = if pid_alive { &a.status } else { "offline" };
+                        let created = if a.created_at.len() > 19 {
+                            &a.created_at[..19]
+                        } else {
+                            &a.created_at
+                        };
+                        println!(
+                            "{:<15} {:<9} {:<6} ${:<9.4} {:<20} {}",
+                            a.config.name,
+                            status,
+                            a.total_turns,
+                            a.total_cost,
+                            created,
+                            a.config.model,
+                        );
+                    }
+                }
+            }
+        },
+        AgentAction::Stderr { name, tail, follow } => {
+            let path = agent::stderr_log_path(&name);
+            if !path.exists() {
+                println!("No stderr logs for {}", name);
+                return Ok(());
+            }
+            let content = std::fs::read_to_string(&path)?;
+            let lines: Vec<&str> = content.lines().collect();
+            let start = lines.len().saturating_sub(tail);
+            for line in &lines[start..] {
+                println!("{}", line);
+            }
+            if follow {
+                let mut pos = std::fs::metadata(&path)?.len();
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    if let Ok(meta) = std::fs::metadata(&path) {
+                        let new_len = meta.len();
+                        if new_len > pos {
+                            let mut f = std::fs::File::open(&path)?;
+                            use std::io::{Read, Seek, SeekFrom};
+                            f.seek(SeekFrom::Start(pos))?;
+                            let mut buf = String::new();
+                            f.read_to_string(&mut buf)?;
+                            print!("{}", buf);
+                            pos = new_len;
+                        }
+                    }
+                }
+            }
+        }
         AgentAction::Rm { name } => {
             agent::remove(&name).await?;
             println!("Agent {} removed", name);


### PR DESCRIPTION
## Summary
- **Stderr persistence (#199)**: Sub-agent stderr now written to `~/.deskd/logs/{name}.stderr.log` with timestamps. Previously stderr was only in a 2KB in-memory buffer lost on exit.
- **`deskd agent stderr <name>`**: View stderr with `--tail N` and `--follow` options
- **`deskd agent status`** (#200): List all agents with live/offline status (PID check via /proc)
- **`deskd agent status <name>`**: Detailed view — PID, model, turns, cost, budget, work dir, parent, stderr tail

Fixes #199, Fixes #200

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` — all pass
- [ ] Manual: start agent, check `deskd agent status`, view `deskd agent stderr <name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)