### PR TITLE
arch: remove DIP excludes for domain::context and domain::task

### DIFF
--- a/.archlint.yaml
+++ b/.archlint.yaml
@@ -139,8 +139,9 @@ rules:
       # (MessageBus, TaskRepository, StateMachineRepository). The linter cannot infer
       # cross-module trait association, so these are correctly excepted.
       - "src::domain::message"      # 3 structs — value objects for bus protocol
-      - "src::domain::context"      # 5 structs + 1 enum — domain context value objects
-      - "src::domain::task"         # 3 structs — task/result value objects; repo trait in ports/store.rs
+      # domain::context and domain::task removed from excludes (#279) — they contain
+      # business logic (compaction policy, retry backoff, criteria matching) that should
+      # eventually be behind port traits. DIP violations are tracked as telemetry.
       - "src::domain::statemachine" # 4 structs — SM value objects; trait in ports/store.rs
       - "src::domain::agent"        # Agent, AgentCapabilities, AgentStatus, SessionMode, AgentRuntime — pure value objects
       - "src::domain::events"       # DomainEvent enum — pure data, no behaviour


### PR DESCRIPTION
## Summary
- Remove `src::domain::context` and `src::domain::task` from `.archlint.yaml` DIP excludes
- These modules contain business logic (compaction policy, retry backoff, criteria matching) that was incorrectly classified as "pure data carriers"
- DIP violations now tracked as telemetry until logic is extracted into port traits

Closes #279

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass
- [x] archlint DIP rule is telemetry level (not taboo) — CI still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)