### PR TITLE
feat: enforce task timeouts via periodic sweep loop

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,6 +18,7 @@ pub mod serve;
 pub mod statemachine;
 pub mod task;
 pub mod tasklog;
+pub mod timeout_sweep;
 pub mod unified_inbox;
 pub mod worker;
 pub mod workflow;

--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -179,6 +179,15 @@ pub async fn serve(config_path: String) -> Result<()> {
             let models: Vec<crate::domain::statemachine::ModelDef> =
                 ucfg.models.iter().cloned().map(Into::into).collect();
             let agent_name = def.name.clone();
+
+            // Start timeout sweep loop alongside the workflow engine.
+            let sweep_models = models.clone();
+            let sweep_interval = std::time::Duration::from_secs(30);
+            tokio::spawn(async move {
+                crate::app::timeout_sweep::run_timeout_sweep(sweep_models, sweep_interval).await;
+            });
+            info!(agent = %def.name, "started timeout sweep loop (interval=30s)");
+
             tokio::spawn(async move {
                 if let Err(e) = workflow::run(&bus, models).await {
                     tracing::error!(agent = %agent_name, error = %e, "workflow engine exited");

--- a/src/app/statemachine.rs
+++ b/src/app/statemachine.rs
@@ -186,6 +186,36 @@ impl StateMachineStore {
         info!(id = %inst.id, from = %from_state, to = %target_state, "state transition");
         Ok(())
     }
+
+    /// Force-move an instance to a new state, bypassing transition validation.
+    ///
+    /// Used by the timeout sweep loop to enforce `timeout_goto` even when no
+    /// explicit transition edge exists from the current state to the target.
+    pub fn force_transition(
+        &self,
+        inst: &mut Instance,
+        target_state: &str,
+        trigger: &str,
+        note: Option<&str>,
+    ) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let from_state = inst.state.clone();
+        let transition = Transition {
+            from: from_state.clone(),
+            to: target_state.to_string(),
+            trigger: trigger.to_string(),
+            timestamp: now.clone(),
+            note: note.map(|s| s.to_string()),
+            cost_usd: None,
+            turns: None,
+        };
+        inst.history.push(transition);
+        inst.state = target_state.to_string();
+        inst.updated_at = now;
+        self.save(inst)?;
+        info!(id = %inst.id, from = %from_state, to = %target_state, trigger = %trigger, "forced state transition");
+        Ok(())
+    }
 }
 
 /// Find valid transitions from the current state.

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -124,6 +124,7 @@ impl TaskStore {
             cost_usd: None,
             turns: None,
             metadata,
+            timed_out_at: None,
         };
 
         self.save(&task)?;
@@ -268,6 +269,29 @@ impl TaskStore {
         task.status = TaskStatus::Failed;
         task.error = Some(error_msg.to_string());
         task.updated_at = Utc::now().to_rfc3339();
+        self.save(&task)?;
+        Ok(task)
+    }
+
+    /// Mark an active or pending task as failed due to a timeout.
+    ///
+    /// Unlike `fail`, this method accepts tasks in either `Active` or `Pending`
+    /// state (a pending task may time out before an agent even claims it).
+    /// Sets `timed_out_at` in addition to the standard `Failed` fields.
+    pub fn timeout_fail(&self, id: &str, error_msg: &str) -> Result<Task> {
+        let mut task = self.load(id)?;
+        if task.status != TaskStatus::Active && task.status != TaskStatus::Pending {
+            bail!(
+                "Cannot timeout task '{}': status is '{}' (must be active or pending)",
+                id,
+                task.status
+            );
+        }
+        let now = Utc::now().to_rfc3339();
+        task.status = TaskStatus::Failed;
+        task.error = Some(error_msg.to_string());
+        task.timed_out_at = Some(now.clone());
+        task.updated_at = now;
         self.save(&task)?;
         Ok(task)
     }
@@ -496,5 +520,49 @@ mod tests {
         let s = store.queue_summary();
         assert_eq!(s.pending, 2);
         assert_eq!(s.active, 0);
+    }
+
+    #[test]
+    fn test_timeout_fail_active_task() {
+        let store = temp_store();
+        store
+            .create("Slow task", TaskCriteria::default(), "kira")
+            .unwrap();
+
+        let claimed = store.claim_next("agent-1", "any", &[]).unwrap().unwrap();
+        assert_eq!(claimed.status, TaskStatus::Active);
+
+        let timed = store
+            .timeout_fail(&claimed.id, "timed out after 60s")
+            .unwrap();
+        assert_eq!(timed.status, TaskStatus::Failed);
+        assert!(timed.timed_out_at.is_some());
+        assert_eq!(timed.error.as_deref(), Some("timed out after 60s"));
+    }
+
+    #[test]
+    fn test_timeout_fail_pending_task() {
+        let store = temp_store();
+        let task = store
+            .create("Unclaimed task", TaskCriteria::default(), "kira")
+            .unwrap();
+
+        let timed = store.timeout_fail(&task.id, "never claimed").unwrap();
+        assert_eq!(timed.status, TaskStatus::Failed);
+        assert!(timed.timed_out_at.is_some());
+    }
+
+    #[test]
+    fn test_timeout_fail_rejects_done_task() {
+        let store = temp_store();
+        store
+            .create("Done task", TaskCriteria::default(), "kira")
+            .unwrap();
+
+        let claimed = store.claim_next("agent-1", "any", &[]).unwrap().unwrap();
+        store.complete(&claimed.id, "all good", None, None).unwrap();
+
+        let result = store.timeout_fail(&claimed.id, "too late");
+        assert!(result.is_err());
     }
 }

--- a/src/app/timeout_sweep.rs
+++ b/src/app/timeout_sweep.rs
@@ -1,0 +1,231 @@
+//! Periodic sweep loop that enforces `TransitionDef.timeout` / `timeout_goto`.
+//!
+//! Background task — started once per `deskd serve`. Every `sweep_interval`
+//! it scans all active tasks that have a linked SM instance, checks whether
+//! `updated_at + timeout` has elapsed, and if so:
+//!
+//! 1. Marks the task as `Failed` with a timeout error and sets `timed_out_at`.
+//! 2. Force-transitions the SM instance to the `timeout_goto` state.
+//!
+//! The sweep interval defaults to 30 s and is configurable via the caller.
+
+use std::time::Duration;
+
+use tracing::{info, warn};
+
+use crate::app::statemachine::StateMachineStore;
+use crate::app::task::TaskStore;
+use crate::domain::statemachine::ModelDef;
+use crate::domain::task::TaskStatus;
+
+/// Parse a human-readable duration string into [`Duration`].
+///
+/// Supported units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days).
+/// Examples: `"30s"`, `"5m"`, `"2h"`, `"1d"`.
+///
+/// Returns `None` if the string is not recognised.
+pub fn parse_duration(s: &str) -> Option<Duration> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    // Find where the numeric part ends.
+    let split = s.find(|c: char| !c.is_ascii_digit())?;
+    let (num_str, unit) = s.split_at(split);
+    let n: u64 = num_str.parse().ok()?;
+    match unit.trim() {
+        "s" => Some(Duration::from_secs(n)),
+        "m" => Some(Duration::from_secs(n * 60)),
+        "h" => Some(Duration::from_secs(n * 3600)),
+        "d" => Some(Duration::from_secs(n * 86400)),
+        _ => None,
+    }
+}
+
+/// Run the timeout sweep loop forever with the given interval.
+///
+/// `models` is the list of SM model definitions known to this agent instance.
+/// This is a long-running async function; call it inside `tokio::spawn`.
+pub async fn run_timeout_sweep(models: Vec<ModelDef>, sweep_interval: Duration) {
+    info!(
+        interval_secs = sweep_interval.as_secs(),
+        "timeout sweep loop started"
+    );
+    let mut ticker = tokio::time::interval(sweep_interval);
+    ticker.tick().await; // skip first immediate tick
+
+    loop {
+        ticker.tick().await;
+        if let Err(e) = sweep_once(&models) {
+            warn!(error = %e, "timeout sweep encountered an error");
+        }
+    }
+}
+
+/// Execute a single sweep pass: check every active task with an SM instance.
+fn sweep_once(models: &[ModelDef]) -> anyhow::Result<()> {
+    let task_store = TaskStore::default_for_home();
+    let sm_store = StateMachineStore::default_for_home();
+
+    let active_tasks = task_store.list(Some(TaskStatus::Active))?;
+
+    for task in active_tasks {
+        // Only care about tasks linked to an SM instance.
+        let sm_id = match &task.sm_instance_id {
+            Some(id) => id.clone(),
+            None => continue,
+        };
+
+        // Load the SM instance; skip on error (might have been deleted).
+        let mut inst = match sm_store.load(&sm_id) {
+            Ok(i) => i,
+            Err(e) => {
+                warn!(
+                    task_id = %task.id,
+                    sm_id = %sm_id,
+                    error = %e,
+                    "timeout sweep: failed to load SM instance, skipping"
+                );
+                continue;
+            }
+        };
+
+        // Look up the model definition by name.
+        let model = match models.iter().find(|m| m.name == inst.model) {
+            Some(m) => m,
+            None => continue, // model not loaded — can't determine timeout
+        };
+
+        // Find the transition out of the current state that carries a timeout.
+        // We pick the first transition from the current state that has both
+        // `timeout` and `timeout_goto` set.
+        let timeout_def = model.transitions.iter().find(|t| {
+            (t.from == inst.state || t.from == "*")
+                && t.timeout.is_some()
+                && t.timeout_goto.is_some()
+        });
+
+        let td = match timeout_def {
+            Some(t) => t,
+            None => continue, // no timeout configured for this state
+        };
+
+        let timeout_str = td.timeout.as_deref().unwrap_or("");
+        let timeout_goto = match &td.timeout_goto {
+            Some(g) => g.clone(),
+            None => continue,
+        };
+
+        let timeout_dur = match parse_duration(timeout_str) {
+            Some(d) => d,
+            None => {
+                warn!(
+                    task_id = %task.id,
+                    timeout = %timeout_str,
+                    "timeout sweep: unparseable timeout string, skipping"
+                );
+                continue;
+            }
+        };
+
+        // Check elapsed time since the task was last updated.
+        let updated_at = match chrono::DateTime::parse_from_rfc3339(&task.updated_at) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let elapsed = chrono::Utc::now()
+            .signed_duration_since(updated_at)
+            .to_std()
+            .unwrap_or(Duration::ZERO);
+
+        if elapsed < timeout_dur {
+            continue; // not expired yet
+        }
+
+        warn!(
+            task_id = %task.id,
+            sm_id = %sm_id,
+            state = %inst.state,
+            timeout_goto = %timeout_goto,
+            elapsed_secs = elapsed.as_secs(),
+            timeout_secs = timeout_dur.as_secs(),
+            "task timed out — forcing SM transition and failing task"
+        );
+
+        // Fail the task.
+        if let Err(e) = task_store.timeout_fail(
+            &task.id,
+            &format!(
+                "task timed out after {}s (limit: {}s)",
+                elapsed.as_secs(),
+                timeout_dur.as_secs()
+            ),
+        ) {
+            warn!(task_id = %task.id, error = %e, "timeout sweep: failed to mark task as failed");
+        }
+
+        // Force-transition the SM instance to timeout_goto.
+        if let Err(e) = sm_store.force_transition(
+            &mut inst,
+            &timeout_goto,
+            "timeout",
+            Some(&format!("timed out after {}s", elapsed.as_secs())),
+        ) {
+            warn!(
+                sm_id = %sm_id,
+                timeout_goto = %timeout_goto,
+                error = %e,
+                "timeout sweep: failed to force-transition SM instance"
+            );
+        }
+
+        info!(
+            task_id = %task.id,
+            sm_id = %sm_id,
+            timeout_goto = %timeout_goto,
+            "timeout sweep: task expired and SM transitioned"
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_duration_seconds() {
+        assert_eq!(parse_duration("30s"), Some(Duration::from_secs(30)));
+        assert_eq!(parse_duration("1s"), Some(Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn test_parse_duration_minutes() {
+        assert_eq!(parse_duration("5m"), Some(Duration::from_secs(300)));
+        assert_eq!(parse_duration("1m"), Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn test_parse_duration_hours() {
+        assert_eq!(parse_duration("2h"), Some(Duration::from_secs(7200)));
+    }
+
+    #[test]
+    fn test_parse_duration_days() {
+        assert_eq!(parse_duration("1d"), Some(Duration::from_secs(86400)));
+    }
+
+    #[test]
+    fn test_parse_duration_invalid() {
+        assert_eq!(parse_duration(""), None);
+        assert_eq!(parse_duration("abc"), None);
+        assert_eq!(parse_duration("5x"), None);
+        assert_eq!(parse_duration("m"), None);
+    }
+
+    #[test]
+    fn test_parse_duration_whitespace() {
+        assert_eq!(parse_duration("  10s  "), Some(Duration::from_secs(10)));
+    }
+}

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -58,6 +58,8 @@ pub struct Task {
     pub turns: Option<u32>,
     /// Structured metadata (JSON object, e.g. worktree path, branch, repo URL).
     pub metadata: serde_json::Value,
+    /// Timestamp when the task was timed out by the sweep loop (RFC 3339).
+    pub timed_out_at: Option<String>,
 }
 
 /// Summary of the queue for status display.

--- a/src/infra/dto.rs
+++ b/src/infra/dto.rs
@@ -124,6 +124,8 @@ pub struct StoredTask {
     pub turns: Option<u32>,
     #[serde(default)]
     pub metadata: serde_json::Value,
+    #[serde(default)]
+    pub timed_out_at: Option<String>,
 }
 
 /// Storage format for task matching criteria.
@@ -167,6 +169,7 @@ impl From<StoredTask> for Task {
             cost_usd: dto.cost_usd,
             turns: dto.turns,
             metadata: dto.metadata,
+            timed_out_at: dto.timed_out_at,
         }
     }
 }
@@ -198,6 +201,7 @@ impl From<&Task> for StoredTask {
             cost_usd: task.cost_usd,
             turns: task.turns,
             metadata: task.metadata.clone(),
+            timed_out_at: task.timed_out_at.clone(),
         }
     }
 }
@@ -786,6 +790,7 @@ mod tests {
             cost_usd: None,
             turns: None,
             metadata: serde_json::Value::Null,
+            timed_out_at: None,
         };
         let stored: StoredTask = (&task).into();
         assert_eq!(stored.status, "active");

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -96,6 +96,7 @@ impl TaskWriter for InMemoryTaskStore {
             cost_usd: None,
             turns: None,
             metadata: serde_json::Value::Null,
+            timed_out_at: None,
         };
         let dto: StoredTask = (&task).into();
         self.tasks.lock().unwrap().insert(id, dto);


### PR DESCRIPTION
## Summary

- Adds a periodic background sweep loop (30s interval) that enforces `TransitionDef.timeout` and `timeout_goto` fields that were previously defined but never enforced
- When an active task's `updated_at + timeout` elapses, the sweep marks the task as `Failed` (setting the new `timed_out_at` timestamp) and force-transitions the linked SM instance to the `timeout_goto` state
- The force-transition bypasses normal edge validation — necessary since `timeout_goto` may not have an explicit transition edge from the stuck state

## Changes

- `domain/task.rs`: new `timed_out_at: Option<String>` field on `Task`
- `infra/dto.rs` + `memory_store.rs`: propagate field through DTO/persistence layer
- `app/task.rs`: new `timeout_fail()` method (accepts `Active` or `Pending` tasks, unlike `fail()`)
- `app/statemachine.rs`: new `force_transition()` on `StateMachineStore` — admin override, no edge validation
- `app/timeout_sweep.rs`: new module — sweep loop + `parse_duration()` supporting `30s`, `5m`, `2h`, `1d` formats
- `app/serve.rs`: spawn sweep alongside workflow engine when models are defined (interval: 30s)

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo test` passes (zero failures)
- [x] Unit tests for `parse_duration` (all units, invalid inputs, whitespace)
- [x] Unit tests for `timeout_fail` (active task, pending task, rejected on Done)

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)