### PR TITLE
fix: write sub-agent PID to state and fix status display

### DIFF
--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -124,22 +124,47 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                     }
                 }
             }
+            // Also check internal buses for sub-agents: each parent agent may
+            // have an internal bus at /tmp/deskd-{parent}-internal.sock.
+            let parent_names: std::collections::HashSet<String> =
+                agents.iter().filter_map(|a| a.parent.clone()).collect();
+            for parent in &parent_names {
+                let internal_sock = format!("/tmp/deskd-{}-internal.sock", parent);
+                if let Ok(more) = crate::app::serve::query_live_agents(&internal_sock).await {
+                    live.extend(more);
+                }
+            }
 
             if agents.is_empty() {
                 println!("No agents registered");
             } else {
                 println!(
-                    "{:<15} {:<7} {:<8} {:<10} {:<12} MODEL",
+                    "{:<15} {:<10} {:<8} {:<10} {:<12} MODEL",
                     "NAME", "STATUS", "TURNS", "COST", "USER"
                 );
                 for a in agents {
                     let status = if live.contains(&a.config.name) {
-                        "live"
+                        if a.parent.is_some() {
+                            "live[sub]".to_string()
+                        } else {
+                            "live".to_string()
+                        }
+                    } else if a.pid > 0
+                        && std::path::Path::new(&format!("/proc/{}", a.pid)).exists()
+                    {
+                        // PID is alive but not yet registered on the bus.
+                        if a.parent.is_some() {
+                            "run[sub]".to_string()
+                        } else {
+                            "running".to_string()
+                        }
+                    } else if a.parent.is_some() {
+                        "idle[sub]".to_string()
                     } else {
-                        "idle"
+                        "idle".to_string()
                     };
                     println!(
-                        "{:<15} {:<7} {:<8} ${:<9.2} {:<12} {}",
+                        "{:<15} {:<10} {:<8} ${:<9.2} {:<12} {}",
                         a.config.name,
                         status,
                         a.total_turns,
@@ -336,8 +361,26 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 let s = agent::load_state(&name)?;
                 let pid_alive =
                     s.pid > 0 && std::path::Path::new(&format!("/proc/{}", s.pid)).exists();
-                let status_str = if pid_alive { &s.status } else { "offline" };
+                // For sub-agents on an internal bus, also check the internal bus socket.
+                let on_internal_bus = if let Some(ref parent) = s.parent {
+                    let internal_sock = format!("/tmp/deskd-{}-internal.sock", parent);
+                    crate::app::serve::query_live_agents(&internal_sock)
+                        .await
+                        .map(|live| live.contains(&s.config.name))
+                        .unwrap_or(false)
+                } else {
+                    false
+                };
+                let status_str = if pid_alive || on_internal_bus {
+                    s.status.as_str()
+                } else {
+                    "offline"
+                };
+                let is_sub_agent = s.parent.is_some();
                 println!("Agent:       {}", s.config.name);
+                if is_sub_agent {
+                    println!("Type:        sub-agent");
+                }
                 println!("Status:      {}", status_str);
                 println!(
                     "PID:         {}",
@@ -379,21 +422,33 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                     println!("No agents registered");
                 } else {
                     println!(
-                        "{:<15} {:<9} {:<6} {:<10} {:<20} MODEL",
+                        "{:<15} {:<12} {:<6} {:<10} {:<20} MODEL",
                         "NAME", "STATUS", "TURNS", "COST", "CREATED"
                     );
-                    println!("{}", "─".repeat(75));
+                    println!("{}", "─".repeat(78));
                     for a in &agents {
                         let pid_alive =
                             a.pid > 0 && std::path::Path::new(&format!("/proc/{}", a.pid)).exists();
-                        let status = if pid_alive { &a.status } else { "offline" };
+                        // Sub-agents: treat as alive if their PID is alive even if
+                        // we can't reach the internal bus from the CLI.
+                        let status = if pid_alive {
+                            if a.parent.is_some() {
+                                format!("{}[sub]", a.status)
+                            } else {
+                                a.status.clone()
+                            }
+                        } else if a.parent.is_some() {
+                            "offline[sub]".to_string()
+                        } else {
+                            "offline".to_string()
+                        };
                         let created = if a.created_at.len() > 19 {
                             &a.created_at[..19]
                         } else {
                             &a.created_at
                         };
                         println!(
-                            "{:<15} {:<9} {:<6} ${:<9.4} {:<20} {}",
+                            "{:<15} {:<12} {:<6} ${:<9.4} {:<20} {}",
                             a.config.name,
                             status,
                             a.total_turns,


### PR DESCRIPTION
Closes #237

## Summary

- **Root cause 1 fixed**: Write worker PID to state file in `add_persistent_agent` immediately after `spawn()`, before moving `child` into the async wait task. Now `agent status <name>` can check `/proc/{pid}` to determine if the sub-agent is actually running.
- **Root cause 2 fixed**: `agent list` now queries `/tmp/deskd-{parent}-internal.sock` for each parent agent found in state files, so sub-agents on the internal bus show `live[sub]` instead of `idle`.
- **Root cause 2 also fixed in `agent status`**: When the `pid` check fails but the agent has a `parent`, the command queries the internal bus socket to determine liveness. Shows `Type: sub-agent` label in output.
- **Better status labels**: `agent status` (no name) now shows `working[sub]`/`idle[sub]`/`offline[sub]` to distinguish sub-agents from top-level agents.

Note: Root cause 3 (turn/cost counters only updated on completion) is a separate concern — the worker's `RuntimeProcess` already updates the state file incrementally via `save_state` after each task. The issue for this bug is that the PID was 0 so status always showed offline.

## Test plan
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (all 290 tests)
- [ ] Spawn a sub-agent via `add_persistent_agent` MCP call; verify `deskd agent status <sub-agent>` shows correct PID and `idle`/`working` status
- [ ] `deskd agent list` shows `live[sub]` for active sub-agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)