### PR TITLE
feat: persist and tail agent stream-json output (#206)

### DIFF
--- a/src/app/agent.rs
+++ b/src/app/agent.rs
@@ -84,6 +84,31 @@ pub fn stderr_log_path(name: &str) -> PathBuf {
     config::log_dir().join(format!("{}.stderr.log", name))
 }
 
+/// Path to the agent's stream-json log file.
+pub fn stream_log_path(name: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let dir = PathBuf::from(home).join(".deskd").join("logs").join(name);
+    dir.join("stream.jsonl")
+}
+
+/// Rotate stream log: if file exceeds max_bytes, keep the last half.
+fn rotate_stream_log(path: &PathBuf, max_bytes: u64) {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return;
+    };
+    if meta.len() <= max_bytes {
+        return;
+    }
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return;
+    };
+    // Keep the last half of lines.
+    let lines: Vec<&str> = content.lines().collect();
+    let keep_from = lines.len() / 2;
+    let truncated: String = lines[keep_from..].iter().flat_map(|l| [*l, "\n"]).collect();
+    let _ = std::fs::write(path, truncated);
+}
+
 pub fn load_state(name: &str) -> Result<AgentState> {
     let path = state_path(name);
     let content =
@@ -771,6 +796,12 @@ pub async fn remove(name: &str) -> Result<()> {
     {
         warn!(agent = %name, error = %e, "failed to remove stderr log file");
     }
+    let stream_log = stream_log_path(name);
+    if stream_log.exists()
+        && let Err(e) = std::fs::remove_file(&stream_log)
+    {
+        warn!(agent = %name, error = %e, "failed to remove stream log file");
+    }
     info!(agent = %name, "agent removed");
     Ok(())
 }
@@ -1133,8 +1164,26 @@ impl AgentProcess {
         let stderr_buf_reader = stderr_buf;
         let task_use_resume = use_resume;
         tokio::spawn(async move {
+            // Open stream log file for persistence.
+            let stream_log = stream_log_path(&agent_name2);
+            if let Some(parent) = stream_log.parent() {
+                std::fs::create_dir_all(parent).ok();
+            }
+            let stream_file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&stream_log);
+            let mut stream_writer = stream_file.ok().map(std::io::BufWriter::new);
+
             let mut lines = tokio::io::BufReader::new(stdout).lines();
             while let Ok(Some(line)) = lines.next_line().await {
+                // Persist raw stream-json line.
+                if let Some(ref mut f) = stream_writer {
+                    use std::io::Write;
+                    let _ = writeln!(f, "{}", line);
+                    let _ = f.flush();
+                }
+
                 if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
                     match v.get("type").and_then(|t| t.as_str()) {
                         Some("assistant") => {
@@ -1192,6 +1241,8 @@ impl AgentProcess {
                             {
                                 break;
                             }
+                            // Rotate stream log after each turn if over 10MB.
+                            rotate_stream_log(&stream_log, 10 * 1024 * 1024);
                         }
                         _ => {}
                     }

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -229,6 +229,20 @@ pub enum AgentAction {
         #[arg(long, default_value = "false")]
         follow: bool,
     },
+    /// Show parsed stream-json output (tool calls, responses, errors).
+    Stream {
+        /// Agent name.
+        name: String,
+        /// Show last N events (default 50).
+        #[arg(long, default_value = "50")]
+        tail: usize,
+        /// Keep watching for new output.
+        #[arg(long, default_value = "false")]
+        follow: bool,
+        /// Show raw JSONL instead of parsed output.
+        #[arg(long, default_value = "false")]
+        raw: bool,
+    },
     /// Remove an agent (state file + log).
     Rm { name: String },
     /// Spawn an ephemeral sub-agent, run a task, print result, clean up.

--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -435,6 +435,52 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 }
             }
         }
+        AgentAction::Stream {
+            name,
+            tail,
+            follow,
+            raw,
+        } => {
+            let path = agent::stream_log_path(&name);
+            if !path.exists() {
+                println!("No stream log for {}", name);
+                return Ok(());
+            }
+            let content = std::fs::read_to_string(&path)?;
+            let lines: Vec<&str> = content.lines().collect();
+            let start = lines.len().saturating_sub(tail);
+            for line in &lines[start..] {
+                if raw {
+                    println!("{}", line);
+                } else {
+                    print_stream_event(line);
+                }
+            }
+            if follow {
+                let mut pos = std::fs::metadata(&path)?.len();
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    if let Ok(meta) = std::fs::metadata(&path) {
+                        let new_len = meta.len();
+                        if new_len > pos {
+                            let mut f = std::fs::File::open(&path)?;
+                            use std::io::{Read, Seek, SeekFrom};
+                            f.seek(SeekFrom::Start(pos))?;
+                            let mut buf = String::new();
+                            f.read_to_string(&mut buf)?;
+                            for line in buf.lines() {
+                                if raw {
+                                    println!("{}", line);
+                                } else {
+                                    print_stream_event(line);
+                                }
+                            }
+                            pos = new_len;
+                        }
+                    }
+                }
+            }
+        }
         AgentAction::Rm { name } => {
             agent::remove(&name).await?;
             println!("Agent {} removed", name);
@@ -471,6 +517,79 @@ pub async fn handle(action: AgentAction) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Parse a stream-json line and print a human-readable summary.
+fn print_stream_event(line: &str) {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+        return;
+    };
+    match v.get("type").and_then(|t| t.as_str()) {
+        Some("assistant") => {
+            if let Some(blocks) = v
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())
+            {
+                for block in blocks {
+                    match block.get("type").and_then(|t| t.as_str()) {
+                        Some("text") => {
+                            if let Some(text) = block.get("text").and_then(|t| t.as_str())
+                                && !text.is_empty()
+                            {
+                                println!("[assistant] {}", truncate(text, 200));
+                            }
+                        }
+                        Some("tool_use") => {
+                            let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("?");
+                            let input = block
+                                .get("input")
+                                .map(|i| {
+                                    let s = i.to_string();
+                                    truncate(&s, 120).to_string()
+                                })
+                                .unwrap_or_default();
+                            println!("[tool_use] {} {}", name, input);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        Some("tool") | Some("tool_result") => {
+            let tool_id = v
+                .get("content")
+                .and_then(|c| c.as_array())
+                .and_then(|a| a.first())
+                .and_then(|b| b.get("text"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("");
+            let is_error = v
+                .get("content")
+                .and_then(|c| c.as_array())
+                .and_then(|a| a.first())
+                .and_then(|b| b.get("is_error"))
+                .and_then(|e| e.as_bool())
+                .unwrap_or(false);
+            if is_error {
+                println!("[tool_error] {}", truncate(tool_id, 200));
+            } else if !tool_id.is_empty() {
+                println!("[tool_result] {}", truncate(tool_id, 200));
+            }
+        }
+        Some("result") => {
+            let cost = v
+                .get("total_cost_usd")
+                .and_then(|c| c.as_f64())
+                .unwrap_or(0.0);
+            let turns = v.get("num_turns").and_then(|t| t.as_u64()).unwrap_or(0);
+            println!("[result] turns={} cost=${:.4}", turns, cost);
+        }
+        Some(other) => {
+            println!("[{}]", other);
+        }
+        None => {}
+    }
 }
 
 fn print_inbox_message(msg: &unified_inbox::InboxMessage) {


### PR DESCRIPTION
## Summary
- Raw stream-json events persisted to `~/.deskd/logs/{name}/stream.jsonl` during task execution
- Auto-rotation: truncates to ~half when file exceeds 10MB (checked after each `result` event)
- New CLI command `deskd agent stream <name>` with parsed human-readable display:
  - `[assistant]` — text responses (truncated)
  - `[tool_use]` — tool calls with name and input
  - `[tool_result]` / `[tool_error]` — tool outcomes
  - `[result]` — turn summary with cost
- `--follow` for live tailing, `--raw` for raw JSONL, `--tail N` for last N events
- Stream log cleaned up on `deskd agent rm`

Fixes #206
Related: #155 (observability), #199 (stderr logs)

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` — all pass
- [ ] Manual: run agent task, check `deskd agent stream <name>`, verify `--follow` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)