### PR TITLE
fix: crash recovery — handle orphaned results and tasks

### DIFF
--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -237,6 +237,9 @@ pub async fn run(
 
     info!(agent = %name, runtime = ?agent_runtime, "agent process ready, waiting for tasks");
 
+    // Startup recovery: handle orphaned active tasks assigned to this agent.
+    recover_orphaned_tasks(name);
+
     // Task queue polling interval (30 seconds).
     let mut queue_poll = tokio::time::interval(std::time::Duration::from_secs(30));
     queue_poll.tick().await; // skip first immediate tick
@@ -773,6 +776,53 @@ fn log_skip(name: &str, msg: &Message, ctx: &TaskContext, status: &str, error: O
     };
     if let Err(e) = tasklog::log_task(name, &log_entry) {
         warn!(agent = %name, error = %e, "failed to write task log");
+    }
+}
+
+/// On startup, find active tasks assigned to this agent and handle them.
+///
+/// If deskd crashed while this agent was processing a task, the task is stuck in
+/// Active status with no one working on it. Tasks with results are completed;
+/// tasks without results are marked as Failed for visibility.
+fn recover_orphaned_tasks(agent_name: &str) {
+    let store = crate::app::task::TaskStore::default_for_home();
+    let active_tasks = match store.list(Some(crate::domain::task::TaskStatus::Active)) {
+        Ok(tasks) => tasks,
+        Err(_) => return,
+    };
+
+    for task in active_tasks {
+        if task.assignee.as_deref() != Some(agent_name) {
+            continue;
+        }
+
+        // If the task already has a result, complete it.
+        if task.result.as_ref().is_some_and(|r| !r.is_empty()) {
+            info!(
+                agent = %agent_name,
+                task_id = %task.id,
+                "recovering orphaned task with result: completing"
+            );
+            if let Err(e) =
+                store.complete(&task.id, task.result.as_deref().unwrap_or(""), None, None)
+            {
+                warn!(agent = %agent_name, task_id = %task.id, error = %e, "failed to complete orphaned task");
+            }
+            continue;
+        }
+
+        // No result — mark as Failed. Manual retry or dead-letter will handle it.
+        info!(
+            agent = %agent_name,
+            task_id = %task.id,
+            "marking orphaned active task as Failed (no result, agent crashed)"
+        );
+        if let Err(e) = store.fail(
+            &task.id,
+            &format!("agent {} crashed — task requires manual retry", agent_name),
+        ) {
+            warn!(agent = %agent_name, task_id = %task.id, error = %e, "failed to mark orphaned task as failed");
+        }
     }
 }
 

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -349,6 +349,10 @@ fn build_task_text(prompt: &str, inst: &statemachine::Instance) -> String {
 }
 
 /// On startup, find non-terminal instances and dispatch them.
+///
+/// Crash recovery: if an instance has a result but hasn't transitioned
+/// (crash between result storage and transition), apply the transition
+/// from the stored result instead of re-dispatching.
 async fn dispatch_pending(
     writer: &Writer,
     models: &[ModelDef],
@@ -358,6 +362,16 @@ async fn dispatch_pending(
         Ok(list) => list,
         Err(_) => return,
     };
+
+    // Build a set of SM instance IDs that already have an active task,
+    // so we don't create duplicate dispatches.
+    let task_store = crate::app::task::TaskStore::default_for_home();
+    let active_sm_ids: std::collections::HashSet<String> = task_store
+        .list(Some(crate::domain::task::TaskStatus::Active))
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|t| t.sm_instance_id)
+        .collect();
 
     for inst in &instances {
         let model = match models.iter().find(|m| m.name == inst.model) {
@@ -370,9 +384,33 @@ async fn dispatch_pending(
             continue;
         }
 
-        // Skip instances that already have a result — work was completed
-        // but the instance hasn't transitioned to a terminal state yet.
+        // Crash recovery: result present but not transitioned.
+        // Apply the transition from the stored result.
         if inst.result.as_ref().is_some_and(|r| !r.is_empty()) {
+            let result = inst.result.as_deref().unwrap_or("");
+            info!(
+                instance = %inst.id,
+                state = %inst.state,
+                "recovering: result present but not transitioned, applying transition"
+            );
+            if let Err(e) = handle_completion(
+                writer,
+                models,
+                store,
+                &inst.id,
+                result,
+                inst.error.as_deref(),
+            )
+            .await
+            {
+                warn!(instance = %inst.id, error = %e, "failed to recover orphaned result");
+            }
+            continue;
+        }
+
+        // Skip if there's already an active task for this instance (idempotency).
+        if active_sm_ids.contains(&inst.id) {
+            debug!(instance = %inst.id, "skipping dispatch: active task already exists");
             continue;
         }
 


### PR DESCRIPTION
## Summary
- `dispatch_pending` now recovers instances with results that weren't transitioned (crash between result storage and SM transition) — applies the transition instead of skipping
- Idempotency check: skips dispatch for instances that already have an active task in the queue
- `recover_orphaned_tasks` on worker startup: resets active tasks assigned to this agent (completes if result exists, fails otherwise for re-dispatch)

Supersedes #260 (reimplemented cleanly on current main, no rebase conflicts).

Closes #247

## Test plan
- [x] All existing workflow_transitions tests pass (7/7)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` zero warnings
- [x] `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)