### PR TITLE
feat: add DeadLetter status for permanently failed tasks

### DIFF
--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -342,9 +342,12 @@ pub enum TaskAction {
     },
     /// List tasks in the queue.
     List {
-        /// Filter by status: pending, active, done, failed, cancelled.
+        /// Filter by status: pending, active, done, failed, cancelled, dead_letter.
         #[arg(long)]
         status: Option<String>,
+        /// Show only dead-lettered tasks (shorthand for --status dead_letter).
+        #[arg(long)]
+        dead_letter: bool,
     },
     /// Cancel a pending task.
     Cancel {

--- a/src/app/commands/task.rs
+++ b/src/app/commands/task.rs
@@ -26,15 +26,23 @@ pub fn handle(action: TaskAction) -> Result<()> {
             };
             println!("Created task {} (pending)", t.id);
         }
-        TaskAction::List { status } => {
-            let filter = match status.as_deref() {
-                Some("pending") => Some(task::TaskStatus::Pending),
-                Some("active") => Some(task::TaskStatus::Active),
-                Some("done") => Some(task::TaskStatus::Done),
-                Some("failed") => Some(task::TaskStatus::Failed),
-                Some("cancelled") => Some(task::TaskStatus::Cancelled),
-                Some(other) => anyhow::bail!("Unknown status: {}", other),
-                None => None,
+        TaskAction::List {
+            status,
+            dead_letter,
+        } => {
+            let filter = if dead_letter {
+                Some(task::TaskStatus::DeadLetter)
+            } else {
+                match status.as_deref() {
+                    Some("pending") => Some(task::TaskStatus::Pending),
+                    Some("active") => Some(task::TaskStatus::Active),
+                    Some("done") => Some(task::TaskStatus::Done),
+                    Some("failed") => Some(task::TaskStatus::Failed),
+                    Some("cancelled") => Some(task::TaskStatus::Cancelled),
+                    Some("dead_letter") => Some(task::TaskStatus::DeadLetter),
+                    Some(other) => anyhow::bail!("Unknown status: {}", other),
+                    None => None,
+                }
             };
             let tasks = store.list(filter)?;
             if tasks.is_empty() {

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -1153,6 +1153,7 @@ async fn call_task_list(args: &Value) -> Result<Value> {
             "done" => Some(crate::app::task::TaskStatus::Done),
             "failed" => Some(crate::app::task::TaskStatus::Failed),
             "cancelled" => Some(crate::app::task::TaskStatus::Cancelled),
+            "dead_letter" => Some(crate::app::task::TaskStatus::DeadLetter),
             _ => None,
         });
 

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -311,7 +311,7 @@ impl TaskStore {
                 TaskStatus::Active => s.active += 1,
                 TaskStatus::Done => s.done += 1,
                 TaskStatus::Failed => s.failed += 1,
-                TaskStatus::Cancelled => {}
+                TaskStatus::Cancelled | TaskStatus::DeadLetter => {}
             }
         }
         s

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -10,6 +10,8 @@ pub enum TaskStatus {
     Done,
     Failed,
     Cancelled,
+    /// Task permanently failed after exhausting all retries.
+    DeadLetter,
 }
 
 impl std::fmt::Display for TaskStatus {
@@ -20,6 +22,7 @@ impl std::fmt::Display for TaskStatus {
             Self::Done => write!(f, "done"),
             Self::Failed => write!(f, "failed"),
             Self::Cancelled => write!(f, "cancelled"),
+            Self::DeadLetter => write!(f, "dead_letter"),
         }
     }
 }

--- a/src/infra/dto.rs
+++ b/src/infra/dto.rs
@@ -150,6 +150,7 @@ impl From<StoredTask> for Task {
                 "done" => TaskStatus::Done,
                 "failed" => TaskStatus::Failed,
                 "cancelled" => TaskStatus::Cancelled,
+                "dead_letter" => TaskStatus::DeadLetter,
                 other => {
                     warn!(status = other, "unknown task status, defaulting to Pending");
                     TaskStatus::Pending
@@ -185,6 +186,7 @@ impl From<&Task> for StoredTask {
                 TaskStatus::Done => "done",
                 TaskStatus::Failed => "failed",
                 TaskStatus::Cancelled => "cancelled",
+                TaskStatus::DeadLetter => "dead_letter",
             }
             .to_string(),
             assignee: task.assignee.clone(),

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -70,7 +70,7 @@ impl TaskReader for InMemoryTaskStore {
                 TaskStatus::Active => s.active += 1,
                 TaskStatus::Done => s.done += 1,
                 TaskStatus::Failed => s.failed += 1,
-                TaskStatus::Cancelled => {}
+                TaskStatus::Cancelled | TaskStatus::DeadLetter => {}
             }
         }
         s


### PR DESCRIPTION
## Summary
- Adds `DeadLetter` variant to `TaskStatus` for tasks that permanently failed after exhausting retries
- CLI: `deskd task list --dead-letter` shorthand filter
- MCP: `task_list` supports `status: "dead_letter"` filter
- Queue summary excludes dead-lettered tasks (same as cancelled)

Closes #246

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` zero warnings
- [x] `cargo test` — all 253+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)