### PR TITLE
arch: split StateMachineRepository into Reader + Writer

### DIFF
--- a/src/app/statemachine.rs
+++ b/src/app/statemachine.rs
@@ -232,15 +232,18 @@ pub fn is_terminal(model: &ModelDef, inst: &Instance) -> bool {
     model.terminal.contains(&inst.state)
 }
 
-impl crate::ports::store::StateMachineRepository for StateMachineStore {
-    fn save(&self, inst: &Instance) -> Result<()> {
-        self.save(inst)
-    }
+impl crate::ports::store::StateMachineReader for StateMachineStore {
     fn load(&self, id: &str) -> Result<Instance> {
         self.load(id)
     }
     fn list_all(&self) -> Result<Vec<Instance>> {
         self.list_all()
+    }
+}
+
+impl crate::ports::store::StateMachineWriter for StateMachineStore {
+    fn save(&self, inst: &Instance) -> Result<()> {
+        self.save(inst)
     }
     fn delete(&self, id: &str) -> Result<()> {
         self.delete(id)

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 use crate::domain::statemachine::{Instance, ModelDef, Transition};
 use crate::domain::task::{QueueSummary, Task, TaskCriteria, TaskStatus, matches_criteria};
 use crate::infra::dto::{StoredInstance, StoredTask};
-use crate::ports::store::{StateMachineRepository, TaskReader, TaskWriter};
+use crate::ports::store::{StateMachineReader, StateMachineWriter, TaskReader, TaskWriter};
 
 // ─── InMemoryTaskStore ───────────────────────────────────────────────────────
 
@@ -240,13 +240,7 @@ impl Default for InMemoryStateMachineStore {
     }
 }
 
-impl StateMachineRepository for InMemoryStateMachineStore {
-    fn save(&self, inst: &Instance) -> Result<()> {
-        let dto: StoredInstance = inst.into();
-        self.instances.lock().unwrap().insert(inst.id.clone(), dto);
-        Ok(())
-    }
-
+impl StateMachineReader for InMemoryStateMachineStore {
     fn load(&self, id: &str) -> Result<Instance> {
         self.instances
             .lock()
@@ -262,6 +256,14 @@ impl StateMachineRepository for InMemoryStateMachineStore {
         let mut result: Vec<Instance> = instances.values().cloned().map(Into::into).collect();
         result.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
         Ok(result)
+    }
+}
+
+impl StateMachineWriter for InMemoryStateMachineStore {
+    fn save(&self, inst: &Instance) -> Result<()> {
+        let dto: StoredInstance = inst.into();
+        self.instances.lock().unwrap().insert(inst.id.clone(), dto);
+        Ok(())
     }
 
     fn delete(&self, id: &str) -> Result<()> {

--- a/src/ports/store.rs
+++ b/src/ports/store.rs
@@ -68,11 +68,15 @@ pub trait TaskRepository: TaskReader + TaskWriter {}
 /// satisfies `TaskRepository`.
 impl<T: TaskReader + TaskWriter> TaskRepository for T {}
 
-/// Persistence operations for state machine instances.
-pub trait StateMachineRepository: Send + Sync {
-    fn save(&self, inst: &Instance) -> Result<()>;
+/// Read-only persistence operations for state machine instances.
+pub trait StateMachineReader: Send + Sync {
     fn load(&self, id: &str) -> Result<Instance>;
     fn list_all(&self) -> Result<Vec<Instance>>;
+}
+
+/// Write/mutate persistence operations for state machine instances.
+pub trait StateMachineWriter: Send + Sync {
+    fn save(&self, inst: &Instance) -> Result<()>;
     fn delete(&self, id: &str) -> Result<()>;
     fn create(
         &self,
@@ -93,3 +97,9 @@ pub trait StateMachineRepository: Send + Sync {
         turns: Option<u32>,
     ) -> Result<()>;
 }
+
+/// Combined supertrait alias for backward compatibility — blanket-implemented
+/// for any type that implements both `StateMachineReader` and `StateMachineWriter`.
+pub trait StateMachineRepository: StateMachineReader + StateMachineWriter {}
+
+impl<T: StateMachineReader + StateMachineWriter> StateMachineRepository for T {}


### PR DESCRIPTION
## Summary

Closes #180

- Split `StateMachineRepository` (6 methods) into `StateMachineReader` (load, list_all) and `StateMachineWriter` (save, delete, create, move_to)
- Follows the same ISP pattern already used by `TaskReader` + `TaskWriter` in `src/ports/store.rs`
- `StateMachineRepository` kept as a supertrait alias with blanket impl for zero-churn backward compatibility
- Updated both implementations: `StateMachineStore` (file-based) and `InMemoryStateMachineStore` (testing)

## Test plan

- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)