### PR TITLE
fix: sm move triggers workflow engine dispatch (#204)

### DIFF
--- a/src/app/commands/sm.rs
+++ b/src/app/commands/sm.rs
@@ -1,14 +1,19 @@
 //! `deskd sm` subcommand handlers.
 
 use anyhow::Result;
+use tracing::warn;
 
 use crate::app::cli::SmAction;
-use crate::app::statemachine;
+use crate::app::{statemachine, workflow};
 use crate::config;
 
 use super::truncate;
 
-pub fn handle(action: SmAction, user_cfg: &config::UserConfig) -> Result<()> {
+pub async fn handle(
+    action: SmAction,
+    user_cfg: &config::UserConfig,
+    config_path: &str,
+) -> Result<()> {
     let store = statemachine::StateMachineStore::default_for_home();
     let models: Vec<statemachine::ModelDef> =
         user_cfg.models.iter().cloned().map(Into::into).collect();
@@ -86,6 +91,21 @@ pub fn handle(action: SmAction, user_cfg: &config::UserConfig) -> Result<()> {
                 std::env::var("DESKD_AGENT_NAME").unwrap_or_else(|_| "manual".to_string());
             store.move_to(&mut inst, m, &state, &trigger, note.as_deref())?;
             println!("{} -> {} ({})", id, inst.state, inst.model);
+
+            // Notify workflow engine if the new state has an assignee.
+            if !inst.assignee.is_empty() && !statemachine::is_terminal(m, &inst) {
+                let bus_socket = std::env::var("DESKD_BUS_SOCKET").unwrap_or_else(|_| {
+                    let work_dir = std::path::Path::new(config_path)
+                        .parent()
+                        .unwrap_or(std::path::Path::new("."));
+                    config::agent_bus_socket(&work_dir.to_string_lossy())
+                });
+                if std::path::Path::new(&bus_socket).exists()
+                    && let Err(e) = workflow::notify_moved(&bus_socket, &id, "cli").await
+                {
+                    warn!(instance = %id, error = %e, "failed to notify workflow engine");
+                }
+            }
         }
         SmAction::Status { id } => {
             let inst = store.load(&id)?;

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -1385,41 +1385,12 @@ async fn call_sm_move(
     store.move_to(&mut inst, &model, state, agent_name, note)?;
     info!(agent = %agent_name, instance = %id, from = %from, to = %state, "sm_move via MCP");
 
-    // If the new state has an assignee, dispatch via bus.
-    if !inst.assignee.is_empty() && !statemachine::is_terminal(&model, &inst) {
-        let task_text = format!(
-            "---\n## Task: {}\n\n{}\n\n---\n## Metadata\ninstance_id: {}\nmodel: {}\nstate: {}",
-            inst.title, inst.body, inst.id, inst.model, inst.state
-        );
-
-        let mut stream = UnixStream::connect(bus_socket)
-            .await
-            .with_context(|| format!("failed to connect to bus at {}", bus_socket))?;
-
-        let reg = serde_json::json!({
-            "type": "register",
-            "name": format!("{}-mcp-sm", agent_name),
-            "subscriptions": []
-        });
-        let mut line = serde_json::to_string(&reg)?;
-        line.push('\n');
-        stream.write_all(line.as_bytes()).await?;
-
-        let msg = serde_json::json!({
-            "type": "message",
-            "id": Uuid::new_v4().to_string(),
-            "source": "workflow-engine",
-            "target": &inst.assignee,
-            "payload": {
-                "task": task_text,
-                "sm_instance_id": inst.id,
-            },
-            "reply_to": format!("sm:{}", inst.id),
-            "metadata": {"priority": 5u8},
-        });
-        let mut msg_line = serde_json::to_string(&msg)?;
-        msg_line.push('\n');
-        stream.write_all(msg_line.as_bytes()).await?;
+    // Notify workflow engine to dispatch if the new state has an assignee.
+    if !inst.assignee.is_empty()
+        && !statemachine::is_terminal(&model, &inst)
+        && let Err(e) = crate::app::workflow::notify_moved(bus_socket, id, agent_name).await
+    {
+        warn!(agent = %agent_name, instance = %id, error = %e, "failed to notify workflow engine after sm_move");
     }
 
     Ok(json!({

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -10,6 +10,37 @@ use crate::domain::statemachine::ModelDef;
 
 type Writer = std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>;
 
+/// Notify the workflow engine that an SM instance was moved.
+///
+/// Connects to the bus, sends an `action: "moved"` message to `sm:<id>`,
+/// and disconnects. The workflow engine picks this up and dispatches if needed.
+pub async fn notify_moved(bus_socket: &str, instance_id: &str, source: &str) -> Result<()> {
+    let mut stream = UnixStream::connect(bus_socket).await?;
+
+    let reg = serde_json::json!({
+        "type": "register",
+        "name": format!("{}-sm-notify", source),
+        "subscriptions": []
+    });
+    let mut line = serde_json::to_string(&reg)?;
+    line.push('\n');
+    stream.write_all(line.as_bytes()).await?;
+
+    let msg = serde_json::json!({
+        "type": "message",
+        "id": Uuid::new_v4().to_string(),
+        "source": source,
+        "target": format!("sm:{}", instance_id),
+        "payload": {"action": "moved"},
+        "metadata": {"priority": 5u8},
+    });
+    let mut msg_line = serde_json::to_string(&msg)?;
+    msg_line.push('\n');
+    stream.write_all(msg_line.as_bytes()).await?;
+
+    Ok(())
+}
+
 /// Run the workflow engine on the given bus.
 /// Registers as `workflow-engine`, subscribes to `sm:*`.
 /// On startup, dispatches pending instances. Then listens for completion messages.
@@ -45,6 +76,15 @@ pub async fn run(socket_path: &str, models: Vec<ModelDef>) -> Result<()> {
             Some(id) => id.to_string(),
             None => continue,
         };
+
+        // Check if this is a move notification (from CLI/MCP sm_move).
+        if msg.payload.get("action").and_then(|a| a.as_str()) == Some("moved") {
+            info!(instance = %instance_id, "received move notification");
+            if let Err(e) = handle_move_notification(&writer, &models, &store, &instance_id).await {
+                warn!(instance = %instance_id, error = %e, "failed to handle move notification");
+            }
+            continue;
+        }
 
         // Extract result from payload.
         let result = msg
@@ -122,6 +162,32 @@ async fn handle_completion(
         }
     } else {
         info!(instance = %instance_id, state = %inst.state, "no matching transition, awaiting manual move");
+    }
+
+    Ok(())
+}
+
+/// Handle a move notification: reload instance and dispatch if it has an assignee.
+async fn handle_move_notification(
+    writer: &Writer,
+    models: &[ModelDef],
+    store: &statemachine::StateMachineStore,
+    instance_id: &str,
+) -> Result<()> {
+    let inst = store.load(instance_id)?;
+    let model = models
+        .iter()
+        .find(|m| m.name == inst.model)
+        .ok_or_else(|| anyhow::anyhow!("model '{}' not found", inst.model))?;
+
+    if statemachine::is_terminal(model, &inst) {
+        info!(instance = %instance_id, state = %inst.state, "moved to terminal state, no dispatch");
+        return Ok(());
+    }
+
+    if !inst.assignee.is_empty() {
+        dispatch_instance(writer, model, &inst).await?;
+        info!(instance = %instance_id, assignee = %inst.assignee, "dispatched after move");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
             action,
         } => {
             let user_cfg = config::UserConfig::load(&config_path)?;
-            commands::sm::handle(action, &user_cfg)?;
+            commands::sm::handle(action, &user_cfg, &config_path).await?;
         }
         Commands::Task { action } => {
             commands::task::handle(action)?;

--- a/tests/workflow_transitions.rs
+++ b/tests/workflow_transitions.rs
@@ -415,9 +415,6 @@ async fn test_workflow_engine_retries_bus_connection() {
     let sock_for_engine = socket.clone();
     let models: Vec<deskd::config::ModelDef> = vec![model.clone()];
     let engine_handle = tokio::spawn(async move {
-        // Override HOME so StateMachineStore::default_for_home() won't find our temp store.
-        // Instead, we rely on the workflow::run function using default_for_home internally,
-        // so we need to test via bus_connect directly.
         deskd::app::worker::bus_connect(
             &sock_for_engine,
             "workflow-engine",
@@ -470,6 +467,56 @@ async fn test_workflow_engine_retries_bus_connection() {
         received.is_some(),
         "reviewer should receive message sent through retried connection"
     );
+
+    let _ = std::fs::remove_file(&socket);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// sm_move → workflow engine receives "moved" notification → dispatches to assignee.
+#[tokio::test]
+async fn test_sm_move_notifies_workflow_engine() {
+    let socket = temp_socket();
+    let tmp = temp_dir();
+
+    // Create SM instance and move to review (has assignee: agent:reviewer).
+    let store = deskd::app::statemachine::StateMachineStore::new(tmp.clone());
+    let model = test_model();
+    let mut inst = store
+        .create(&model, "Move test", "Testing move dispatch", "cli")
+        .unwrap();
+    store
+        .move_to(&mut inst, &model, "review", "manual", None)
+        .unwrap();
+    assert_eq!(inst.state, "review");
+    assert_eq!(inst.assignee, "agent:reviewer");
+
+    // Start bus.
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::app::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Connect workflow engine (subscribes to sm:*).
+    let (mut engine_rx, mut engine_tx) =
+        connect_and_register(&socket, "workflow-engine", &["sm:*"]).await;
+
+    // Connect reviewer to receive dispatched tasks.
+    let (mut reviewer_rx, _reviewer_tx) =
+        connect_and_register(&socket, "reviewer", &["agent:reviewer"]).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Simulate what sm_move does: send "moved" notification via bus.
+    deskd::app::workflow::notify_moved(&socket, &inst.id, "cli")
+        .await
+        .unwrap();
+
+    // Workflow engine should receive the notification.
+    let received = read_one(&mut engine_rx, 2000).await;
+    assert!(received.is_some(), "engine should receive move notification");
+    let received = received.unwrap();
+    assert_eq!(received["target"], format!("sm:{}", inst.id));
+    assert_eq!(received["payload"]["action"], "moved");
 
     let _ = std::fs::remove_file(&socket);
     let _ = std::fs::remove_dir_all(&tmp);


### PR DESCRIPTION
## Summary
- `deskd sm move` and MCP `sm_move` now notify the workflow engine after moving an instance
- Workflow engine handles `action: "moved"` messages — reloads instance, dispatches to assignee via `dispatch_instance()` (full logic: prompt, criteria, queue support)
- MCP `sm_move` no longer duplicates dispatch logic — uses shared `notify_moved()` helper
- Bus socket resolved from `DESKD_BUS_SOCKET` env or derived from config path

Fixes #204

## Test plan
- [x] New test: `test_sm_move_notifies_workflow_engine` — move instance, verify notification reaches workflow engine
- [x] All existing tests pass: `cargo fmt && cargo clippy -- -D warnings && cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)