### PR TITLE
feat: structured metadata on SM instances and tasks

### DIFF
--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -278,6 +278,9 @@ pub enum SmAction {
         title: String,
         #[arg(long)]
         body: Option<String>,
+        /// Structured metadata as JSON string (e.g. '{"branch": "feat/x"}').
+        #[arg(long)]
+        metadata: Option<String>,
     },
     /// Move an instance to a new state.
     Move {
@@ -333,6 +336,9 @@ pub enum TaskAction {
         /// Required labels (comma-separated).
         #[arg(long, value_delimiter = ',')]
         labels: Vec<String>,
+        /// Structured metadata as JSON string (e.g. '{"worktree": "/path"}').
+        #[arg(long)]
+        metadata: Option<String>,
     },
     /// List tasks in the queue.
     List {

--- a/src/app/commands/sm.rs
+++ b/src/app/commands/sm.rs
@@ -69,13 +69,23 @@ pub async fn handle(
                 );
             }
         }
-        SmAction::Create { model, title, body } => {
+        SmAction::Create {
+            model,
+            title,
+            body,
+            metadata,
+        } => {
             let m = models
                 .iter()
                 .find(|m| m.name == model)
                 .ok_or_else(|| anyhow::anyhow!("Model '{}' not found", model))?;
             let creator = std::env::var("DESKD_AGENT_NAME").unwrap_or_else(|_| "cli".to_string());
-            let inst = store.create(m, &title, body.as_deref().unwrap_or(""), &creator)?;
+            let mut inst = store.create(m, &title, body.as_deref().unwrap_or(""), &creator)?;
+            if let Some(ref meta_str) = metadata {
+                inst.metadata = serde_json::from_str(meta_str)
+                    .map_err(|e| anyhow::anyhow!("invalid --metadata JSON: {}", e))?;
+                store.save(&inst)?;
+            }
             println!(
                 "Created {} (model={}, state={})",
                 inst.id, inst.model, inst.state
@@ -122,6 +132,11 @@ pub async fn handle(
             }
             if let Some(ref e) = inst.error {
                 println!("Error:     {}", e);
+            }
+            if !inst.metadata.is_null()
+                && let Ok(pretty) = serde_json::to_string(&inst.metadata)
+            {
+                println!("Metadata:  {}", pretty);
             }
             println!("Created:   {} by {}", inst.created_at, inst.created_by);
             println!("Updated:   {}", inst.updated_at);

--- a/src/app/commands/task.rs
+++ b/src/app/commands/task.rs
@@ -14,9 +14,16 @@ pub fn handle(action: TaskAction) -> Result<()> {
             description,
             model,
             labels,
+            metadata,
         } => {
             let criteria = task::TaskCriteria { model, labels };
-            let t = store.create(&description, criteria, "cli")?;
+            let t = if let Some(ref meta_str) = metadata {
+                let meta: serde_json::Value = serde_json::from_str(meta_str)
+                    .map_err(|e| anyhow::anyhow!("invalid --metadata JSON: {}", e))?;
+                store.create_with_metadata(&description, criteria, "cli", meta)?
+            } else {
+                store.create(&description, criteria, "cli")?
+            };
             println!("Created task {} (pending)", t.id);
         }
         TaskAction::List { status } => {

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -464,6 +464,10 @@ fn handle_tools_list(
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Required labels. Only workers with ALL listed labels will pick up the task."
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Structured metadata (e.g. {\"worktree\": \"/path\", \"branch\": \"feat/x\"})"
                 }
             },
             "required": ["description"]
@@ -529,7 +533,8 @@ fn handle_tools_list(
                 "properties": {
                     "model": {"type": "string", "description": "Model name (e.g. 'feature', 'bugfix')"},
                     "title": {"type": "string", "description": "Instance title"},
-                    "body": {"type": "string", "description": "Instance body/description"}
+                    "body": {"type": "string", "description": "Instance body/description"},
+                    "metadata": {"type": "object", "description": "Structured metadata (e.g. {\"worktree\": \"/path\", \"branch\": \"feat/x\"})"}
                 },
                 "required": ["model", "title"]
             }
@@ -1080,9 +1085,18 @@ async fn call_task_create(args: &Value, agent_name: &str) -> Result<Value> {
         })
         .unwrap_or_default();
 
+    let metadata = args
+        .get("metadata")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+
     let store = crate::app::task::TaskStore::default_for_home();
     let criteria = crate::app::task::TaskCriteria { model, labels };
-    let task = store.create(description, criteria, agent_name)?;
+    let task = if metadata.is_null() {
+        store.create(description, criteria, agent_name)?
+    } else {
+        store.create_with_metadata(description, criteria, agent_name, metadata)?
+    };
 
     info!(agent = %agent_name, task_id = %task.id, "task_create via MCP");
 
@@ -1303,8 +1317,17 @@ async fn call_sm_create(
         .ok_or_else(|| anyhow::anyhow!("model '{}' not found", model_name))?
         .into();
 
+    let metadata = args
+        .get("metadata")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+
     let store = statemachine::StateMachineStore::default_for_home();
-    let inst = store.create(&model, title, body, agent_name)?;
+    let mut inst = store.create(&model, title, body, agent_name)?;
+    if !metadata.is_null() {
+        inst.metadata = metadata;
+        store.save(&inst)?;
+    }
     info!(agent = %agent_name, instance = %inst.id, model = %model_name, "sm_create via MCP");
 
     // If the initial state has an assignee, dispatch the first task via the bus.

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -61,7 +61,24 @@ impl TaskStore {
         criteria: TaskCriteria,
         created_by: &str,
     ) -> Result<Task> {
-        self.create_inner(description, criteria, created_by, None)
+        self.create_inner(
+            description,
+            criteria,
+            created_by,
+            None,
+            serde_json::Value::Null,
+        )
+    }
+
+    /// Create a new task with structured metadata.
+    pub fn create_with_metadata(
+        &self,
+        description: &str,
+        criteria: TaskCriteria,
+        created_by: &str,
+        metadata: serde_json::Value,
+    ) -> Result<Task> {
+        self.create_inner(description, criteria, created_by, None, metadata)
     }
 
     /// Create a new task linked to a state machine instance.
@@ -77,6 +94,7 @@ impl TaskStore {
             criteria,
             created_by,
             Some(sm_instance_id.to_string()),
+            serde_json::Value::Null,
         )
     }
 
@@ -86,6 +104,7 @@ impl TaskStore {
         criteria: TaskCriteria,
         created_by: &str,
         sm_instance_id: Option<String>,
+        metadata: serde_json::Value,
     ) -> Result<Task> {
         let id = format!("task-{}", &uuid::Uuid::new_v4().to_string()[..8]);
         let now = Utc::now().to_rfc3339();
@@ -104,6 +123,7 @@ impl TaskStore {
             sm_instance_id,
             cost_usd: None,
             turns: None,
+            metadata,
         };
 
         self.save(&task)?;
@@ -280,6 +300,15 @@ impl crate::ports::store::TaskRepository for TaskStore {
     }
     fn create(&self, description: &str, criteria: TaskCriteria, created_by: &str) -> Result<Task> {
         self.create(description, criteria, created_by)
+    }
+    fn create_with_metadata(
+        &self,
+        description: &str,
+        criteria: TaskCriteria,
+        created_by: &str,
+        metadata: serde_json::Value,
+    ) -> Result<Task> {
+        self.create_with_metadata(description, criteria, created_by, metadata)
     }
     fn create_for_sm(
         &self,

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -333,10 +333,16 @@ fn build_task_text(prompt: &str, inst: &statemachine::Instance) -> String {
         parts.push(format!("---\n## Previous step result\n\n{}", result));
     }
 
-    parts.push(format!(
+    let mut meta_lines = format!(
         "---\n## Metadata\ninstance_id: {}\nmodel: {}\nstate: {}",
         inst.id, inst.model, inst.state
-    ));
+    );
+    if !inst.metadata.is_null()
+        && let Ok(pretty) = serde_json::to_string_pretty(&inst.metadata)
+    {
+        meta_lines.push_str(&format!("\nmetadata: {}", pretty));
+    }
+    parts.push(meta_lines);
 
     parts.join("\n\n")
 }

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -56,6 +56,8 @@ pub struct Task {
     pub cost_usd: Option<f64>,
     /// Number of turns used (set on completion).
     pub turns: Option<u32>,
+    /// Structured metadata (JSON object, e.g. worktree path, branch, repo URL).
+    pub metadata: serde_json::Value,
 }
 
 /// Summary of the queue for status display.

--- a/src/infra/dto.rs
+++ b/src/infra/dto.rs
@@ -122,6 +122,8 @@ pub struct StoredTask {
     pub cost_usd: Option<f64>,
     #[serde(default)]
     pub turns: Option<u32>,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
 }
 
 /// Storage format for task matching criteria.
@@ -164,6 +166,7 @@ impl From<StoredTask> for Task {
             sm_instance_id: dto.sm_instance_id,
             cost_usd: dto.cost_usd,
             turns: dto.turns,
+            metadata: dto.metadata,
         }
     }
 }
@@ -194,6 +197,7 @@ impl From<&Task> for StoredTask {
             sm_instance_id: task.sm_instance_id.clone(),
             cost_usd: task.cost_usd,
             turns: task.turns,
+            metadata: task.metadata.clone(),
         }
     }
 }
@@ -781,6 +785,7 @@ mod tests {
             sm_instance_id: None,
             cost_usd: None,
             turns: None,
+            metadata: serde_json::Value::Null,
         };
         let stored: StoredTask = (&task).into();
         assert_eq!(stored.status, "active");

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -60,9 +60,24 @@ impl TaskRepository for InMemoryTaskStore {
             sm_instance_id: None,
             cost_usd: None,
             turns: None,
+            metadata: serde_json::Value::Null,
         };
         let dto: StoredTask = (&task).into();
         self.tasks.lock().unwrap().insert(id, dto);
+        Ok(task)
+    }
+
+    fn create_with_metadata(
+        &self,
+        description: &str,
+        criteria: TaskCriteria,
+        created_by: &str,
+        metadata: serde_json::Value,
+    ) -> Result<Task> {
+        let mut task = self.create(description, criteria, created_by)?;
+        task.metadata = metadata;
+        let dto: StoredTask = (&task).into();
+        self.tasks.lock().unwrap().insert(task.id.clone(), dto);
         Ok(task)
     }
 

--- a/src/ports/store.rs
+++ b/src/ports/store.rs
@@ -12,6 +12,13 @@ use crate::domain::task::{QueueSummary, Task, TaskCriteria, TaskStatus};
 pub trait TaskRepository: Send + Sync {
     fn load(&self, id: &str) -> Result<Task>;
     fn create(&self, description: &str, criteria: TaskCriteria, created_by: &str) -> Result<Task>;
+    fn create_with_metadata(
+        &self,
+        description: &str,
+        criteria: TaskCriteria,
+        created_by: &str,
+        metadata: serde_json::Value,
+    ) -> Result<Task>;
     fn create_for_sm(
         &self,
         description: &str,


### PR DESCRIPTION
## Summary
- Adds `metadata` (JSON) field to Task domain type, with `#[serde(default)]` on DTO for backward compat
- `deskd sm create <model> "title" --metadata '{"branch":"feat/x"}'` stores metadata on instance
- `deskd task add "desc" --metadata '{"worktree":"/path"}'` stores metadata on task
- `sm_create` and `task_create` MCP tools accept optional `metadata` parameter
- `build_task_text()` includes instance metadata when dispatching SM tasks to agents
- `deskd sm status` displays metadata when present
- Instance already had `metadata: serde_json::Value` — this exposes it through CLI and MCP

Closes #208

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass
- [x] Existing stored data loads correctly (serde default)
- [x] `--metadata` flag accepts valid JSON, rejects invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)