### PR TITLE
feat: retry policy with attempt counter and backoff (#245)

### DIFF
--- a/src/app/statemachine.rs
+++ b/src/app/statemachine.rs
@@ -306,6 +306,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "in_review".into(),
@@ -319,6 +320,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "in_review".into(),
@@ -332,6 +334,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "*".into(),
@@ -345,6 +348,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
             ],
         }

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -46,6 +46,11 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Public save — used by workflow engine to update task fields after creation.
+    pub fn save_pub(&self, task: &Task) -> Result<()> {
+        self.save(task)
+    }
+
     pub fn load(&self, id: &str) -> Result<Task> {
         let path = self.task_path(id);
         let content =
@@ -125,6 +130,9 @@ impl TaskStore {
             turns: None,
             metadata,
             timed_out_at: None,
+            attempt: 0,
+            max_retries: 0,
+            retry_after: None,
         };
 
         self.save(&task)?;
@@ -187,6 +195,7 @@ impl TaskStore {
             return Ok(None);
         }
 
+        let now = chrono::Utc::now();
         let mut pending: Vec<Task> = Vec::new();
         for entry in std::fs::read_dir(&self.dir)? {
             let entry = entry?;
@@ -196,7 +205,9 @@ impl TaskStore {
                 && let Ok(dto) = serde_json::from_str::<StoredTask>(&content)
             {
                 let task: Task = dto.into();
-                if task.status == TaskStatus::Pending {
+                if task.status == TaskStatus::Pending
+                    && !crate::domain::task::is_retry_pending(&task, &now)
+                {
                     pending.push(task);
                 }
             }
@@ -256,7 +267,11 @@ impl TaskStore {
         Ok(task)
     }
 
-    /// Mark a task as failed.
+    /// Mark a task as failed, or retry if attempts remain.
+    ///
+    /// If `attempt < max_retries`, resets to Pending with incremented attempt
+    /// counter and exponential backoff. If retries are exhausted, moves to
+    /// DeadLetter. If no retries configured, moves to Failed.
     pub fn fail(&self, id: &str, error_msg: &str) -> Result<Task> {
         let mut task = self.load(id)?;
         if task.status != TaskStatus::Active {
@@ -266,9 +281,28 @@ impl TaskStore {
                 task.status
             );
         }
-        task.status = TaskStatus::Failed;
-        task.error = Some(error_msg.to_string());
-        task.updated_at = Utc::now().to_rfc3339();
+
+        let next_attempt = task.attempt + 1;
+        if next_attempt <= task.max_retries {
+            // Retry: reset to Pending with backoff.
+            task.status = TaskStatus::Pending;
+            task.attempt = next_attempt;
+            task.assignee = None;
+            task.error = Some(error_msg.to_string());
+            task.retry_after = Some(crate::domain::task::compute_retry_after(next_attempt));
+            task.updated_at = Utc::now().to_rfc3339();
+        } else if task.max_retries > 0 {
+            // Exhausted all retries — dead letter.
+            task.status = TaskStatus::DeadLetter;
+            task.error = Some(error_msg.to_string());
+            task.updated_at = Utc::now().to_rfc3339();
+        } else {
+            // No retries configured — plain failure.
+            task.status = TaskStatus::Failed;
+            task.error = Some(error_msg.to_string());
+            task.updated_at = Utc::now().to_rfc3339();
+        }
+
         self.save(&task)?;
         Ok(task)
     }

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -286,10 +286,16 @@ async fn dispatch_instance(
     if let Some(criteria) = transition_criteria {
         // Dispatch via task queue (pull-based).
         let store = crate::app::task::TaskStore::default_for_home();
-        let task = store.create_for_sm(&task_text, criteria, "workflow-engine", &inst.id)?;
+        let max_retries = transition_def.map(|t| t.max_retries).unwrap_or(0);
+        let mut task = store.create_for_sm(&task_text, criteria, "workflow-engine", &inst.id)?;
+        if max_retries > 0 {
+            task.max_retries = max_retries;
+            store.save_pub(&task)?;
+        }
         info!(
             instance = %inst.id,
             task_id = %task.id,
+            max_retries = max_retries,
             "task created in queue for SM dispatch"
         );
         return Ok(());
@@ -415,6 +421,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "review".into(),
@@ -428,6 +435,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "review".into(),
@@ -441,6 +449,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
             ],
         }
@@ -509,6 +518,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "a".into(),
@@ -522,6 +532,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
             ],
         };
@@ -611,6 +622,7 @@ mod tests {
                         model: Some("claude-sonnet-4-6".into()),
                         labels: vec!["planning".into()],
                     }),
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "planning".into(),
@@ -627,6 +639,7 @@ mod tests {
                         model: Some("claude-sonnet-4-6".into()),
                         labels: vec![],
                     }),
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "implementing".into(),
@@ -640,6 +653,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
             ],
         }

--- a/src/domain/statemachine.rs
+++ b/src/domain/statemachine.rs
@@ -30,6 +30,8 @@ pub struct TransitionDef {
     /// Task queue criteria for this transition (model, labels).
     /// When set, dispatch creates a task in the queue instead of direct bus message.
     pub criteria: Option<crate::domain::task::TaskCriteria>,
+    /// Maximum number of retries for tasks dispatched by this transition (default 0).
+    pub max_retries: u32,
 }
 
 /// An instance of a state machine model.

--- a/src/domain/task.rs
+++ b/src/domain/task.rs
@@ -63,6 +63,12 @@ pub struct Task {
     pub metadata: serde_json::Value,
     /// Timestamp when the task was timed out by the sweep loop (RFC 3339).
     pub timed_out_at: Option<String>,
+    /// Current attempt number (0-based). Incremented on each retry.
+    pub attempt: u32,
+    /// Maximum number of retries before moving to DeadLetter. 0 means no retry.
+    pub max_retries: u32,
+    /// RFC 3339 timestamp before which this task should not be claimed (backoff).
+    pub retry_after: Option<String>,
 }
 
 /// Summary of the queue for status display.
@@ -71,6 +77,29 @@ pub struct QueueSummary {
     pub active: usize,
     pub done: usize,
     pub failed: usize,
+}
+
+/// Compute the `retry_after` timestamp using exponential backoff.
+/// Formula: `min(30s * 2^attempt, 5m)` from now.
+pub fn compute_retry_after(attempt: u32) -> String {
+    let base_secs: u64 = 30;
+    let max_secs: u64 = 300; // 5 minutes
+    let backoff_secs = std::cmp::min(
+        base_secs.saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1))),
+        max_secs,
+    );
+    let retry_at = chrono::Utc::now() + chrono::Duration::seconds(backoff_secs as i64);
+    retry_at.to_rfc3339()
+}
+
+/// Check if a task is pending retry (has a `retry_after` in the future).
+pub fn is_retry_pending(task: &Task, now: &chrono::DateTime<chrono::Utc>) -> bool {
+    if let Some(ref retry_after) = task.retry_after
+        && let Ok(retry_time) = chrono::DateTime::parse_from_rfc3339(retry_after)
+    {
+        return retry_time > *now;
+    }
+    false
 }
 
 /// Check if a task's criteria match a worker's capabilities.
@@ -131,5 +160,75 @@ mod tests {
             "any",
             &["y".into()]
         ));
+    }
+
+    #[test]
+    fn test_compute_retry_after_backoff() {
+        // attempt 1 -> 30s
+        let before = chrono::Utc::now();
+        let ts = compute_retry_after(1);
+        let parsed = chrono::DateTime::parse_from_rfc3339(&ts).unwrap();
+        let diff = parsed.signed_duration_since(before);
+        assert!(diff.num_seconds() >= 29 && diff.num_seconds() <= 31);
+
+        // attempt 2 -> 60s
+        let before = chrono::Utc::now();
+        let ts = compute_retry_after(2);
+        let parsed = chrono::DateTime::parse_from_rfc3339(&ts).unwrap();
+        let diff = parsed.signed_duration_since(before);
+        assert!(diff.num_seconds() >= 59 && diff.num_seconds() <= 61);
+
+        // attempt 4 -> 240s
+        let before = chrono::Utc::now();
+        let ts = compute_retry_after(4);
+        let parsed = chrono::DateTime::parse_from_rfc3339(&ts).unwrap();
+        let diff = parsed.signed_duration_since(before);
+        assert!(diff.num_seconds() >= 239 && diff.num_seconds() <= 241);
+
+        // attempt 5 -> capped at 300s (5min)
+        let before = chrono::Utc::now();
+        let ts = compute_retry_after(5);
+        let parsed = chrono::DateTime::parse_from_rfc3339(&ts).unwrap();
+        let diff = parsed.signed_duration_since(before);
+        assert!(diff.num_seconds() >= 299 && diff.num_seconds() <= 301);
+    }
+
+    #[test]
+    fn test_is_retry_pending() {
+        let now = chrono::Utc::now();
+        let future = (now + chrono::Duration::seconds(60)).to_rfc3339();
+        let past = (now - chrono::Duration::seconds(60)).to_rfc3339();
+
+        let mut task = Task {
+            id: "t1".into(),
+            description: "test".into(),
+            status: TaskStatus::Pending,
+            criteria: TaskCriteria::default(),
+            assignee: None,
+            result: None,
+            error: None,
+            created_at: now.to_rfc3339(),
+            updated_at: now.to_rfc3339(),
+            created_by: "test".into(),
+            sm_instance_id: None,
+            cost_usd: None,
+            turns: None,
+            metadata: serde_json::Value::Null,
+            timed_out_at: None,
+            attempt: 1,
+            max_retries: 3,
+            retry_after: Some(future),
+        };
+
+        // Future retry_after -> pending
+        assert!(is_retry_pending(&task, &now));
+
+        // Past retry_after -> not pending
+        task.retry_after = Some(past);
+        assert!(!is_retry_pending(&task, &now));
+
+        // No retry_after -> not pending
+        task.retry_after = None;
+        assert!(!is_retry_pending(&task, &now));
     }
 }

--- a/src/infra/dto.rs
+++ b/src/infra/dto.rs
@@ -126,6 +126,12 @@ pub struct StoredTask {
     pub metadata: serde_json::Value,
     #[serde(default)]
     pub timed_out_at: Option<String>,
+    #[serde(default)]
+    pub attempt: u32,
+    #[serde(default)]
+    pub max_retries: u32,
+    #[serde(default)]
+    pub retry_after: Option<String>,
 }
 
 /// Storage format for task matching criteria.
@@ -171,6 +177,9 @@ impl From<StoredTask> for Task {
             turns: dto.turns,
             metadata: dto.metadata,
             timed_out_at: dto.timed_out_at,
+            attempt: dto.attempt,
+            max_retries: dto.max_retries,
+            retry_after: dto.retry_after,
         }
     }
 }
@@ -204,6 +213,9 @@ impl From<&Task> for StoredTask {
             turns: task.turns,
             metadata: task.metadata.clone(),
             timed_out_at: task.timed_out_at.clone(),
+            attempt: task.attempt,
+            max_retries: task.max_retries,
+            retry_after: task.retry_after.clone(),
         }
     }
 }
@@ -423,6 +435,8 @@ pub struct ConfigTransitionDef {
     pub timeout_goto: Option<String>,
     #[serde(default)]
     pub criteria: Option<ConfigTaskCriteria>,
+    #[serde(default)]
+    pub max_retries: u32,
 }
 
 /// Config-level task criteria (serde for YAML parsing).
@@ -474,6 +488,7 @@ impl From<ConfigTransitionDef> for TransitionDef {
             timeout: dto.timeout,
             timeout_goto: dto.timeout_goto,
             criteria: dto.criteria.map(Into::into),
+            max_retries: dto.max_retries,
         }
     }
 }
@@ -492,6 +507,7 @@ impl From<&TransitionDef> for ConfigTransitionDef {
             timeout: t.timeout.clone(),
             timeout_goto: t.timeout_goto.clone(),
             criteria: t.criteria.as_ref().map(Into::into),
+            max_retries: t.max_retries,
         }
     }
 }
@@ -793,6 +809,9 @@ mod tests {
             turns: None,
             metadata: serde_json::Value::Null,
             timed_out_at: None,
+            attempt: 0,
+            max_retries: 0,
+            retry_after: None,
         };
         let stored: StoredTask = (&task).into();
         assert_eq!(stored.status, "active");

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -97,6 +97,9 @@ impl TaskWriter for InMemoryTaskStore {
             turns: None,
             metadata: serde_json::Value::Null,
             timed_out_at: None,
+            attempt: 0,
+            max_retries: 0,
+            retry_after: None,
         };
         let dto: StoredTask = (&task).into();
         self.tasks.lock().unwrap().insert(id, dto);
@@ -153,6 +156,7 @@ impl TaskWriter for InMemoryTaskStore {
         agent_labels: &[String],
     ) -> Result<Option<Task>> {
         let mut tasks = self.tasks.lock().unwrap();
+        let now = chrono::Utc::now();
         let mut pending: Vec<String> = tasks
             .values()
             .cloned()
@@ -160,6 +164,7 @@ impl TaskWriter for InMemoryTaskStore {
             .filter(|t| {
                 t.status == TaskStatus::Pending
                     && matches_criteria(&t.criteria, agent_model, agent_labels)
+                    && !crate::domain::task::is_retry_pending(t, &now)
             })
             .map(|t| t.id.clone())
             .collect();
@@ -211,9 +216,28 @@ impl TaskWriter for InMemoryTaskStore {
         if task.status != TaskStatus::Active {
             bail!("Cannot fail task '{}': status is '{}'", id, task.status);
         }
-        task.status = TaskStatus::Failed;
-        task.error = Some(error_msg.to_string());
-        task.updated_at = chrono::Utc::now().to_rfc3339();
+
+        let next_attempt = task.attempt + 1;
+        if next_attempt <= task.max_retries {
+            // Retry: reset to Pending with backoff.
+            task.status = TaskStatus::Pending;
+            task.attempt = next_attempt;
+            task.assignee = None;
+            task.error = Some(error_msg.to_string());
+            task.retry_after = Some(crate::domain::task::compute_retry_after(next_attempt));
+            task.updated_at = chrono::Utc::now().to_rfc3339();
+        } else if task.max_retries > 0 {
+            // Exhausted all retries — dead letter.
+            task.status = TaskStatus::DeadLetter;
+            task.error = Some(error_msg.to_string());
+            task.updated_at = chrono::Utc::now().to_rfc3339();
+        } else {
+            // No retries configured — plain failure.
+            task.status = TaskStatus::Failed;
+            task.error = Some(error_msg.to_string());
+            task.updated_at = chrono::Utc::now().to_rfc3339();
+        }
+
         tasks.insert(id.to_string(), (&task).into());
         Ok(task)
     }
@@ -444,6 +468,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
                 TransitionDef {
                     from: "in_review".to_string(),
@@ -457,6 +482,7 @@ mod tests {
                     timeout: None,
                     timeout_goto: None,
                     criteria: None,
+                    max_retries: 0,
                 },
             ],
         };
@@ -489,5 +515,81 @@ mod tests {
 
         let all = store.list_all().unwrap();
         assert_eq!(all.len(), 1);
+    }
+
+    #[test]
+    fn test_retry_on_fail_resets_to_pending() {
+        let store = InMemoryTaskStore::new();
+        let mut task = store
+            .create("Retryable task", TaskCriteria::default(), "kira")
+            .unwrap();
+
+        // Set max_retries on the task (simulating SM dispatch setting it).
+        task.max_retries = 2;
+        let dto: crate::infra::dto::StoredTask = (&task).into();
+        store.tasks.lock().unwrap().insert(task.id.clone(), dto);
+
+        // Claim and fail the task — should retry (attempt 0 -> 1, max_retries=2).
+        let claimed = store.claim_next("w1", "any", &[]).unwrap().unwrap();
+        assert_eq!(claimed.id, task.id);
+
+        let failed = store.fail(&claimed.id, "transient error").unwrap();
+        assert_eq!(failed.status, TaskStatus::Pending);
+        assert_eq!(failed.attempt, 1);
+        assert!(failed.retry_after.is_some());
+        assert!(failed.assignee.is_none());
+        assert_eq!(failed.error.as_deref(), Some("transient error"));
+    }
+
+    #[test]
+    fn test_retry_exhausted_goes_to_dead_letter() {
+        let store = InMemoryTaskStore::new();
+        let mut task = store
+            .create("Retryable task", TaskCriteria::default(), "kira")
+            .unwrap();
+
+        // Set max_retries=1, attempt=1 (already retried once).
+        task.max_retries = 1;
+        task.attempt = 1;
+        let dto: crate::infra::dto::StoredTask = (&task).into();
+        store.tasks.lock().unwrap().insert(task.id.clone(), dto);
+
+        // Claim and fail — should go to DeadLetter (attempt 1+1=2 > max_retries=1).
+        let claimed = store.claim_next("w1", "any", &[]).unwrap().unwrap();
+        let result = store.fail(&claimed.id, "permanent error").unwrap();
+        assert_eq!(result.status, TaskStatus::DeadLetter);
+    }
+
+    #[test]
+    fn test_no_retry_configured_goes_to_failed() {
+        let store = InMemoryTaskStore::new();
+        let task = store
+            .create("No-retry task", TaskCriteria::default(), "kira")
+            .unwrap();
+        assert_eq!(task.max_retries, 0);
+
+        let claimed = store.claim_next("w1", "any", &[]).unwrap().unwrap();
+        let result = store.fail(&claimed.id, "error").unwrap();
+        assert_eq!(result.status, TaskStatus::Failed);
+    }
+
+    #[test]
+    fn test_claim_next_skips_retry_pending_tasks() {
+        let store = InMemoryTaskStore::new();
+        let mut task = store
+            .create("Retry-pending task", TaskCriteria::default(), "kira")
+            .unwrap();
+
+        // Set retry_after to 1 hour in the future.
+        let future = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        task.retry_after = Some(future);
+        task.attempt = 1;
+        task.max_retries = 3;
+        let dto: crate::infra::dto::StoredTask = (&task).into();
+        store.tasks.lock().unwrap().insert(task.id.clone(), dto);
+
+        // claim_next should return None (task is pending but retry_after is in future).
+        let claimed = store.claim_next("w1", "any", &[]).unwrap();
+        assert!(claimed.is_none());
     }
 }

--- a/tests/workflow_transitions.rs
+++ b/tests/workflow_transitions.rs
@@ -93,6 +93,7 @@ fn test_model() -> deskd::config::ModelDef {
                 timeout: None,
                 timeout_goto: None,
                 criteria: None,
+                max_retries: 0,
             },
             deskd::config::TransitionDef {
                 from: "review".into(),
@@ -106,6 +107,7 @@ fn test_model() -> deskd::config::ModelDef {
                 timeout: None,
                 timeout_goto: None,
                 criteria: None,
+                max_retries: 0,
             },
             deskd::config::TransitionDef {
                 from: "review".into(),
@@ -119,6 +121,7 @@ fn test_model() -> deskd::config::ModelDef {
                 timeout: None,
                 timeout_goto: None,
                 criteria: None,
+                max_retries: 0,
             },
         ],
     }


### PR DESCRIPTION
## Summary
- Add `attempt`, `max_retries`, and `retry_after` fields to Task domain type and StoredTask DTO with backward-compatible defaults (0, 0, None)
- Add `max_retries` field to `TransitionDef` (SM config) so transitions can configure retry behavior for dispatched tasks
- Update `fail()` in both file-based and in-memory stores: if retries remain, reset to Pending with incremented attempt and exponential backoff (`min(30s * 2^attempt, 5m)`); if exhausted, move to DeadLetter; if no retries configured, plain Failed
- Update `claim_next()` in both stores to skip tasks with `retry_after` in the future
- Workflow engine propagates `max_retries` from TransitionDef to tasks created via SM dispatch

## Test plan
- [x] Unit tests for `compute_retry_after` backoff formula (30s, 60s, 240s, 300s cap)
- [x] Unit test for `is_retry_pending` with future/past/None timestamps
- [x] Test: fail with retries remaining resets to Pending with incremented attempt
- [x] Test: fail with retries exhausted moves to DeadLetter
- [x] Test: fail with max_retries=0 moves to Failed (backward compat)
- [x] Test: claim_next skips tasks with future retry_after
- [x] All existing tests pass (`cargo test`)
- [x] Quality gate: `cargo fmt && cargo clippy -- -D warnings && cargo test`

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)