### PR TITLE
fix: schedule raw action delivers config.message to agent

### DIFF
--- a/src/app/schedule.rs
+++ b/src/app/schedule.rs
@@ -179,7 +179,12 @@ async fn fire_raw(def: &ScheduleDef, bus_socket: &str, agent_name: &str) -> Resu
     let text = def
         .config
         .as_ref()
-        .and_then(|c| c.as_str())
+        .and_then(|c| {
+            // Try scalar string first (config: "message text"),
+            // then mapping with message key (config: { message: "..." }).
+            c.as_str()
+                .or_else(|| c.get("message").and_then(|m| m.as_str()))
+        })
         .unwrap_or("scheduled event");
 
     // Write to unified inbox


### PR DESCRIPTION
## Summary
- `fire_raw()` now extracts message text from both scalar config (`config: "text"`) and mapping config (`config: { message: "text" }`)
- Fixes #297 — agents can now distinguish between different scheduled events

## Change
One-line fix in `schedule.rs:fire_raw()`: added fallback to `c.get("message").and_then(|m| m.as_str())` when `c.as_str()` returns None.

## Test plan
- [ ] Configure two schedules with different `config.message` values
- [ ] Verify each schedule delivers its specific message text (not "scheduled event")
- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)