### PR TITLE
arch: Task owned by SM Instance aggregate (#255)

### DIFF
--- a/src/app/commands/sm.rs
+++ b/src/app/commands/sm.rs
@@ -171,6 +171,13 @@ pub async fn handle(
                     inst.total_cost, inst.total_turns
                 );
             }
+            if !inst.task_ids.is_empty() {
+                println!(
+                    "Tasks:     {} ({})",
+                    inst.task_ids.len(),
+                    inst.task_ids.join(", ")
+                );
+            }
             if !inst.history.is_empty() {
                 println!();
                 println!(

--- a/src/app/statemachine.rs
+++ b/src/app/statemachine.rs
@@ -109,6 +109,7 @@ impl StateMachineStore {
             metadata: serde_json::Value::Null,
             total_cost: 0.0,
             total_turns: 0,
+            task_ids: Vec::new(),
         };
         self.save(&inst)?;
         info!(id = %inst.id, model = %inst.model, state = %inst.state, "instance created");
@@ -513,6 +514,7 @@ mod tests {
             metadata: serde_json::Value::Null,
             total_cost: 0.0,
             total_turns: 0,
+            task_ids: Vec::new(),
         };
         assert!(!is_terminal(&model, &inst_open));
 

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -500,13 +500,14 @@ async fn dispatch_instance(
     );
     let task_id = dispatch_work_item(writer, model, inst, &work_item).await?;
 
-    // Link the task_id to the last transition in the instance history.
+    // Link the task_id to the instance aggregate and the last transition.
     if let Some(task_id) = task_id {
         let store = statemachine::StateMachineStore::default_for_home();
-        if let Ok(mut updated_inst) = store.load(&inst.id)
-            && let Some(last) = updated_inst.history.last_mut()
-        {
-            last.task_id = Some(task_id);
+        if let Ok(mut updated_inst) = store.load(&inst.id) {
+            updated_inst.record_task(&task_id);
+            if let Some(last) = updated_inst.history.last_mut() {
+                last.task_id = Some(task_id);
+            }
             let _ = store.save(&updated_inst);
         }
     }
@@ -1013,6 +1014,7 @@ mod tests {
             metadata: serde_json::Value::Null,
             total_cost: 0.0,
             total_turns: 0,
+            task_ids: Vec::new(),
         };
         let text = build_task_text("Review this code.", &inst);
         assert!(text.contains("Review this code."));
@@ -1039,6 +1041,7 @@ mod tests {
             metadata: serde_json::Value::Null,
             total_cost: 0.0,
             total_turns: 0,
+            task_ids: Vec::new(),
         };
         let text = build_task_text("", &inst);
         assert!(text.contains("Previous output here"));
@@ -1304,6 +1307,7 @@ mod tests {
             metadata: serde_json::Value::Null,
             total_cost: 0.0,
             total_turns: 0,
+            task_ids: Vec::new(),
         }
     }
 

--- a/src/domain/statemachine.rs
+++ b/src/domain/statemachine.rs
@@ -98,6 +98,22 @@ pub struct Instance {
     pub total_cost: f64,
     /// Cumulative turns across all transitions.
     pub total_turns: u32,
+    /// Task IDs owned by this instance (current and historical).
+    pub task_ids: Vec<String>,
+}
+
+impl Instance {
+    /// Record a task as owned by this instance.
+    pub fn record_task(&mut self, task_id: &str) {
+        if !self.task_ids.contains(&task_id.to_string()) {
+            self.task_ids.push(task_id.to_string());
+        }
+    }
+
+    /// Get the current (most recently dispatched) task ID, if any.
+    pub fn current_task_id(&self) -> Option<&str> {
+        self.history.last().and_then(|h| h.task_id.as_deref())
+    }
 }
 
 /// A recorded transition in the instance history.
@@ -146,5 +162,61 @@ mod tests {
         assert_eq!(StepType::Check.to_string(), "check");
         assert_eq!(StepType::Validate.to_string(), "validate");
         assert_eq!(StepType::Human.to_string(), "human");
+    }
+
+    fn make_test_instance() -> Instance {
+        Instance {
+            id: "sm-test".into(),
+            model: "test".into(),
+            title: "Test".into(),
+            body: String::new(),
+            state: "open".into(),
+            assignee: "dev".into(),
+            result: None,
+            error: None,
+            created_by: "test".into(),
+            created_at: String::new(),
+            updated_at: String::new(),
+            history: vec![Transition {
+                from: "new".into(),
+                to: "open".into(),
+                trigger: "auto".into(),
+                timestamp: String::new(),
+                note: None,
+                cost_usd: None,
+                turns: None,
+                task_id: Some("task-abc".into()),
+            }],
+            metadata: serde_json::Value::Null,
+            total_cost: 0.0,
+            total_turns: 0,
+            task_ids: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_record_task() {
+        let mut inst = make_test_instance();
+        assert!(inst.task_ids.is_empty());
+
+        inst.record_task("task-001");
+        assert_eq!(inst.task_ids, vec!["task-001"]);
+
+        // Duplicate is not added.
+        inst.record_task("task-001");
+        assert_eq!(inst.task_ids.len(), 1);
+
+        inst.record_task("task-002");
+        assert_eq!(inst.task_ids, vec!["task-001", "task-002"]);
+    }
+
+    #[test]
+    fn test_current_task_id() {
+        let inst = make_test_instance();
+        assert_eq!(inst.current_task_id(), Some("task-abc"));
+
+        let mut inst2 = inst;
+        inst2.history.clear();
+        assert_eq!(inst2.current_task_id(), None);
     }
 }

--- a/src/infra/dto.rs
+++ b/src/infra/dto.rs
@@ -246,6 +246,9 @@ pub struct StoredInstance {
     pub total_cost: f64,
     #[serde(default)]
     pub total_turns: u32,
+    /// Task IDs owned by this instance.
+    #[serde(default)]
+    pub task_ids: Vec<String>,
 }
 
 /// Storage format for a recorded state transition.
@@ -285,6 +288,7 @@ impl From<StoredInstance> for Instance {
             metadata: dto.metadata,
             total_cost: dto.total_cost,
             total_turns: dto.total_turns,
+            task_ids: dto.task_ids,
         }
     }
 }
@@ -307,6 +311,7 @@ impl From<&Instance> for StoredInstance {
             metadata: inst.metadata.clone(),
             total_cost: inst.total_cost,
             total_turns: inst.total_turns,
+            task_ids: inst.task_ids.clone(),
         }
     }
 }
@@ -876,6 +881,7 @@ mod tests {
             metadata: serde_json::json!({}),
             total_cost: 0.0,
             total_turns: 0,
+            task_ids: vec!["task-abc123".into()],
         };
         let stored: StoredInstance = (&inst).into();
         let restored: Instance = stored.into();

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -340,6 +340,7 @@ impl StateMachineWriter for InMemoryStateMachineStore {
             metadata: serde_json::Value::Null,
             total_cost: 0.0,
             total_turns: 0,
+            task_ids: Vec::new(),
         };
         let dto: StoredInstance = (&inst).into();
         self.instances.lock().unwrap().insert(id, dto);


### PR DESCRIPTION
## Summary
- `Instance` gains `task_ids: Vec<String>` — the aggregate now tracks all tasks created for its lifecycle
- `Instance::record_task()` adds a task ID (dedup), `current_task_id()` returns latest
- `dispatch_instance` calls `record_task()` after creating a task, persisting the linkage
- `StoredInstance` serializes `task_ids` with `#[serde(default)]` for backward compatibility
- `deskd sm status` shows task count and IDs
- Standalone tasks (not linked to SM) work unchanged
- 2 new domain tests for `record_task` and `current_task_id`

Closes #255

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo test` — 345 tests pass, 0 failures
- [ ] Manual: create SM instance, dispatch steps, verify `task_ids` populated in instance YAML
- [ ] Manual: `deskd sm status <id>` shows "Tasks: N (id1, id2)" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)