### PR TITLE
feat: Agent as proper domain entity with capabilities and health (#253)

### DIFF
--- a/src/app/agent.rs
+++ b/src/app/agent.rs
@@ -782,6 +782,57 @@ pub async fn list() -> Result<Vec<AgentState>> {
     Ok(agents)
 }
 
+/// Build a domain `Agent` from an `AgentState`, checking process health.
+///
+/// `live_agents` is the set of agent names currently registered on a bus.
+/// If the agent's PID is gone and it's not in `live_agents`, it's marked Unhealthy.
+pub fn to_domain_agent(
+    state: &AgentState,
+    live_agents: &std::collections::HashSet<String>,
+) -> crate::domain::agent::Agent {
+    use crate::domain::agent::{Agent, AgentCapabilities, AgentRuntime, AgentStatus, SessionMode};
+
+    let runtime = match state.config.runtime {
+        ConfigAgentRuntime::Claude => AgentRuntime::Claude,
+        ConfigAgentRuntime::Acp => AgentRuntime::Acp,
+    };
+
+    let session_mode = match state.config.session {
+        ConfigSessionMode::Persistent => SessionMode::Persistent,
+        ConfigSessionMode::Ephemeral => SessionMode::Ephemeral,
+    };
+
+    let status = if state.status == "working" {
+        AgentStatus::Busy {
+            task_id: state.current_task.clone(),
+        }
+    } else if live_agents.contains(&state.config.name) {
+        AgentStatus::Ready
+    } else if state.pid > 0 && std::path::Path::new(&format!("/proc/{}", state.pid)).exists() {
+        // Process alive but not yet registered on bus — treat as Ready.
+        AgentStatus::Ready
+    } else if state.pid > 0 {
+        AgentStatus::Unhealthy {
+            since: chrono::Utc::now().to_rfc3339(),
+            reason: format!("process {} not found", state.pid),
+        }
+    } else {
+        // pid == 0 means agent was never started or was cleaned up.
+        AgentStatus::Ready
+    };
+
+    Agent {
+        name: state.config.name.clone(),
+        runtime,
+        session_mode,
+        capabilities: AgentCapabilities {
+            model: state.config.model.clone(),
+            labels: Vec::new(),
+        },
+        status,
+    }
+}
+
 /// Remove an agent (state file + log).
 pub async fn remove(name: &str) -> Result<()> {
     let path = state_path(name);

--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -139,38 +139,36 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 println!("No agents registered");
             } else {
                 println!(
-                    "{:<15} {:<10} {:<8} {:<10} {:<12} MODEL",
+                    "{:<15} {:<12} {:<8} {:<10} {:<12} MODEL",
                     "NAME", "STATUS", "TURNS", "COST", "USER"
                 );
-                for a in agents {
-                    let status = if live.contains(&a.config.name) {
-                        if a.parent.is_some() {
-                            "live[sub]".to_string()
-                        } else {
-                            "live".to_string()
+                for a in &agents {
+                    let domain = agent::to_domain_agent(a, &live);
+                    let status_str = match &domain.status {
+                        crate::domain::agent::AgentStatus::Ready => {
+                            if a.parent.is_some() {
+                                "ready[sub]"
+                            } else {
+                                "ready"
+                            }
                         }
-                    } else if a.pid > 0
-                        && std::path::Path::new(&format!("/proc/{}", a.pid)).exists()
-                    {
-                        // PID is alive but not yet registered on the bus.
-                        if a.parent.is_some() {
-                            "run[sub]".to_string()
-                        } else {
-                            "running".to_string()
+                        crate::domain::agent::AgentStatus::Busy { .. } => {
+                            if a.parent.is_some() {
+                                "busy[sub]"
+                            } else {
+                                "busy"
+                            }
                         }
-                    } else if a.parent.is_some() {
-                        "idle[sub]".to_string()
-                    } else {
-                        "idle".to_string()
+                        crate::domain::agent::AgentStatus::Unhealthy { .. } => "unhealthy",
                     };
                     println!(
-                        "{:<15} {:<10} {:<8} ${:<9.2} {:<12} {}",
-                        a.config.name,
-                        status,
+                        "{:<15} {:<12} {:<8} ${:<9.2} {:<12} {}",
+                        domain.name,
+                        status_str,
                         a.total_turns,
                         a.total_cost,
                         a.config.unix_user.as_deref().unwrap_or("-"),
-                        a.config.model,
+                        domain.capabilities.model,
                     );
                 }
             }

--- a/src/app/mcp_service.rs
+++ b/src/app/mcp_service.rs
@@ -499,21 +499,33 @@ pub fn sm_query(
 
 /// Build a JSON summary for a sub-agent, given its name and worker handle status.
 pub fn build_agent_summary(name: &str, is_finished: bool) -> Value {
-    let (model, turns, cost_usd) = match crate::app::agent::load_state(name) {
-        Ok(state) => (
-            state.config.model.clone(),
-            state.total_turns,
-            state.total_cost,
-        ),
-        Err(_) => ("unknown".to_string(), 0, 0.0),
+    let (model, turns, cost_usd, agent_status) = match crate::app::agent::load_state(name) {
+        Ok(state) => {
+            let live = if is_finished {
+                std::collections::HashSet::new()
+            } else {
+                let mut s = std::collections::HashSet::new();
+                s.insert(name.to_string());
+                s
+            };
+            let domain = crate::app::agent::to_domain_agent(&state, &live);
+            (
+                state.config.model.clone(),
+                state.total_turns,
+                state.total_cost,
+                domain.status.to_string(),
+            )
+        }
+        Err(_) => {
+            let status = if is_finished { "finished" } else { "unknown" };
+            ("unknown".to_string(), 0, 0.0, status.to_string())
+        }
     };
-
-    let status = if is_finished { "finished" } else { "running" };
 
     json!({
         "name": name,
         "model": model,
-        "status": status,
+        "status": agent_status,
         "turns": turns,
         "cost_usd": cost_usd,
     })

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -20,3 +20,152 @@ pub enum AgentRuntime {
     /// Agent Client Protocol (ACP) — JSON-RPC 2.0 over stdin/stdout.
     Acp,
 }
+
+/// Domain-level representation of an agent with capabilities and status.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Agent {
+    pub name: String,
+    pub runtime: AgentRuntime,
+    pub session_mode: SessionMode,
+    pub capabilities: AgentCapabilities,
+    pub status: AgentStatus,
+}
+
+/// What an agent can do — model and labels for routing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentCapabilities {
+    pub model: String,
+    pub labels: Vec<String>,
+}
+
+/// Current status of an agent.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentStatus {
+    /// Agent is idle and ready for work.
+    Ready,
+    /// Agent is executing a task.
+    Busy { task_id: String },
+    /// Agent process is dead or unreachable.
+    Unhealthy { since: String, reason: String },
+}
+
+impl AgentStatus {
+    /// Short display label.
+    pub fn label(&self) -> &str {
+        match self {
+            AgentStatus::Ready => "ready",
+            AgentStatus::Busy { .. } => "busy",
+            AgentStatus::Unhealthy { .. } => "unhealthy",
+        }
+    }
+}
+
+impl std::fmt::Display for AgentStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AgentStatus::Ready => write!(f, "ready"),
+            AgentStatus::Busy { task_id } => write!(f, "busy ({})", task_id),
+            AgentStatus::Unhealthy { reason, .. } => write!(f, "unhealthy: {}", reason),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_status_labels() {
+        assert_eq!(AgentStatus::Ready.label(), "ready");
+        assert_eq!(
+            AgentStatus::Busy {
+                task_id: "t1".into()
+            }
+            .label(),
+            "busy"
+        );
+        assert_eq!(
+            AgentStatus::Unhealthy {
+                since: "2026-01-01".into(),
+                reason: "process dead".into()
+            }
+            .label(),
+            "unhealthy"
+        );
+    }
+
+    #[test]
+    fn agent_status_display() {
+        assert_eq!(format!("{}", AgentStatus::Ready), "ready");
+        assert_eq!(
+            format!(
+                "{}",
+                AgentStatus::Busy {
+                    task_id: "task-42".into()
+                }
+            ),
+            "busy (task-42)"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                AgentStatus::Unhealthy {
+                    since: "2026-01-01".into(),
+                    reason: "pid gone".into()
+                }
+            ),
+            "unhealthy: pid gone"
+        );
+    }
+
+    #[test]
+    fn agent_entity_construction() {
+        let agent = Agent {
+            name: "dev".into(),
+            runtime: AgentRuntime::Claude,
+            session_mode: SessionMode::Persistent,
+            capabilities: AgentCapabilities {
+                model: "claude-sonnet-4-6".into(),
+                labels: vec!["coding".into(), "review".into()],
+            },
+            status: AgentStatus::Ready,
+        };
+        assert_eq!(agent.name, "dev");
+        assert_eq!(agent.capabilities.model, "claude-sonnet-4-6");
+        assert_eq!(agent.capabilities.labels.len(), 2);
+        assert_eq!(agent.status.label(), "ready");
+    }
+
+    #[test]
+    fn agent_busy_status_carries_task_id() {
+        let status = AgentStatus::Busy {
+            task_id: "abc-123".into(),
+        };
+        assert_eq!(status.label(), "busy");
+        if let AgentStatus::Busy { task_id } = &status {
+            assert_eq!(task_id, "abc-123");
+        } else {
+            panic!("expected Busy");
+        }
+    }
+
+    #[test]
+    fn agent_unhealthy_carries_reason() {
+        let status = AgentStatus::Unhealthy {
+            since: "2026-04-06T00:00:00Z".into(),
+            reason: "process exited".into(),
+        };
+        assert_eq!(status.label(), "unhealthy");
+        assert!(format!("{status}").contains("process exited"));
+    }
+
+    #[test]
+    fn default_session_mode_is_persistent() {
+        assert_eq!(SessionMode::default(), SessionMode::Persistent);
+    }
+
+    #[test]
+    fn default_runtime_is_claude() {
+        assert_eq!(AgentRuntime::default(), AgentRuntime::Claude);
+    }
+}


### PR DESCRIPTION
## Summary
- Promote `domain::agent` from two bare enums to full domain entity: `Agent`, `AgentCapabilities`, `AgentStatus` (Ready/Busy/Unhealthy)
- Add `to_domain_agent()` in `app::agent` that converts `AgentState` + live bus set → domain `Agent` with health check (checks `/proc/{pid}`)
- `deskd agent list` now shows domain status (ready/busy/unhealthy) instead of ad-hoc string logic
- MCP `list_agents` uses domain status instead of raw running/finished strings
- 7 unit tests covering status labels, Display impl, entity construction

Closes #253

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo test` — 293 tests pass, 0 failures
- [ ] Manual: `deskd agent list` shows ready/busy/unhealthy status
- [ ] Manual: MCP `list_agents` returns domain status in JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)