### PR TITLE
fix: chown .deskd directory to agent unix_user on startup (#267)

### DIFF
--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -5,6 +5,7 @@ use tracing::info;
 
 use crate::app::{adapters, agent, bus, schedule, worker, workflow};
 use crate::config;
+use crate::infra::paths;
 
 /// Start per-agent buses and workers for all agents in workspace config.
 /// Each agent has its own isolated bus at {work_dir}/.deskd/bus.sock.
@@ -52,9 +53,9 @@ pub async fn serve(config_path: String) -> Result<()> {
         let name = state.config.name.clone();
         let bus_socket = def.bus_socket();
 
-        // Ensure {work_dir}/.deskd/ exists.
+        // Ensure {work_dir}/.deskd/ exists and is owned by the agent's unix user.
         let bus_dir = std::path::Path::new(&def.work_dir).join(".deskd");
-        std::fs::create_dir_all(&bus_dir)?;
+        paths::ensure_dir_owned(&bus_dir, def.unix_user.as_deref())?;
 
         // Start the agent's isolated bus.
         {

--- a/src/infra/paths.rs
+++ b/src/infra/paths.rs
@@ -2,7 +2,54 @@
 //!
 //! All paths are relative to `$HOME/.deskd/`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Ensure a directory exists and is owned by `unix_user` (if provided).
+///
+/// When `deskd serve` runs as root but agents run as a different user
+/// (via `unix_user` in workspace.yaml), directories created by the serve
+/// process would be owned by root. This helper chowns the directory tree
+/// to the target user so agents can write to it.
+pub fn ensure_dir_owned(dir: &Path, unix_user: Option<&str>) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+
+    #[cfg(unix)]
+    if let Some(user) = unix_user {
+        chown_recursive(dir, user);
+    }
+
+    let _ = unix_user; // suppress unused warning on non-unix
+    Ok(())
+}
+
+/// Recursively chown a directory tree to the given unix user.
+#[cfg(unix)]
+fn chown_recursive(dir: &Path, user: &str) {
+    use std::process::Command;
+    // Use chown -R to set ownership on the directory and all contents.
+    match Command::new("chown")
+        .args(["-R", &format!("{user}:{user}"), &dir.to_string_lossy()])
+        .status()
+    {
+        Ok(s) if !s.success() => {
+            tracing::warn!(
+                dir = %dir.display(),
+                user = %user,
+                exit_code = s.code().unwrap_or(-1),
+                "chown .deskd directory failed (not running as root?)"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                dir = %dir.display(),
+                user = %user,
+                error = %e,
+                "failed to run chown on .deskd directory"
+            );
+        }
+        _ => {}
+    }
+}
 
 /// Where agent state files are stored: `~/.deskd/agents/`.
 pub fn state_dir() -> PathBuf {
@@ -36,4 +83,34 @@ pub fn agent_bus_socket(work_dir: &str) -> String {
         .join("bus.sock")
         .to_string_lossy()
         .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_dir_owned_creates_directory() {
+        let base = std::env::temp_dir().join("deskd-test-ensure-dir-owned");
+        let _ = std::fs::remove_dir_all(&base);
+        let target = base.join("sub").join("nested");
+        assert!(!target.exists());
+
+        ensure_dir_owned(&target, None).unwrap();
+        assert!(target.is_dir());
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn ensure_dir_owned_idempotent() {
+        let base = std::env::temp_dir().join("deskd-test-ensure-dir-idempotent");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+
+        ensure_dir_owned(&base, None).unwrap();
+        assert!(base.is_dir());
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `ensure_dir_owned()` helper in `infra/paths.rs` that creates a directory and recursively chowns it to the agent's `unix_user`
- Use it in `serve.rs` when creating `{work_dir}/.deskd/` so agents can write subdirectories (reminders, logs, etc.) without sudo
- Logs a warning if chown fails (e.g. not running as root) instead of hard-failing

Closes #267

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 325 tests pass
- [ ] Manual: run `deskd serve` as root with `unix_user: dev`, verify `.deskd/` is owned by `dev:dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)