### PR TITLE
arch: wire store traits into workflow engine

### DIFF
--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -99,9 +99,10 @@ pub async fn handle(action: AgentAction) -> Result<()> {
             } else {
                 Some(subscribe)
             };
+            let task_store = crate::app::task::TaskStore::default_for_home();
             info!(agent = %name, "starting worker");
             tokio::select! {
-                result = worker::run(&name, &socket, Some(socket.clone()), subs) => { result?; }
+                result = worker::run(&name, &socket, Some(socket.clone()), subs, &task_store) => { result?; }
                 _ = tokio::signal::ctrl_c() => {
                     info!(agent = %name, "shutting down");
                 }

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -141,6 +141,10 @@ pub async fn run(agent_name: &str) -> Result<()> {
     // Lazy-initialized internal bus for sub-agent orchestration.
     let internal_bus: Arc<Mutex<Option<InternalBus>>> = Arc::new(Mutex::new(None));
 
+    // Create stores once at startup — passed as trait references to all handlers.
+    let task_store = crate::app::task::TaskStore::default_for_home();
+    let sm_store = crate::app::statemachine::StateMachineStore::default_for_home();
+
     info!(agent = %agent_name, bus = %bus_socket, "MCP server started");
 
     let stdin = tokio::io::stdin();
@@ -207,6 +211,8 @@ pub async fn run(agent_name: &str) -> Result<()> {
                     &bus_socket,
                     user_config.as_ref(),
                     &internal_bus,
+                    &task_store,
+                    &sm_store,
                 )
                 .await;
                 let mut out = stdout.lock().await;
@@ -265,6 +271,8 @@ async fn handle_request(
     bus_socket: &str,
     user_config: Option<&UserConfig>,
     internal_bus: &Arc<Mutex<Option<InternalBus>>>,
+    task_store: &dyn crate::ports::store::TaskRepository,
+    sm_store: &dyn crate::ports::store::StateMachineRepository,
 ) -> Response {
     let id = req.id.clone();
     match req.method.as_str() {
@@ -272,7 +280,16 @@ async fn handle_request(
         "tools/list" => handle_tools_list(id, agent_name, user_config),
         "tools/call" => {
             let params = req.params.as_ref().unwrap_or(&Value::Null);
-            match handle_tools_call(params, agent_name, bus_socket, user_config, internal_bus).await
+            match handle_tools_call(
+                params,
+                agent_name,
+                bus_socket,
+                user_config,
+                internal_bus,
+                task_store,
+                sm_store,
+            )
+            .await
             {
                 Ok(resp) => Response::ok(id, resp),
                 Err(e) => Response::err(id, -32603, &format!("{:#}", e)),
@@ -637,6 +654,8 @@ async fn handle_tools_call(
     bus_socket: &str,
     user_config: Option<&UserConfig>,
     internal_bus: &Arc<Mutex<Option<InternalBus>>>,
+    task_store: &dyn crate::ports::store::TaskRepository,
+    sm_store: &dyn crate::ports::store::StateMachineRepository,
 ) -> Result<Value> {
     let name = params
         .get("name")
@@ -657,14 +676,14 @@ async fn handle_tools_call(
         "read_inbox" => call_read_inbox(args).await,
         "search_inbox" => call_search_inbox(args).await,
         "run_graph" => call_run_graph(args).await,
-        "task_create" => call_task_create(args, agent_name).await,
-        "task_list" => call_task_list(args).await,
-        "task_cancel" => call_task_cancel(args).await,
+        "task_create" => call_task_create(args, agent_name, task_store).await,
+        "task_list" => call_task_list(args, task_store).await,
+        "task_cancel" => call_task_cancel(args, task_store).await,
         "list_agents" => call_list_agents(internal_bus).await,
         "remove_agent" => call_remove_agent(args, agent_name, internal_bus).await,
-        "sm_create" => call_sm_create(args, agent_name, bus_socket, user_config).await,
-        "sm_move" => call_sm_move(args, agent_name, bus_socket, user_config).await,
-        "sm_query" => call_sm_query(args).await,
+        "sm_create" => call_sm_create(args, agent_name, bus_socket, user_config, sm_store).await,
+        "sm_move" => call_sm_move(args, agent_name, bus_socket, user_config, sm_store).await,
+        "sm_query" => call_sm_query(args, sm_store).await,
         "usage_stats" => call_usage_stats(args).await,
         other => bail!("Unknown tool: {}", other),
     }
@@ -1018,7 +1037,11 @@ async fn call_run_graph(args: &Value) -> Result<Value> {
 
 // ─── Task queue tool implementations ─────────────────────────────────────────
 
-async fn call_task_create(args: &Value, agent_name: &str) -> Result<Value> {
+async fn call_task_create(
+    args: &Value,
+    agent_name: &str,
+    task_store: &dyn crate::ports::store::TaskRepository,
+) -> Result<Value> {
     let description = args
         .get("description")
         .and_then(|d| d.as_str())
@@ -1039,7 +1062,8 @@ async fn call_task_create(args: &Value, agent_name: &str) -> Result<Value> {
         .cloned()
         .unwrap_or(serde_json::Value::Null);
 
-    let result = mcp_service::task_create(description, model, labels, metadata, agent_name)?;
+    let result =
+        mcp_service::task_create(description, model, labels, metadata, agent_name, task_store)?;
 
     Ok(json!({
         "content": [{"type": "text", "text": format!(
@@ -1049,10 +1073,13 @@ async fn call_task_create(args: &Value, agent_name: &str) -> Result<Value> {
     }))
 }
 
-async fn call_task_list(args: &Value) -> Result<Value> {
+async fn call_task_list(
+    args: &Value,
+    task_store: &dyn crate::ports::store::TaskRepository,
+) -> Result<Value> {
     let status_filter = args.get("status").and_then(|s| s.as_str());
 
-    let summary = mcp_service::task_list(status_filter)?;
+    let summary = mcp_service::task_list(status_filter, task_store)?;
 
     Ok(json!({
         "content": [{"type": "text", "text": serde_json::to_string_pretty(&summary)?}],
@@ -1060,13 +1087,16 @@ async fn call_task_list(args: &Value) -> Result<Value> {
     }))
 }
 
-async fn call_task_cancel(args: &Value) -> Result<Value> {
+async fn call_task_cancel(
+    args: &Value,
+    task_store: &dyn crate::ports::store::TaskRepository,
+) -> Result<Value> {
     let id = args
         .get("id")
         .and_then(|i| i.as_str())
         .context("missing id")?;
 
-    let result = mcp_service::task_cancel(id)?;
+    let result = mcp_service::task_cancel(id, task_store)?;
 
     Ok(json!({
         "content": [{"type": "text", "text": format!("Task {} cancelled", result.id)}],
@@ -1149,6 +1179,7 @@ async fn call_sm_create(
     agent_name: &str,
     bus_socket: &str,
     user_config: Option<&UserConfig>,
+    sm_store: &dyn crate::ports::store::StateMachineRepository,
 ) -> Result<Value> {
     let model_name = args
         .get("model")
@@ -1166,7 +1197,7 @@ async fn call_sm_create(
 
     let cfg = user_config.context("no user config loaded — models not available")?;
     let result = mcp_service::sm_create(
-        model_name, title, body, metadata, agent_name, bus_socket, cfg,
+        model_name, title, body, metadata, agent_name, bus_socket, cfg, sm_store,
     )
     .await?;
 
@@ -1184,6 +1215,7 @@ async fn call_sm_move(
     agent_name: &str,
     bus_socket: &str,
     user_config: Option<&UserConfig>,
+    sm_store: &dyn crate::ports::store::StateMachineRepository,
 ) -> Result<Value> {
     let id = args
         .get("id")
@@ -1196,7 +1228,8 @@ async fn call_sm_move(
     let note = args.get("note").and_then(|n| n.as_str());
 
     let cfg = user_config.context("no user config loaded — models not available")?;
-    let result = mcp_service::sm_move(id, state, note, agent_name, bus_socket, cfg).await?;
+    let result =
+        mcp_service::sm_move(id, state, note, agent_name, bus_socket, cfg, sm_store).await?;
 
     Ok(json!({
         "content": [{"type": "text", "text": format!("{} → {} (model={})", result.id, result.state, result.model)}],
@@ -1204,12 +1237,15 @@ async fn call_sm_move(
     }))
 }
 
-async fn call_sm_query(args: &Value) -> Result<Value> {
+async fn call_sm_query(
+    args: &Value,
+    sm_store: &dyn crate::ports::store::StateMachineRepository,
+) -> Result<Value> {
     let id = args.get("id").and_then(|i| i.as_str());
     let model_filter = args.get("model").and_then(|m| m.as_str());
     let state_filter = args.get("state").and_then(|s| s.as_str());
 
-    let result = mcp_service::sm_query(id, model_filter, state_filter)?;
+    let result = mcp_service::sm_query(id, model_filter, state_filter, sm_store)?;
 
     Ok(json!({
         "content": [{"type": "text", "text": serde_json::to_string_pretty(&result)?}],
@@ -1498,7 +1534,18 @@ mod tests {
             method: "nonexistent/method".into(),
             params: None,
         };
-        let resp = handle_request(&req, "test", "/tmp/fake.sock", None, &internal_bus).await;
+        let task_store = crate::infra::memory_store::InMemoryTaskStore::new();
+        let sm_store = crate::infra::memory_store::InMemoryStateMachineStore::new();
+        let resp = handle_request(
+            &req,
+            "test",
+            "/tmp/fake.sock",
+            None,
+            &internal_bus,
+            &task_store,
+            &sm_store,
+        )
+        .await;
         assert!(resp.error.is_some());
         let err = resp.error.unwrap();
         assert_eq!(err["code"], -32601);
@@ -1508,13 +1555,24 @@ mod tests {
     #[tokio::test]
     async fn test_handle_request_initialize() {
         let internal_bus = std::sync::Arc::new(tokio::sync::Mutex::new(None));
+        let task_store = crate::infra::memory_store::InMemoryTaskStore::new();
+        let sm_store = crate::infra::memory_store::InMemoryStateMachineStore::new();
         let req = Request {
             jsonrpc: "2.0".into(),
             id: Some(json!(1)),
             method: "initialize".into(),
             params: None,
         };
-        let resp = handle_request(&req, "test", "/tmp/fake.sock", None, &internal_bus).await;
+        let resp = handle_request(
+            &req,
+            "test",
+            "/tmp/fake.sock",
+            None,
+            &internal_bus,
+            &task_store,
+            &sm_store,
+        )
+        .await;
         assert!(resp.error.is_none());
         assert_eq!(resp.result.unwrap()["serverInfo"]["name"], "deskd");
     }

--- a/src/app/mcp_service.rs
+++ b/src/app/mcp_service.rs
@@ -16,6 +16,7 @@ use crate::app::unified_inbox;
 use crate::app::workflow;
 use crate::config::UserConfig;
 use crate::domain::events::DomainEvent;
+use crate::ports::store::{StateMachineRepository, TaskRepository};
 
 // ─── Reminder ────────────────────────────────────────────────────────────────
 
@@ -220,13 +221,13 @@ pub fn task_create(
     labels: Vec<String>,
     metadata: Value,
     created_by: &str,
+    task_store: &dyn TaskRepository,
 ) -> Result<TaskCreated> {
-    let store = crate::app::task::TaskStore::default_for_home();
     let criteria = crate::app::task::TaskCriteria { model, labels };
     let task = if metadata.is_null() {
-        store.create(description, criteria, created_by)?
+        task_store.create(description, criteria, created_by)?
     } else {
-        store.create_with_metadata(description, criteria, created_by, metadata)?
+        task_store.create_with_metadata(description, criteria, created_by, metadata)?
     };
 
     info!(agent = %created_by, task_id = %task.id, "task_create");
@@ -251,10 +252,12 @@ fn parse_task_status(s: &str) -> Option<crate::app::task::TaskStatus> {
 }
 
 /// List tasks, optionally filtered by status string.
-pub fn task_list(status_filter: Option<&str>) -> Result<Vec<Value>> {
+pub fn task_list(
+    status_filter: Option<&str>,
+    task_store: &dyn TaskRepository,
+) -> Result<Vec<Value>> {
     let filter = status_filter.and_then(parse_task_status);
-    let store = crate::app::task::TaskStore::default_for_home();
-    let tasks = store.list(filter)?;
+    let tasks = task_store.list(filter)?;
 
     Ok(tasks
         .iter()
@@ -277,9 +280,8 @@ pub struct TaskCancelled {
     pub id: String,
 }
 
-pub fn task_cancel(id: &str) -> Result<TaskCancelled> {
-    let store = crate::app::task::TaskStore::default_for_home();
-    let task = store.cancel(id)?;
+pub fn task_cancel(id: &str, task_store: &dyn TaskRepository) -> Result<TaskCancelled> {
+    let task = task_store.cancel(id)?;
     info!(task_id = %task.id, "task_cancel");
     Ok(TaskCancelled { id: task.id })
 }
@@ -296,6 +298,7 @@ pub struct SmCreated {
 
 /// Create a new state machine instance. If the initial state has an assignee,
 /// dispatches the first task to the bus.
+#[allow(clippy::too_many_arguments)]
 pub async fn sm_create(
     model_name: &str,
     title: &str,
@@ -304,6 +307,7 @@ pub async fn sm_create(
     agent_name: &str,
     bus_socket: &str,
     user_config: &UserConfig,
+    sm_store: &dyn StateMachineRepository,
 ) -> Result<SmCreated> {
     let model: statemachine::ModelDef = user_config
         .models
@@ -314,11 +318,10 @@ pub async fn sm_create(
         .try_into()
         .map_err(|e: String| anyhow::anyhow!("{e}"))?;
 
-    let store = statemachine::StateMachineStore::default_for_home();
-    let mut inst = store.create(&model, title, body, agent_name)?;
+    let mut inst = sm_store.create(&model, title, body, agent_name)?;
     if !metadata.is_null() {
         inst.metadata = metadata;
-        store.save(&inst)?;
+        sm_store.save(&inst)?;
     }
     info!(agent = %agent_name, instance = %inst.id, model = %model_name, "sm_create");
 
@@ -412,9 +415,9 @@ pub async fn sm_move(
     agent_name: &str,
     bus_socket: &str,
     user_config: &UserConfig,
+    sm_store: &dyn StateMachineRepository,
 ) -> Result<SmMoved> {
-    let store = statemachine::StateMachineStore::default_for_home();
-    let mut inst = store.load(id)?;
+    let mut inst = sm_store.load(id)?;
     let model: statemachine::ModelDef = user_config
         .models
         .iter()
@@ -425,7 +428,7 @@ pub async fn sm_move(
         .map_err(|e: String| anyhow::anyhow!("{e}"))?;
 
     let from = inst.state.clone();
-    store.move_to(&mut inst, &model, state, agent_name, note, None, None)?;
+    sm_store.move_to(&mut inst, &model, state, agent_name, note, None, None)?;
     info!(agent = %agent_name, instance = %id, from = %from, to = %state, "sm_move");
 
     // Emit TransitionApplied event.
@@ -461,16 +464,15 @@ pub fn sm_query(
     id: Option<&str>,
     model_filter: Option<&str>,
     state_filter: Option<&str>,
+    sm_store: &dyn StateMachineRepository,
 ) -> Result<Value> {
-    let store = statemachine::StateMachineStore::default_for_home();
-
     if let Some(id) = id {
-        let inst = store.load(id)?;
+        let inst = sm_store.load(id)?;
         let dto: crate::infra::dto::StoredInstance = (&inst).into();
         return Ok(serde_json::to_value(&dto)?);
     }
 
-    let mut instances = store.list_all()?;
+    let mut instances = sm_store.list_all()?;
     if let Some(mf) = model_filter {
         instances.retain(|i| i.model == mf);
     }

--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -203,8 +203,10 @@ pub async fn serve(config_path: String) -> Result<()> {
             });
             info!(agent = %def.name, "started timeout sweep loop (interval=30s)");
 
+            let sm_store = crate::app::statemachine::StateMachineStore::default_for_home();
+            let task_store = crate::app::task::TaskStore::default_for_home();
             tokio::spawn(async move {
-                if let Err(e) = workflow::run(&bus, models).await {
+                if let Err(e) = workflow::run(&bus, models, &sm_store, &task_store).await {
                     tracing::error!(agent = %agent_name, error = %e, "workflow engine exited");
                 }
             });

--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -107,8 +107,11 @@ pub async fn serve(config_path: String) -> Result<()> {
 
         // Start worker on the agent's bus.
         let bus = bus_socket.clone();
+        let worker_task_store = crate::app::task::TaskStore::default_for_home();
         tokio::spawn(async move {
-            if let Err(e) = worker::run(&name, &bus, Some(bus.clone()), None).await {
+            if let Err(e) =
+                worker::run(&name, &bus, Some(bus.clone()), None, &worker_task_store).await
+            {
                 tracing::error!(agent = %name, error = %e, "worker exited with error");
             }
         });
@@ -161,9 +164,16 @@ pub async fn serve(config_path: String) -> Result<()> {
                 let sub_name = sub.name.clone();
                 let bus = bus_socket.clone();
                 let subs = sub.subscribe.clone();
+                let sub_task_store = crate::app::task::TaskStore::default_for_home();
                 tokio::spawn(async move {
-                    if let Err(e) =
-                        worker::run(&sub_name, &bus, Some(bus.clone()), Some(subs)).await
+                    if let Err(e) = worker::run(
+                        &sub_name,
+                        &bus,
+                        Some(bus.clone()),
+                        Some(subs),
+                        &sub_task_store,
+                    )
+                    .await
                     {
                         tracing::error!(agent = %sub_name, error = %e, "sub-agent worker exited");
                     }
@@ -206,7 +216,18 @@ pub async fn serve(config_path: String) -> Result<()> {
             let sm_store = crate::app::statemachine::StateMachineStore::default_for_home();
             let task_store = crate::app::task::TaskStore::default_for_home();
             tokio::spawn(async move {
-                if let Err(e) = workflow::run(&bus, models, &sm_store, &task_store).await {
+                let bus_client = match crate::infra::unix_bus::UnixBus::connect(&bus).await {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::error!(
+                            agent = %agent_name,
+                            error = %e,
+                            "workflow engine failed to connect to bus"
+                        );
+                        return;
+                    }
+                };
+                if let Err(e) = workflow::run(&bus_client, models, &sm_store, &task_store).await {
                     tracing::error!(agent = %agent_name, error = %e, "workflow engine exited");
                 }
             });

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -409,6 +409,9 @@ impl crate::ports::store::TaskWriter for TaskStore {
     fn fail(&self, id: &str, error_msg: &str) -> Result<Task> {
         self.fail(id, error_msg)
     }
+    fn save(&self, task: &Task) -> Result<()> {
+        self.save_pub(task)
+    }
 }
 
 #[cfg(test)]

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -163,6 +163,7 @@ pub async fn run(
     socket_path: &str,
     bus_socket: Option<String>,
     subscriptions: Option<Vec<String>>,
+    task_store: &dyn crate::ports::store::TaskRepository,
 ) -> Result<()> {
     let initial_state = agent::load_state(name)?;
     let budget_usd = initial_state.config.budget_usd;
@@ -203,7 +204,7 @@ pub async fn run(
     info!(agent = %name, runtime = ?agent_runtime, "agent process ready, waiting for tasks");
 
     // Startup recovery: handle orphaned active tasks assigned to this agent.
-    recover_orphaned_tasks(name);
+    recover_orphaned_tasks(name, task_store);
 
     // Task queue polling interval (30 seconds).
     let mut queue_poll = tokio::time::interval(std::time::Duration::from_secs(30));
@@ -223,8 +224,7 @@ pub async fn run(
             }
             _ = queue_poll.tick() => {
                 // Poll the task queue for pending tasks matching this worker.
-                let store = crate::app::task::TaskStore::default_for_home();
-                if let Ok(Some(task)) = store.claim_next(name, &agent_model, &agent_labels) {
+                if let Ok(Some(task)) = task_store.claim_next(name, &agent_model, &agent_labels) {
                     info!(
                         agent = %name,
                         task_id = %task.id,
@@ -489,12 +489,14 @@ pub async fn run(
                     &initial_state.config.work_dir,
                     &initial_state.config.model,
                     &writer,
+                    task_store,
                 )
                 .await;
             }
             Err(ref e) => {
                 let needs_restart =
-                    handle_task_failure(name, &msg, &ctx, e, task_duration_ms, &writer).await;
+                    handle_task_failure(name, &msg, &ctx, e, task_duration_ms, &writer, task_store)
+                        .await;
                 if needs_restart {
                     warn!(agent = %name, "agent process crashed, restarting with fresh session");
                     match start_executor_fresh(name, &effective_bus, &agent_runtime).await {
@@ -757,9 +759,8 @@ fn log_skip(name: &str, msg: &Message, ctx: &TaskContext, status: &str, error: O
 /// If deskd crashed while this agent was processing a task, the task is stuck in
 /// Active status with no one working on it. Tasks with results are completed;
 /// tasks without results are marked as Failed for visibility.
-fn recover_orphaned_tasks(agent_name: &str) {
-    let store = crate::app::task::TaskStore::default_for_home();
-    let active_tasks = match store.list(Some(crate::domain::task::TaskStatus::Active)) {
+fn recover_orphaned_tasks(agent_name: &str, task_store: &dyn crate::ports::store::TaskRepository) {
+    let active_tasks = match task_store.list(Some(crate::domain::task::TaskStatus::Active)) {
         Ok(tasks) => tasks,
         Err(_) => return,
     };
@@ -777,7 +778,7 @@ fn recover_orphaned_tasks(agent_name: &str) {
                 "recovering orphaned task with result: completing"
             );
             if let Err(e) =
-                store.complete(&task.id, task.result.as_deref().unwrap_or(""), None, None)
+                task_store.complete(&task.id, task.result.as_deref().unwrap_or(""), None, None)
             {
                 warn!(agent = %agent_name, task_id = %task.id, error = %e, "failed to complete orphaned task");
             }
@@ -790,7 +791,7 @@ fn recover_orphaned_tasks(agent_name: &str) {
             task_id = %task.id,
             "marking orphaned active task as Failed (no result, agent crashed)"
         );
-        if let Err(e) = store.fail(
+        if let Err(e) = task_store.fail(
             &task.id,
             &format!("agent {} crashed — task requires manual retry", agent_name),
         ) {
@@ -812,6 +813,7 @@ async fn handle_task_success(
     work_dir: &str,
     model: &str,
     writer: &std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    task_store: &dyn crate::ports::store::TaskRepository,
 ) {
     info!(
         agent = %name,
@@ -863,7 +865,6 @@ async fn handle_task_success(
 
     // Update task queue if this came from the queue.
     if let Some(ref tq_id) = ctx.task_queue_id {
-        let store = crate::app::task::TaskStore::default_for_home();
         let result_text = if response.len() > 500 {
             let mut end = 500;
             while !response.is_char_boundary(end) {
@@ -873,7 +874,7 @@ async fn handle_task_success(
         } else {
             response.clone()
         };
-        if let Err(e) = store.complete(
+        if let Err(e) = task_store.complete(
             tq_id,
             &result_text,
             Some(turn.cost_usd),
@@ -919,6 +920,7 @@ async fn handle_task_failure(
     error: &anyhow::Error,
     task_duration_ms: u64,
     writer: &std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    task_store: &dyn crate::ports::store::TaskRepository,
 ) -> bool {
     let err_str = format!("{}", error);
     warn!(agent = %name, error = %err_str, "task failed");
@@ -942,11 +944,10 @@ async fn handle_task_failure(
         warn!(agent = %name, error = %le, "failed to write task log");
     }
 
-    if let Some(ref tq_id) = ctx.task_queue_id {
-        let store = crate::app::task::TaskStore::default_for_home();
-        if let Err(e) = store.fail(tq_id, &err_str) {
-            warn!(agent = %name, task_id = %tq_id, error = %e, "failed to mark queue task failed");
-        }
+    if let Some(ref tq_id) = ctx.task_queue_id
+        && let Err(e) = task_store.fail(tq_id, &err_str)
+    {
+        warn!(agent = %name, task_id = %tq_id, error = %e, "failed to mark queue task failed");
     }
 
     let needs_restart = err_str.contains("process exited") || err_str.contains("stdin closed");

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -1,38 +1,33 @@
 use anyhow::Result;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixStream;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::app::message::Message;
 use crate::app::statemachine;
-use crate::app::worker;
 use crate::domain::events::DomainEvent;
+use crate::domain::message::{Message, Metadata};
 use crate::domain::statemachine::{ModelDef, StepType};
 use crate::domain::workitem::WorkItem;
+use crate::ports::bus::MessageBus;
 use crate::ports::store::{StateMachineRepository, TaskRepository};
-
-type Writer = std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>;
 
 /// Publish a domain event to the message bus.
 ///
 /// Events are sent to `events:<event_type>` targets so subscribers can
 /// use glob patterns like `events:*` to receive all events.
-async fn emit_event(writer: &Writer, event: &DomainEvent) {
-    let msg = serde_json::json!({
-        "type": "message",
-        "id": Uuid::new_v4().to_string(),
-        "source": "workflow-engine",
-        "target": format!("events:{}", event.event_type()),
-        "payload": event.to_json(),
-        "metadata": {"priority": 1u8},
-    });
-    if let Ok(mut line) = serde_json::to_string(&msg) {
-        line.push('\n');
-        let mut w = writer.lock().await;
-        if let Err(e) = w.write_all(line.as_bytes()).await {
-            warn!(error = %e, event = %event.event_type(), "failed to emit domain event");
-        }
+async fn emit_event(bus: &dyn MessageBus, event: &DomainEvent) {
+    let msg = Message {
+        id: Uuid::new_v4().to_string(),
+        source: "workflow-engine".to_string(),
+        target: format!("events:{}", event.event_type()),
+        payload: event.to_json(),
+        reply_to: None,
+        metadata: Metadata {
+            priority: 1,
+            ..Default::default()
+        },
+    };
+    if let Err(e) = bus.send(&msg).await {
+        warn!(error = %e, event = %event.event_type(), "failed to emit domain event");
     }
 }
 
@@ -41,30 +36,20 @@ async fn emit_event(writer: &Writer, event: &DomainEvent) {
 /// Used by callers outside the workflow engine (e.g. MCP handlers) to emit
 /// events without holding a persistent bus connection.
 pub async fn publish_event(bus_socket: &str, source: &str, event: &DomainEvent) -> Result<()> {
-    let mut stream = UnixStream::connect(bus_socket).await?;
-
-    let reg = serde_json::json!({
-        "type": "register",
-        "name": format!("{}-event-pub", source),
-        "subscriptions": []
-    });
-    let mut line = serde_json::to_string(&reg)?;
-    line.push('\n');
-    stream.write_all(line.as_bytes()).await?;
-
-    let msg = serde_json::json!({
-        "type": "message",
-        "id": Uuid::new_v4().to_string(),
-        "source": source,
-        "target": format!("events:{}", event.event_type()),
-        "payload": event.to_json(),
-        "metadata": {"priority": 1u8},
-    });
-    let mut msg_line = serde_json::to_string(&msg)?;
-    msg_line.push('\n');
-    stream.write_all(msg_line.as_bytes()).await?;
-    stream.flush().await?;
-
+    let bus = crate::infra::unix_bus::UnixBus::connect(bus_socket).await?;
+    bus.register(&format!("{}-event-pub", source), &[]).await?;
+    let msg = Message {
+        id: Uuid::new_v4().to_string(),
+        source: source.to_string(),
+        target: format!("events:{}", event.event_type()),
+        payload: event.to_json(),
+        reply_to: None,
+        metadata: Metadata {
+            priority: 1,
+            ..Default::default()
+        },
+    };
+    bus.send(&msg).await?;
     Ok(())
 }
 
@@ -73,30 +58,17 @@ pub async fn publish_event(bus_socket: &str, source: &str, event: &DomainEvent) 
 /// Connects to the bus, sends an `action: "moved"` message to `sm:<id>`,
 /// and disconnects. The workflow engine picks this up and dispatches if needed.
 pub async fn notify_moved(bus_socket: &str, instance_id: &str, source: &str) -> Result<()> {
-    let mut stream = UnixStream::connect(bus_socket).await?;
-
-    let reg = serde_json::json!({
-        "type": "register",
-        "name": format!("{}-sm-notify", source),
-        "subscriptions": []
-    });
-    let mut line = serde_json::to_string(&reg)?;
-    line.push('\n');
-    stream.write_all(line.as_bytes()).await?;
-
-    let msg = serde_json::json!({
-        "type": "message",
-        "id": Uuid::new_v4().to_string(),
-        "source": source,
-        "target": format!("sm:{}", instance_id),
-        "payload": {"action": "moved"},
-        "metadata": {"priority": 5u8},
-    });
-    let mut msg_line = serde_json::to_string(&msg)?;
-    msg_line.push('\n');
-    stream.write_all(msg_line.as_bytes()).await?;
-    stream.flush().await?;
-
+    let bus = crate::infra::unix_bus::UnixBus::connect(bus_socket).await?;
+    bus.register(&format!("{}-sm-notify", source), &[]).await?;
+    let msg = Message {
+        id: Uuid::new_v4().to_string(),
+        source: source.to_string(),
+        target: format!("sm:{}", instance_id),
+        payload: serde_json::json!({"action": "moved"}),
+        reply_to: None,
+        metadata: Metadata::default(),
+    };
+    bus.send(&msg).await?;
     Ok(())
 }
 
@@ -104,34 +76,22 @@ pub async fn notify_moved(bus_socket: &str, instance_id: &str, source: &str) -> 
 /// Registers as `workflow-engine`, subscribes to `sm:*`.
 /// On startup, dispatches pending instances. Then listens for completion messages.
 pub async fn run(
-    socket_path: &str,
+    bus: &dyn MessageBus,
     models: Vec<ModelDef>,
     sm_store: &dyn StateMachineRepository,
     task_store: &dyn TaskRepository,
 ) -> Result<()> {
-    let stream =
-        worker::bus_connect(socket_path, "workflow-engine", vec!["sm:*".to_string()]).await?;
-
-    let (reader, writer_half) = stream.into_split();
-
-    let writer: Writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer_half));
-    let mut lines = BufReader::new(reader).lines();
+    bus.register("workflow-engine", &["sm:*".to_string()])
+        .await?;
 
     info!("workflow engine started, subscribed to sm:*");
 
     // On startup: check for pending instances and dispatch them.
-    dispatch_pending(&writer, &models, sm_store, task_store).await;
+    dispatch_pending(bus, &models, sm_store, task_store).await;
 
     // Main loop: listen for completion messages.
-    while let Some(line) = lines.next_line().await? {
-        if line.is_empty() {
-            continue;
-        }
-
-        let msg: Message = match serde_json::from_str::<crate::infra::dto::BusMessage>(&line) {
-            Ok(dto) => dto.into(),
-            Err(_) => continue,
-        };
+    loop {
+        let msg = bus.recv().await?;
 
         // Extract instance ID from target: "sm:sm-a1b2c3d4"
         let instance_id = match msg.target.strip_prefix("sm:") {
@@ -143,7 +103,7 @@ pub async fn run(
         if msg.payload.get("action").and_then(|a| a.as_str()) == Some("moved") {
             info!(instance = %instance_id, "received move notification");
             if let Err(e) =
-                handle_move_notification(&writer, &models, sm_store, task_store, &instance_id).await
+                handle_move_notification(bus, &models, sm_store, task_store, &instance_id).await
             {
                 warn!(instance = %instance_id, error = %e, "failed to handle move notification");
             }
@@ -167,7 +127,7 @@ pub async fn run(
         info!(instance = %instance_id, "received completion");
 
         if let Err(e) = handle_completion(
-            &writer,
+            bus,
             &models,
             sm_store,
             task_store,
@@ -180,13 +140,11 @@ pub async fn run(
             warn!(instance = %instance_id, error = %e, "failed to process completion");
         }
     }
-
-    Ok(())
 }
 
 /// Handle a task completion: apply transitions and dispatch next step.
 async fn handle_completion(
-    writer: &Writer,
+    bus: &dyn MessageBus,
     models: &[ModelDef],
     store: &dyn StateMachineRepository,
     task_store: &dyn TaskRepository,
@@ -223,7 +181,7 @@ async fn handle_completion(
         );
 
         emit_event(
-            writer,
+            bus,
             &DomainEvent::TransitionApplied {
                 instance_id: instance_id.to_string(),
                 from: current_state.clone(),
@@ -236,7 +194,7 @@ async fn handle_completion(
         // If terminal, emit completion event.
         if statemachine::is_terminal(model, &inst) {
             emit_event(
-                writer,
+                bus,
                 &DomainEvent::InstanceCompleted {
                     instance_id: instance_id.to_string(),
                     model: inst.model.clone(),
@@ -245,7 +203,7 @@ async fn handle_completion(
             )
             .await;
         } else {
-            dispatch_instance(writer, model, &inst, store, task_store).await?;
+            dispatch_instance(bus, model, &inst, store, task_store).await?;
         }
     } else {
         info!(instance = %instance_id, state = %inst.state, "no matching transition, awaiting manual move");
@@ -256,7 +214,7 @@ async fn handle_completion(
 
 /// Handle a move notification: reload instance and dispatch if it has an assignee.
 async fn handle_move_notification(
-    writer: &Writer,
+    bus: &dyn MessageBus,
     models: &[ModelDef],
     store: &dyn StateMachineRepository,
     task_store: &dyn TaskRepository,
@@ -274,7 +232,7 @@ async fn handle_move_notification(
     }
 
     if !inst.assignee.is_empty() {
-        dispatch_instance(writer, model, &inst, store, task_store).await?;
+        dispatch_instance(bus, model, &inst, store, task_store).await?;
         info!(instance = %instance_id, assignee = %inst.assignee, "dispatched after move");
     }
 
@@ -360,7 +318,7 @@ fn build_work_item(model: &ModelDef, inst: &statemachine::Instance) -> WorkItem 
 ///
 /// Returns the task ID if a task was created (Agent steps always create one).
 async fn dispatch_work_item(
-    writer: &Writer,
+    bus: &dyn MessageBus,
     model: &ModelDef,
     inst: &statemachine::Instance,
     work_item: &WorkItem,
@@ -370,26 +328,22 @@ async fn dispatch_work_item(
     match work_item.step_type {
         StepType::Human => {
             if let Some(ref notify_target) = work_item.notify {
-                let msg = serde_json::json!({
-                    "type": "message",
-                    "id": Uuid::new_v4().to_string(),
-                    "source": "workflow-engine",
-                    "target": notify_target,
-                    "payload": {
+                let msg = Message {
+                    id: Uuid::new_v4().to_string(),
+                    source: "workflow-engine".to_string(),
+                    target: notify_target.clone(),
+                    payload: serde_json::json!({
                         "task": work_item.task_text,
                         "sm_instance_id": work_item.instance_id,
-                    },
-                    "reply_to": format!("sm:{}", work_item.instance_id),
-                    "metadata": {"priority": 5u8},
-                });
-                let mut line = serde_json::to_string(&msg)?;
-                line.push('\n');
-                let mut w = writer.lock().await;
-                w.write_all(line.as_bytes()).await?;
+                    }),
+                    reply_to: Some(format!("sm:{}", work_item.instance_id)),
+                    metadata: Metadata::default(),
+                };
+                bus.send(&msg).await?;
                 info!(instance = %work_item.instance_id, target = %notify_target, "human notification sent");
                 // Emit event so observers know a notification was sent.
                 emit_event(
-                    writer,
+                    bus,
                     &DomainEvent::TaskDispatched {
                         task_id: String::new(),
                         instance_id: Some(work_item.instance_id.clone()),
@@ -402,15 +356,15 @@ async fn dispatch_work_item(
         }
         StepType::Check => {
             let transition_def = model.transitions.iter().find(|t| t.to == inst.state);
-            dispatch_check_step(writer, model, inst, transition_def, sm_store, task_store).await?;
+            dispatch_check_step(bus, model, inst, transition_def, sm_store, task_store).await?;
             Ok(None)
         }
         StepType::Validate => {
-            dispatch_validate_step(writer, model, inst, work_item, sm_store, task_store).await?;
+            dispatch_validate_step(bus, model, inst, work_item, sm_store, task_store).await?;
             Ok(None)
         }
         StepType::Agent => {
-            let task_id = dispatch_agent(writer, inst, work_item, task_store).await?;
+            let task_id = dispatch_agent(bus, inst, work_item, task_store).await?;
             Ok(Some(task_id))
         }
     }
@@ -422,7 +376,7 @@ async fn dispatch_work_item(
 ///
 /// Returns the task ID of the created task.
 async fn dispatch_agent(
-    writer: &Writer,
+    bus: &dyn MessageBus,
     inst: &statemachine::Instance,
     work_item: &WorkItem,
     task_store: &dyn TaskRepository,
@@ -452,24 +406,19 @@ async fn dispatch_agent(
     } else {
         // Direct bus message dispatch — task exists for tracking but work
         // is pushed directly to the assignee.
-        let msg = serde_json::json!({
-            "type": "message",
-            "id": Uuid::new_v4().to_string(),
-            "source": "workflow-engine",
-            "target": &inst.assignee,
-            "payload": {
+        let msg = Message {
+            id: Uuid::new_v4().to_string(),
+            source: "workflow-engine".to_string(),
+            target: inst.assignee.clone(),
+            payload: serde_json::json!({
                 "task": work_item.task_text,
                 "sm_instance_id": work_item.instance_id,
                 "task_queue_id": task_id,
-            },
-            "reply_to": format!("sm:{}", work_item.instance_id),
-            "metadata": {"priority": 5u8},
-        });
-
-        let mut line = serde_json::to_string(&msg)?;
-        line.push('\n');
-        let mut w = writer.lock().await;
-        w.write_all(line.as_bytes()).await?;
+            }),
+            reply_to: Some(format!("sm:{}", work_item.instance_id)),
+            metadata: Metadata::default(),
+        };
+        bus.send(&msg).await?;
 
         info!(
             instance = %work_item.instance_id,
@@ -480,7 +429,7 @@ async fn dispatch_agent(
     }
 
     emit_event(
-        writer,
+        bus,
         &DomainEvent::TaskDispatched {
             task_id: task_id.clone(),
             instance_id: Some(work_item.instance_id.clone()),
@@ -495,7 +444,7 @@ async fn dispatch_agent(
 ///
 /// Creates a WorkItem and routes it to the appropriate execution path.
 async fn dispatch_instance(
-    writer: &Writer,
+    bus: &dyn MessageBus,
     model: &ModelDef,
     inst: &statemachine::Instance,
     sm_store: &dyn StateMachineRepository,
@@ -512,7 +461,7 @@ async fn dispatch_instance(
         step_type = %work_item.step_type,
         "work item created"
     );
-    let task_id = dispatch_work_item(writer, model, inst, &work_item, sm_store, task_store).await?;
+    let task_id = dispatch_work_item(bus, model, inst, &work_item, sm_store, task_store).await?;
 
     // Link the task_id to the instance aggregate and the last transition.
     if let Some(task_id) = task_id
@@ -561,7 +510,7 @@ fn build_task_text(prompt: &str, inst: &statemachine::Instance) -> String {
 /// Execute a check step: run a shell command and use the result to trigger
 /// the next transition. Exit 0 = pass (result is stdout), non-zero = fail.
 async fn dispatch_check_step(
-    writer: &Writer,
+    bus: &dyn MessageBus,
     model: &ModelDef,
     inst: &statemachine::Instance,
     transition_def: Option<&crate::domain::statemachine::TransitionDef>,
@@ -618,7 +567,7 @@ async fn dispatch_check_step(
     // the async recursion cycle: handle_completion → dispatch_instance →
     // dispatch_check_step → handle_completion.
     let _ = Box::pin(handle_completion(
-        writer,
+        bus,
         std::slice::from_ref(model),
         sm_store,
         task_store,
@@ -634,7 +583,7 @@ async fn dispatch_check_step(
 /// Execute a validate step: run Claude in print mode (-p) with structured
 /// output for a cheap LLM review. No full agent session — single inference.
 async fn dispatch_validate_step(
-    writer: &Writer,
+    bus: &dyn MessageBus,
     model: &ModelDef,
     inst: &statemachine::Instance,
     work_item: &WorkItem,
@@ -702,7 +651,7 @@ async fn dispatch_validate_step(
             "validate step: claude process failed"
         );
         let _ = Box::pin(handle_completion(
-            writer,
+            bus,
             std::slice::from_ref(model),
             sm_store,
             task_store,
@@ -751,7 +700,7 @@ async fn dispatch_validate_step(
     };
 
     let _ = Box::pin(handle_completion(
-        writer,
+        bus,
         std::slice::from_ref(model),
         sm_store,
         task_store,
@@ -785,7 +734,7 @@ fn extract_claude_json_result(raw: &str) -> String {
 /// (crash between result storage and transition), apply the transition
 /// from the stored result instead of re-dispatching.
 async fn dispatch_pending(
-    writer: &Writer,
+    bus: &dyn MessageBus,
     models: &[ModelDef],
     store: &dyn StateMachineRepository,
     task_store: &dyn TaskRepository,
@@ -825,7 +774,7 @@ async fn dispatch_pending(
                 "recovering: result present but not transitioned, applying transition"
             );
             if let Err(e) = handle_completion(
-                writer,
+                bus,
                 models,
                 store,
                 task_store,
@@ -848,7 +797,7 @@ async fn dispatch_pending(
 
         // Dispatch if has assignee (pending work).
         if !inst.assignee.is_empty()
-            && let Err(e) = dispatch_instance(writer, model, inst, store, task_store).await
+            && let Err(e) = dispatch_instance(bus, model, inst, store, task_store).await
         {
             warn!(instance = %inst.id, error = %e, "failed to dispatch pending instance");
         }
@@ -859,6 +808,7 @@ async fn dispatch_pending(
 mod tests {
     use super::*;
     use crate::domain::statemachine::{StepType, TransitionDef};
+    use crate::ports::store::{StateMachineReader, StateMachineWriter};
 
     fn test_model() -> ModelDef {
         ModelDef {
@@ -1609,5 +1559,89 @@ mod tests {
         assert_eq!(wi.step_type, StepType::Validate);
         assert_eq!(wi.command.as_deref(), Some("claude-sonnet-4-6"));
         assert_eq!(wi.prompt, "Check for security issues.");
+    }
+
+    /// Test dispatch_pending with in-memory stores and bus — demonstrates
+    /// testability enabled by port trait wiring (#254).
+    #[tokio::test]
+    async fn test_dispatch_pending_with_mock_stores() {
+        use crate::infra::memory_bus::InMemoryBus;
+        use crate::infra::memory_store::{InMemoryStateMachineStore, InMemoryTaskStore};
+
+        let model = test_model();
+        let sm_store = InMemoryStateMachineStore::new();
+        let task_store = InMemoryTaskStore::new();
+        let (bus_client, bus_server) = InMemoryBus::pair();
+
+        // Create an instance in the "draft" state with an assignee.
+        // The test_model has an auto transition draft → review with assignee "agent:reviewer".
+        let mut inst = sm_store
+            .create(&model, "Test PR", "Please review", "kira")
+            .unwrap();
+        assert_eq!(inst.state, "draft");
+
+        // Manually set assignee to simulate a pending dispatch.
+        inst.assignee = "agent:reviewer".to_string();
+        sm_store.save(&inst).unwrap();
+
+        // Run dispatch_pending — should dispatch the instance via the bus.
+        dispatch_pending(&bus_client, &[model], &sm_store, &task_store).await;
+
+        // The bus server side should have received at least one message
+        // (the dispatched task or event).
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(100), bus_server.recv())
+            .await
+            .expect("expected a message on the bus")
+            .expect("bus recv failed");
+
+        // Verify the message targets the assignee.
+        assert_eq!(msg.target, "agent:reviewer");
+        assert!(msg.payload.get("task").and_then(|t| t.as_str()).is_some());
+    }
+
+    /// Test handle_completion with mock stores — verifies transition logic
+    /// without any filesystem or socket dependencies.
+    #[tokio::test]
+    async fn test_handle_completion_applies_transition() {
+        use crate::infra::memory_bus::InMemoryBus;
+        use crate::infra::memory_store::{InMemoryStateMachineStore, InMemoryTaskStore};
+
+        let model = test_model();
+        let sm_store = InMemoryStateMachineStore::new();
+        let task_store = InMemoryTaskStore::new();
+        let bus = InMemoryBus::loopback();
+
+        // Create an instance and move it to "review" state.
+        let inst = sm_store
+            .create(&model, "Fix bug", "Details", "kira")
+            .unwrap();
+        sm_store
+            .move_to(
+                &mut inst.clone(),
+                &model,
+                "review",
+                "auto",
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        // Simulate a completion with "LGTM" result — should transition to "approved".
+        let result = handle_completion(
+            &bus,
+            &[model.clone()],
+            &sm_store,
+            &task_store,
+            &inst.id,
+            "LGTM looks good",
+            None,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        // Verify the instance transitioned to terminal state "approved".
+        let updated = sm_store.load(&inst.id).unwrap();
+        assert_eq!(updated.state, "approved");
     }
 }

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -10,6 +10,7 @@ use crate::app::worker;
 use crate::domain::events::DomainEvent;
 use crate::domain::statemachine::{ModelDef, StepType};
 use crate::domain::workitem::WorkItem;
+use crate::ports::store::{StateMachineRepository, TaskRepository};
 
 type Writer = std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>;
 
@@ -102,9 +103,12 @@ pub async fn notify_moved(bus_socket: &str, instance_id: &str, source: &str) -> 
 /// Run the workflow engine on the given bus.
 /// Registers as `workflow-engine`, subscribes to `sm:*`.
 /// On startup, dispatches pending instances. Then listens for completion messages.
-pub async fn run(socket_path: &str, models: Vec<ModelDef>) -> Result<()> {
-    let store = statemachine::StateMachineStore::default_for_home();
-
+pub async fn run(
+    socket_path: &str,
+    models: Vec<ModelDef>,
+    sm_store: &dyn StateMachineRepository,
+    task_store: &dyn TaskRepository,
+) -> Result<()> {
     let stream =
         worker::bus_connect(socket_path, "workflow-engine", vec!["sm:*".to_string()]).await?;
 
@@ -116,7 +120,7 @@ pub async fn run(socket_path: &str, models: Vec<ModelDef>) -> Result<()> {
     info!("workflow engine started, subscribed to sm:*");
 
     // On startup: check for pending instances and dispatch them.
-    dispatch_pending(&writer, &models, &store).await;
+    dispatch_pending(&writer, &models, sm_store, task_store).await;
 
     // Main loop: listen for completion messages.
     while let Some(line) = lines.next_line().await? {
@@ -138,7 +142,9 @@ pub async fn run(socket_path: &str, models: Vec<ModelDef>) -> Result<()> {
         // Check if this is a move notification (from CLI/MCP sm_move).
         if msg.payload.get("action").and_then(|a| a.as_str()) == Some("moved") {
             info!(instance = %instance_id, "received move notification");
-            if let Err(e) = handle_move_notification(&writer, &models, &store, &instance_id).await {
+            if let Err(e) =
+                handle_move_notification(&writer, &models, sm_store, task_store, &instance_id).await
+            {
                 warn!(instance = %instance_id, error = %e, "failed to handle move notification");
             }
             continue;
@@ -163,7 +169,8 @@ pub async fn run(socket_path: &str, models: Vec<ModelDef>) -> Result<()> {
         if let Err(e) = handle_completion(
             &writer,
             &models,
-            &store,
+            sm_store,
+            task_store,
             &instance_id,
             &result,
             error.as_deref(),
@@ -181,7 +188,8 @@ pub async fn run(socket_path: &str, models: Vec<ModelDef>) -> Result<()> {
 async fn handle_completion(
     writer: &Writer,
     models: &[ModelDef],
-    store: &statemachine::StateMachineStore,
+    store: &dyn StateMachineRepository,
+    task_store: &dyn TaskRepository,
     instance_id: &str,
     result: &str,
     error: Option<&str>,
@@ -237,7 +245,7 @@ async fn handle_completion(
             )
             .await;
         } else {
-            dispatch_instance(writer, model, &inst).await?;
+            dispatch_instance(writer, model, &inst, store, task_store).await?;
         }
     } else {
         info!(instance = %instance_id, state = %inst.state, "no matching transition, awaiting manual move");
@@ -250,7 +258,8 @@ async fn handle_completion(
 async fn handle_move_notification(
     writer: &Writer,
     models: &[ModelDef],
-    store: &statemachine::StateMachineStore,
+    store: &dyn StateMachineRepository,
+    task_store: &dyn TaskRepository,
     instance_id: &str,
 ) -> Result<()> {
     let inst = store.load(instance_id)?;
@@ -265,7 +274,7 @@ async fn handle_move_notification(
     }
 
     if !inst.assignee.is_empty() {
-        dispatch_instance(writer, model, &inst).await?;
+        dispatch_instance(writer, model, &inst, store, task_store).await?;
         info!(instance = %instance_id, assignee = %inst.assignee, "dispatched after move");
     }
 
@@ -355,6 +364,8 @@ async fn dispatch_work_item(
     model: &ModelDef,
     inst: &statemachine::Instance,
     work_item: &WorkItem,
+    sm_store: &dyn StateMachineRepository,
+    task_store: &dyn TaskRepository,
 ) -> Result<Option<String>> {
     match work_item.step_type {
         StepType::Human => {
@@ -391,15 +402,15 @@ async fn dispatch_work_item(
         }
         StepType::Check => {
             let transition_def = model.transitions.iter().find(|t| t.to == inst.state);
-            dispatch_check_step(writer, model, inst, transition_def).await?;
+            dispatch_check_step(writer, model, inst, transition_def, sm_store, task_store).await?;
             Ok(None)
         }
         StepType::Validate => {
-            dispatch_validate_step(writer, model, inst, work_item).await?;
+            dispatch_validate_step(writer, model, inst, work_item, sm_store, task_store).await?;
             Ok(None)
         }
         StepType::Agent => {
-            let task_id = dispatch_agent(writer, inst, work_item).await?;
+            let task_id = dispatch_agent(writer, inst, work_item, task_store).await?;
             Ok(Some(task_id))
         }
     }
@@ -414,8 +425,9 @@ async fn dispatch_agent(
     writer: &Writer,
     inst: &statemachine::Instance,
     work_item: &WorkItem,
+    task_store: &dyn TaskRepository,
 ) -> Result<String> {
-    let store = crate::app::task::TaskStore::default_for_home();
+    let store = task_store;
     let criteria = work_item.criteria.clone().unwrap_or_default();
     let mut task = store.create_for_sm(
         &work_item.task_text,
@@ -425,7 +437,7 @@ async fn dispatch_agent(
     )?;
     if work_item.max_retries > 0 {
         task.max_retries = work_item.max_retries;
-        store.save_pub(&task)?;
+        store.save(&task)?;
     }
     let task_id = task.id.clone();
 
@@ -486,6 +498,8 @@ async fn dispatch_instance(
     writer: &Writer,
     model: &ModelDef,
     inst: &statemachine::Instance,
+    sm_store: &dyn StateMachineRepository,
+    task_store: &dyn TaskRepository,
 ) -> Result<()> {
     if inst.assignee.is_empty() {
         debug!(instance = %inst.id, state = %inst.state, "no assignee, skipping dispatch");
@@ -498,18 +512,17 @@ async fn dispatch_instance(
         step_type = %work_item.step_type,
         "work item created"
     );
-    let task_id = dispatch_work_item(writer, model, inst, &work_item).await?;
+    let task_id = dispatch_work_item(writer, model, inst, &work_item, sm_store, task_store).await?;
 
     // Link the task_id to the instance aggregate and the last transition.
-    if let Some(task_id) = task_id {
-        let store = statemachine::StateMachineStore::default_for_home();
-        if let Ok(mut updated_inst) = store.load(&inst.id) {
-            updated_inst.record_task(&task_id);
-            if let Some(last) = updated_inst.history.last_mut() {
-                last.task_id = Some(task_id);
-            }
-            let _ = store.save(&updated_inst);
+    if let Some(task_id) = task_id
+        && let Ok(mut updated_inst) = sm_store.load(&inst.id)
+    {
+        updated_inst.record_task(&task_id);
+        if let Some(last) = updated_inst.history.last_mut() {
+            last.task_id = Some(task_id);
         }
+        let _ = sm_store.save(&updated_inst);
     }
 
     Ok(())
@@ -552,6 +565,8 @@ async fn dispatch_check_step(
     model: &ModelDef,
     inst: &statemachine::Instance,
     transition_def: Option<&crate::domain::statemachine::TransitionDef>,
+    sm_store: &dyn StateMachineRepository,
+    task_store: &dyn TaskRepository,
 ) -> Result<()> {
     let command = match transition_def.and_then(|t| t.command.as_deref()) {
         Some(cmd) => cmd,
@@ -602,11 +617,11 @@ async fn dispatch_check_step(
     // the transition and dispatches the next step. Box::pin to break
     // the async recursion cycle: handle_completion → dispatch_instance →
     // dispatch_check_step → handle_completion.
-    let store = statemachine::StateMachineStore::default_for_home();
     let _ = Box::pin(handle_completion(
         writer,
         std::slice::from_ref(model),
-        &store,
+        sm_store,
+        task_store,
         &inst.id,
         &result,
         error.as_deref(),
@@ -623,6 +638,8 @@ async fn dispatch_validate_step(
     model: &ModelDef,
     inst: &statemachine::Instance,
     work_item: &WorkItem,
+    sm_store: &dyn StateMachineRepository,
+    task_store: &dyn TaskRepository,
 ) -> Result<()> {
     let validate_prompt = if work_item.prompt.is_empty() {
         format!(
@@ -684,11 +701,11 @@ async fn dispatch_validate_step(
             stderr = %stderr,
             "validate step: claude process failed"
         );
-        let store = statemachine::StateMachineStore::default_for_home();
         let _ = Box::pin(handle_completion(
             writer,
             std::slice::from_ref(model),
-            &store,
+            sm_store,
+            task_store,
             &inst.id,
             &format!("validate error: {stderr}"),
             Some("validate step failed: claude process error"),
@@ -733,11 +750,11 @@ async fn dispatch_validate_step(
         }
     };
 
-    let store = statemachine::StateMachineStore::default_for_home();
     let _ = Box::pin(handle_completion(
         writer,
         std::slice::from_ref(model),
-        &store,
+        sm_store,
+        task_store,
         &inst.id,
         &result,
         error.as_deref(),
@@ -770,7 +787,8 @@ fn extract_claude_json_result(raw: &str) -> String {
 async fn dispatch_pending(
     writer: &Writer,
     models: &[ModelDef],
-    store: &statemachine::StateMachineStore,
+    store: &dyn StateMachineRepository,
+    task_store: &dyn TaskRepository,
 ) {
     let instances = match store.list_all() {
         Ok(list) => list,
@@ -779,7 +797,6 @@ async fn dispatch_pending(
 
     // Build a set of SM instance IDs that already have an active task,
     // so we don't create duplicate dispatches.
-    let task_store = crate::app::task::TaskStore::default_for_home();
     let active_sm_ids: std::collections::HashSet<String> = task_store
         .list(Some(crate::domain::task::TaskStatus::Active))
         .unwrap_or_default()
@@ -811,6 +828,7 @@ async fn dispatch_pending(
                 writer,
                 models,
                 store,
+                task_store,
                 &inst.id,
                 result,
                 inst.error.as_deref(),
@@ -830,7 +848,7 @@ async fn dispatch_pending(
 
         // Dispatch if has assignee (pending work).
         if !inst.assignee.is_empty()
-            && let Err(e) = dispatch_instance(writer, model, inst).await
+            && let Err(e) = dispatch_instance(writer, model, inst, store, task_store).await
         {
             warn!(instance = %inst.id, error = %e, "failed to dispatch pending instance");
         }

--- a/src/infra/memory_store.rs
+++ b/src/infra/memory_store.rs
@@ -241,6 +241,12 @@ impl TaskWriter for InMemoryTaskStore {
         tasks.insert(id.to_string(), (&task).into());
         Ok(task)
     }
+
+    fn save(&self, task: &Task) -> Result<()> {
+        let dto: StoredTask = task.into();
+        self.tasks.lock().unwrap().insert(task.id.clone(), dto);
+        Ok(())
+    }
 }
 
 // ─── InMemoryStateMachineStore ───────────────────────────────────────────────

--- a/src/ports/store.rs
+++ b/src/ports/store.rs
@@ -56,6 +56,7 @@ pub trait TaskWriter: Send + Sync {
         turns: Option<u32>,
     ) -> Result<Task>;
     fn fail(&self, id: &str, error_msg: &str) -> Result<Task>;
+    fn save(&self, task: &Task) -> Result<()>;
 }
 
 /// Combined task persistence trait for code that needs both read and write access.

--- a/tests/workflow_transitions.rs
+++ b/tests/workflow_transitions.rs
@@ -610,7 +610,10 @@ async fn test_dispatch_pending_skips_completed_instances() {
     let sm_store = deskd::app::statemachine::StateMachineStore::default_for_home();
     let task_store = deskd::app::task::TaskStore::default_for_home();
     tokio::spawn(async move {
-        let _ = deskd::app::workflow::run(&sock_for_engine, models, &sm_store, &task_store).await;
+        let bus = deskd::infra::unix_bus::UnixBus::connect(&sock_for_engine)
+            .await
+            .expect("failed to connect workflow engine to bus");
+        let _ = deskd::app::workflow::run(&bus, models, &sm_store, &task_store).await;
     });
     tokio::time::sleep(Duration::from_millis(300)).await;
 

--- a/tests/workflow_transitions.rs
+++ b/tests/workflow_transitions.rs
@@ -607,8 +607,10 @@ async fn test_dispatch_pending_skips_completed_instances() {
     // Start workflow engine — dispatch_pending runs on startup.
     let sock_for_engine = socket.clone();
     let models: Vec<deskd::config::ModelDef> = vec![model.clone()];
+    let sm_store = deskd::app::statemachine::StateMachineStore::default_for_home();
+    let task_store = deskd::app::task::TaskStore::default_for_home();
     tokio::spawn(async move {
-        let _ = deskd::app::workflow::run(&sock_for_engine, models).await;
+        let _ = deskd::app::workflow::run(&sock_for_engine, models, &sm_store, &task_store).await;
     });
     tokio::time::sleep(Duration::from_millis(300)).await;
 


### PR DESCRIPTION
## Summary

Partial implementation of #254 — wire port traits into the workflow engine.

- `workflow::run()` now accepts `&dyn StateMachineRepository` + `&dyn TaskRepository` instead of constructing concrete stores internally
- All internal workflow functions pass trait references through the call chain
- Stores constructed at composition root (`serve.rs`) and injected
- Added `save()` to `TaskWriter` trait + both implementations (`TaskStore`, `InMemoryTaskStore`)
- Integration test updated to pass stores explicitly

## What this enables

The workflow engine is now fully decoupled from concrete store implementations. Mock stores can be injected for unit testing without touching the filesystem.

## Remaining for #254

- Wire `MessageBus` trait into `workflow.rs` (replace raw `UnixStream` connections)
- Wire traits into `worker.rs`
- Wire repository traits into `mcp.rs`

## Test plan

- [x] Quality gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
- [ ] Workflow engine starts and processes SM completions as before
- [ ] dispatch_pending works with injected stores
- [ ] Integration tests pass with explicit store injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)