### PR TITLE
arch: extract ContextRepository port trait

### DIFF
--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -1,30 +1,24 @@
 //! Context application layer — I/O operations on context types.
 //!
 //! Pure domain types live in `domain::context`. This module adds
-//! persistence (load/save) and materialization (execute live nodes).
+//! persistence (load/save via ContextRepository) and materialization
+//! (execute live nodes).
 
-use crate::infra::dto::StoredMainBranch;
+use crate::infra::context_store::FileContextStore;
+use crate::ports::store::ContextRepository;
 
 // Re-export all domain types for backward compatibility.
 pub use crate::domain::context::*;
 
 impl MainBranch {
-    /// Load from YAML file
+    /// Load from YAML file (convenience wrapper over ContextRepository).
     pub fn load(path: &std::path::Path) -> anyhow::Result<Self> {
-        let content = std::fs::read_to_string(path)?;
-        let dto: StoredMainBranch = serde_yaml::from_str(&content)?;
-        Ok(dto.into())
+        FileContextStore::new().load(path)
     }
 
-    /// Save to YAML file
+    /// Save to YAML file (convenience wrapper over ContextRepository).
     pub fn save(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let dto: StoredMainBranch = self.into();
-        let content = serde_yaml::to_string(&dto)?;
-        std::fs::write(path, content)?;
-        Ok(())
+        FileContextStore::new().save(self, path)
     }
 
     /// Materialize: execute live nodes and produce message list for session injection

--- a/src/infra/context_store.rs
+++ b/src/infra/context_store.rs
@@ -1,0 +1,77 @@
+//! File-based context persistence — implements ContextRepository.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::domain::context::MainBranch;
+use crate::infra::dto::StoredMainBranch;
+use crate::ports::store::ContextRepository;
+
+/// File-based context store backed by YAML files on disk.
+pub struct FileContextStore;
+
+impl FileContextStore {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for FileContextStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ContextRepository for FileContextStore {
+    fn load(&self, path: &Path) -> Result<MainBranch> {
+        let content = std::fs::read_to_string(path)?;
+        let dto: StoredMainBranch = serde_yaml::from_str(&content)?;
+        Ok(dto.into())
+    }
+
+    fn save(&self, branch: &MainBranch, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let dto: StoredMainBranch = branch.into();
+        let content = serde_yaml::to_string(&dto)?;
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::context::{Node, NodeKind};
+
+    #[test]
+    fn test_file_context_store_roundtrip() {
+        let store = FileContextStore::new();
+        let dir =
+            std::env::temp_dir().join(format!("deskd-ctx-store-test-{}", uuid::Uuid::new_v4()));
+        let path = dir.join("main.yaml");
+
+        let mut branch = MainBranch::new("test-agent", 8000);
+        branch.nodes.push(Node {
+            id: "s1".into(),
+            kind: NodeKind::Static {
+                role: "system".into(),
+                content: "Hello world".into(),
+            },
+            label: "Greeting".into(),
+            tokens_estimate: 100,
+        });
+
+        store.save(&branch, &path).expect("save failed");
+        let loaded = store.load(&path).expect("load failed");
+
+        assert_eq!(loaded.agent, "test-agent");
+        assert_eq!(loaded.budget_tokens, 8000);
+        assert_eq!(loaded.nodes.len(), 1);
+        assert_eq!(loaded.nodes[0].id, "s1");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,5 +1,6 @@
 //! Infrastructure layer — concrete implementations of port traits.
 
+pub mod context_store;
 pub mod dto;
 pub mod memory_bus;
 pub mod memory_store;

--- a/src/ports/store.rs
+++ b/src/ports/store.rs
@@ -5,8 +5,17 @@
 
 use anyhow::Result;
 
+use std::path::Path;
+
+use crate::domain::context::MainBranch;
 use crate::domain::statemachine::{Instance, ModelDef};
 use crate::domain::task::{QueueSummary, Task, TaskCriteria, TaskStatus};
+
+/// Persistence operations for context branches (MainBranch YAML files).
+pub trait ContextRepository: Send + Sync {
+    fn load(&self, path: &Path) -> Result<MainBranch>;
+    fn save(&self, branch: &MainBranch, path: &Path) -> Result<()>;
+}
 
 /// Persistence operations for the task queue.
 pub trait TaskRepository: Send + Sync {


### PR DESCRIPTION
## Summary
- Adds `ContextRepository` trait to `ports/store.rs` with `load`/`save` methods, following the existing `TaskRepository`/`StateMachineRepository` pattern
- Implements `FileContextStore` in `infra/context_store.rs` backed by YAML files via `StoredMainBranch` DTO
- Updates `MainBranch::load`/`save` in `app/context.rs` to delegate through the port trait instead of doing direct file I/O

Fixes the DIP violation where context persistence was hardcoded in the app layer.

Closes #194

## Test plan
- [x] `FileContextStore` roundtrip test (new)
- [x] Existing `MainBranch` save/load roundtrip test passes
- [x] All materialize tests pass
- [x] Quality gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 244+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)