### PR TITLE
fix: flush stream before drop in bus writes

### DIFF
--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -677,6 +677,7 @@ async fn call_send_message(
     let mut msg_line = serde_json::to_string(&msg)?;
     msg_line.push('\n');
     stream.write_all(msg_line.as_bytes()).await?;
+    stream.flush().await?;
 
     info!(agent = %agent_name, target = %target, bus = %effective_socket, "send_message via MCP");
 
@@ -1365,6 +1366,7 @@ async fn call_sm_create(
         let mut msg_line = serde_json::to_string(&msg)?;
         msg_line.push('\n');
         stream.write_all(msg_line.as_bytes()).await?;
+        stream.flush().await?;
         info!(instance = %inst.id, assignee = %inst.assignee, "dispatched initial task");
     }
 

--- a/src/app/schedule.rs
+++ b/src/app/schedule.rs
@@ -910,6 +910,7 @@ async fn post_payload_to_stream(
     let mut msg_line = serde_json::to_string(&msg)?;
     msg_line.push('\n');
     stream.write_all(msg_line.as_bytes()).await?;
+    stream.flush().await?;
 
     Ok(())
 }

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -38,6 +38,7 @@ pub async fn notify_moved(bus_socket: &str, instance_id: &str, source: &str) -> 
     let mut msg_line = serde_json::to_string(&msg)?;
     msg_line.push('\n');
     stream.write_all(msg_line.as_bytes()).await?;
+    stream.flush().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add `stream.flush().await?` before stream drop in all connect-send-disconnect bus write patterns
- Fixes MCP `send_message`, `sm_create` dispatch, workflow `notify_bus`, and schedule `post_to_bus`

## Problem
When MCP `send_message` sends to a sub-agent on the internal bus, it connects, writes register + message, then returns — dropping the `UnixStream`. Without explicit flush, buffered data may not reach the bus before the socket closes. This caused sub-agent workers spawned via `add_persistent_agent` to appear idle (0 turns) because they never received their first task.

Fixes #232

## Test plan
- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` passes
- [ ] Deploy to container, verify sub-agent receives `send_message` after `add_persistent_agent`