### PR TITLE
arch: split TaskRepository into TaskReader + TaskWriter

### DIFF
--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -294,10 +294,19 @@ impl TaskStore {
     }
 }
 
-impl crate::ports::store::TaskRepository for TaskStore {
+impl crate::ports::store::TaskReader for TaskStore {
     fn load(&self, id: &str) -> Result<Task> {
         self.load(id)
     }
+    fn list(&self, status_filter: Option<TaskStatus>) -> Result<Vec<Task>> {
+        self.list(status_filter)
+    }
+    fn queue_summary(&self) -> QueueSummary {
+        self.queue_summary()
+    }
+}
+
+impl crate::ports::store::TaskWriter for TaskStore {
     fn create(&self, description: &str, criteria: TaskCriteria, created_by: &str) -> Result<Task> {
         self.create(description, criteria, created_by)
     }
@@ -318,9 +327,6 @@ impl crate::ports::store::TaskRepository for TaskStore {
         sm_instance_id: &str,
     ) -> Result<Task> {
         self.create_for_sm(description, criteria, created_by, sm_instance_id)
-    }
-    fn list(&self, status_filter: Option<TaskStatus>) -> Result<Vec<Task>> {
-        self.list(status_filter)
     }
     fn cancel(&self, id: &str) -> Result<Task> {
         self.cancel(id)
@@ -344,9 +350,6 @@ impl crate::ports::store::TaskRepository for TaskStore {
     }
     fn fail(&self, id: &str, error_msg: &str) -> Result<Task> {
         self.fail(id, error_msg)
-    }
-    fn queue_summary(&self) -> QueueSummary {
-        self.queue_summary()
     }
 }
 

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 use crate::domain::statemachine::{Instance, ModelDef, Transition};
 use crate::domain::task::{QueueSummary, Task, TaskCriteria, TaskStatus, matches_criteria};
 use crate::infra::dto::{StoredInstance, StoredTask};
-use crate::ports::store::{StateMachineRepository, TaskRepository};
+use crate::ports::store::{StateMachineRepository, TaskReader, TaskWriter};
 
 // ─── InMemoryTaskStore ───────────────────────────────────────────────────────
 
@@ -33,7 +33,7 @@ impl Default for InMemoryTaskStore {
     }
 }
 
-impl TaskRepository for InMemoryTaskStore {
+impl TaskReader for InMemoryTaskStore {
     fn load(&self, id: &str) -> Result<Task> {
         let tasks = self.tasks.lock().unwrap();
         tasks
@@ -43,6 +43,41 @@ impl TaskRepository for InMemoryTaskStore {
             .ok_or_else(|| anyhow::anyhow!("Task '{}' not found", id))
     }
 
+    fn list(&self, status_filter: Option<TaskStatus>) -> Result<Vec<Task>> {
+        let tasks = self.tasks.lock().unwrap();
+        let mut result: Vec<Task> = tasks
+            .values()
+            .cloned()
+            .map(Into::into)
+            .filter(|t: &Task| status_filter.is_none() || Some(t.status) == status_filter)
+            .collect();
+        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        Ok(result)
+    }
+
+    fn queue_summary(&self) -> QueueSummary {
+        let tasks = self.tasks.lock().unwrap();
+        let mut s = QueueSummary {
+            pending: 0,
+            active: 0,
+            done: 0,
+            failed: 0,
+        };
+        for dto in tasks.values() {
+            let task: Task = dto.clone().into();
+            match task.status {
+                TaskStatus::Pending => s.pending += 1,
+                TaskStatus::Active => s.active += 1,
+                TaskStatus::Done => s.done += 1,
+                TaskStatus::Failed => s.failed += 1,
+                TaskStatus::Cancelled => {}
+            }
+        }
+        s
+    }
+}
+
+impl TaskWriter for InMemoryTaskStore {
     fn create(&self, description: &str, criteria: TaskCriteria, created_by: &str) -> Result<Task> {
         let id = format!("task-{}", &uuid::Uuid::new_v4().to_string()[..8]);
         let now = chrono::Utc::now().to_rfc3339();
@@ -93,18 +128,6 @@ impl TaskRepository for InMemoryTaskStore {
         let dto: StoredTask = (&task).into();
         self.tasks.lock().unwrap().insert(task.id.clone(), dto);
         Ok(task)
-    }
-
-    fn list(&self, status_filter: Option<TaskStatus>) -> Result<Vec<Task>> {
-        let tasks = self.tasks.lock().unwrap();
-        let mut result: Vec<Task> = tasks
-            .values()
-            .cloned()
-            .map(Into::into)
-            .filter(|t: &Task| status_filter.is_none() || Some(t.status) == status_filter)
-            .collect();
-        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
-        Ok(result)
     }
 
     fn cancel(&self, id: &str) -> Result<Task> {
@@ -192,27 +215,6 @@ impl TaskRepository for InMemoryTaskStore {
         task.updated_at = chrono::Utc::now().to_rfc3339();
         tasks.insert(id.to_string(), (&task).into());
         Ok(task)
-    }
-
-    fn queue_summary(&self) -> QueueSummary {
-        let tasks = self.tasks.lock().unwrap();
-        let mut s = QueueSummary {
-            pending: 0,
-            active: 0,
-            done: 0,
-            failed: 0,
-        };
-        for dto in tasks.values() {
-            let task: Task = dto.clone().into();
-            match task.status {
-                TaskStatus::Pending => s.pending += 1,
-                TaskStatus::Active => s.active += 1,
-                TaskStatus::Done => s.done += 1,
-                TaskStatus::Failed => s.failed += 1,
-                TaskStatus::Cancelled => {}
-            }
-        }
-        s
     }
 }
 

--- a/src/ports/store.rs
+++ b/src/ports/store.rs
@@ -17,9 +17,15 @@ pub trait ContextRepository: Send + Sync {
     fn save(&self, branch: &MainBranch, path: &Path) -> Result<()>;
 }
 
-/// Persistence operations for the task queue.
-pub trait TaskRepository: Send + Sync {
+/// Read-only persistence operations for the task queue.
+pub trait TaskReader: Send + Sync {
     fn load(&self, id: &str) -> Result<Task>;
+    fn list(&self, status_filter: Option<TaskStatus>) -> Result<Vec<Task>>;
+    fn queue_summary(&self) -> QueueSummary;
+}
+
+/// Write/mutate persistence operations for the task queue.
+pub trait TaskWriter: Send + Sync {
     fn create(&self, description: &str, criteria: TaskCriteria, created_by: &str) -> Result<Task>;
     fn create_with_metadata(
         &self,
@@ -35,7 +41,6 @@ pub trait TaskRepository: Send + Sync {
         created_by: &str,
         sm_instance_id: &str,
     ) -> Result<Task>;
-    fn list(&self, status_filter: Option<TaskStatus>) -> Result<Vec<Task>>;
     fn cancel(&self, id: &str) -> Result<Task>;
     fn claim_next(
         &self,
@@ -51,8 +56,17 @@ pub trait TaskRepository: Send + Sync {
         turns: Option<u32>,
     ) -> Result<Task>;
     fn fail(&self, id: &str, error_msg: &str) -> Result<Task>;
-    fn queue_summary(&self) -> QueueSummary;
 }
+
+/// Combined task persistence trait for code that needs both read and write access.
+///
+/// Supertrait of [`TaskReader`] + [`TaskWriter`]; implementors only need to satisfy
+/// the two constituent traits — the blanket impl below covers the rest.
+pub trait TaskRepository: TaskReader + TaskWriter {}
+
+/// Blanket impl: any type that is both a `TaskReader` and a `TaskWriter` automatically
+/// satisfies `TaskRepository`.
+impl<T: TaskReader + TaskWriter> TaskRepository for T {}
 
 /// Persistence operations for state machine instances.
 pub trait StateMachineRepository: Send + Sync {


### PR DESCRIPTION
## Summary

- Fixes ISP violation in `src/ports/store.rs`: `TaskRepository` had 9 methods
- Split into `TaskReader` (3 methods: `load`, `list`, `queue_summary`) and `TaskWriter` (7 methods: `create`, `create_with_metadata`, `create_for_sm`, `cancel`, `claim_next`, `complete`, `fail`)
- `TaskRepository` becomes a supertrait of both, with a blanket impl so existing impls just need the two constituent traits
- Updated `TaskStore` (`src/app/task.rs`) and `InMemoryTaskStore` (`src/infra/memory_store.rs`) to implement the split traits

## Test plan
- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — 244 unit tests + all integration tests pass

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)