### PR TITLE
feat: bus status CLI — show bus diagnostics and connected clients

### DIFF
--- a/src/app/bus.rs
+++ b/src/app/bus.rs
@@ -33,6 +33,19 @@ impl BusState {
         self.clients.keys().cloned().collect()
     }
 
+    /// Return client details: name + subscriptions.
+    fn list_clients_detail(&self) -> Vec<serde_json::Value> {
+        self.clients
+            .values()
+            .map(|c| {
+                serde_json::json!({
+                    "name": c.name,
+                    "subscriptions": c.subscriptions.iter().collect::<Vec<_>>(),
+                })
+            })
+            .collect()
+    }
+
     fn route(&self, msg: &Message) {
         let target = &msg.target;
 
@@ -195,12 +208,17 @@ async fn handle_connection(stream: UnixStream, state: Arc<RwLock<BusState>>) -> 
             crate::domain::message::Envelope::List => {
                 let bus = state.read().await;
                 let clients = bus.list_clients();
+                let clients_detail = bus.list_clients_detail();
                 if let Some(client) = bus.clients.get(&name) {
                     let resp = Message {
                         id: "list-response".to_string(),
                         source: "bus".to_string(),
                         target: name.clone(),
-                        payload: serde_json::json!({"type": "list_response", "clients": clients}),
+                        payload: serde_json::json!({
+                            "type": "list_response",
+                            "clients": clients,
+                            "clients_detail": clients_detail,
+                        }),
                         reply_to: None,
                         metadata: crate::app::message::Metadata::default(),
                     };

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -93,6 +93,11 @@ pub enum Commands {
         #[arg(long, global = true)]
         config: Option<String>,
     },
+    /// Show bus diagnostics and connected clients.
+    Bus {
+        #[command(subcommand)]
+        action: BusAction,
+    },
     /// Manage the pull-based task queue.
     Task {
         #[command(subcommand)]
@@ -365,5 +370,15 @@ pub enum ScheduleSubcommand {
     Rm {
         /// Schedule index (0-based).
         index: usize,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum BusAction {
+    /// Show bus state: connected clients and their subscriptions.
+    Status {
+        /// Bus socket path.
+        #[arg(long, default_value = DEFAULT_SOCKET)]
+        socket: String,
     },
 }

--- a/src/app/commands/bus.rs
+++ b/src/app/commands/bus.rs
@@ -1,0 +1,142 @@
+//! `deskd bus` subcommand handlers.
+
+use anyhow::Result;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use crate::app::cli::BusAction;
+
+pub async fn handle(action: BusAction) -> Result<()> {
+    match action {
+        BusAction::Status { socket } => {
+            if !std::path::Path::new(&socket).exists() {
+                println!("Bus is not running (socket not found: {})", socket);
+                return Ok(());
+            }
+
+            let mut stream = UnixStream::connect(&socket)
+                .await
+                .map_err(|e| anyhow::anyhow!("Cannot connect to bus at {}: {}", socket, e))?;
+
+            // Register as temporary client.
+            let reg = serde_json::json!({
+                "type": "register",
+                "name": "deskd-bus-status",
+                "subscriptions": []
+            });
+            let mut line = serde_json::to_string(&reg)?;
+            line.push('\n');
+            stream.write_all(line.as_bytes()).await?;
+
+            // Request client list.
+            let list_req = serde_json::json!({"type": "list"});
+            let mut req_line = serde_json::to_string(&list_req)?;
+            req_line.push('\n');
+            stream.write_all(req_line.as_bytes()).await?;
+
+            // Read response with timeout.
+            let (reader, _) = stream.into_split();
+            let mut lines = BufReader::new(reader).lines();
+
+            let timeout = tokio::time::Duration::from_secs(3);
+            let result = tokio::time::timeout(timeout, async {
+                while let Some(l) = lines.next_line().await? {
+                    let v: serde_json::Value = serde_json::from_str(&l)?;
+
+                    // Check for list_response in payload (comes as a bus message).
+                    let payload = if v.get("type").and_then(|t| t.as_str()) == Some("list_response")
+                    {
+                        v
+                    } else if let Some(p) = v.get("payload") {
+                        if p.get("type").and_then(|t| t.as_str()) == Some("list_response") {
+                            p.clone()
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    };
+
+                    return Ok::<_, anyhow::Error>(Some(payload));
+                }
+                Ok(None)
+            })
+            .await;
+
+            let payload = match result {
+                Ok(Ok(Some(p))) => p,
+                Ok(Ok(None)) => {
+                    println!("Bus is running but returned no client list.");
+                    return Ok(());
+                }
+                Ok(Err(e)) => {
+                    anyhow::bail!("Error reading bus response: {}", e);
+                }
+                Err(_) => {
+                    println!("Bus is running but did not respond in time.");
+                    return Ok(());
+                }
+            };
+
+            println!("Bus:    running");
+            println!("Socket: {}", socket);
+            println!();
+
+            // Use detailed client info if available, fall back to names.
+            if let Some(detail) = payload.get("clients_detail").and_then(|d| d.as_array()) {
+                let client_count = detail.len();
+                // Exclude our own status query client.
+                let clients: Vec<_> = detail
+                    .iter()
+                    .filter(|c| c.get("name").and_then(|n| n.as_str()) != Some("deskd-bus-status"))
+                    .collect();
+
+                println!("Clients: {} connected", clients.len());
+                if clients.is_empty() {
+                    return Ok(());
+                }
+                println!();
+                println!("{:<25} SUBSCRIPTIONS", "NAME");
+                for c in &clients {
+                    let name = c.get("name").and_then(|n| n.as_str()).unwrap_or("unknown");
+                    let subs: Vec<&str> = c
+                        .get("subscriptions")
+                        .and_then(|s| s.as_array())
+                        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+                        .unwrap_or_default();
+                    let subs_str = if subs.is_empty() {
+                        "-".to_string()
+                    } else {
+                        subs.join(", ")
+                    };
+                    println!("{:<25} {}", name, subs_str);
+                }
+
+                // Show count excluding ourselves.
+                if client_count > clients.len() + 1 {
+                    println!(
+                        "\n({} internal clients hidden)",
+                        client_count - clients.len() - 1
+                    );
+                }
+            } else if let Some(clients) = payload.get("clients").and_then(|c| c.as_array()) {
+                let names: Vec<&str> = clients
+                    .iter()
+                    .filter_map(|n| n.as_str())
+                    .filter(|n| *n != "deskd-bus-status")
+                    .collect();
+                println!("Clients: {} connected", names.len());
+                if !names.is_empty() {
+                    println!();
+                    println!("NAME");
+                    for name in &names {
+                        println!("{}", name);
+                    }
+                }
+            } else {
+                println!("Clients: unknown (unexpected response format)");
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/app/commands/mod.rs
+++ b/src/app/commands/mod.rs
@@ -1,6 +1,7 @@
 //! Command handlers — one module per subcommand group.
 
 pub mod agent;
+pub mod bus;
 pub mod graph;
 pub mod remind;
 pub mod restart;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::Agent { action } => {
             commands::agent::handle(action).await?;
         }
+        Commands::Bus { action } => {
+            commands::bus::handle(action).await?;
+        }
         Commands::Graph { action } => {
             commands::graph::handle(action).await?;
         }


### PR DESCRIPTION
## Summary
- Adds `deskd bus status` command showing bus state and connected clients
- Shows per-client name and subscriptions (extended list_response protocol)
- Graceful handling: clear output when bus is not running, timeout on unresponsive bus
- Backward compatible: new `clients_detail` field alongside existing `clients` array

Closes #201

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass
- [x] Handles non-running bus (socket not found) with clear message
- [x] Output excludes the status query's own temporary client

🤖 Generated with [Claude Code](https://claude.com/claude-code)