### PR TITLE
arch: fix DIP violations — inject bus and context repo traits (#291)

### DIFF
--- a/src/app/agent_process.rs
+++ b/src/app/agent_process.rs
@@ -267,7 +267,8 @@ impl AgentProcess {
                 .map(std::path::PathBuf::from)
                 .unwrap_or_else(|| crate::app::context::default_main_path(&state.config.work_dir));
             if main_path.exists() {
-                match crate::app::context::MainBranch::load(&main_path) {
+                let ctx_repo = crate::infra::context_store::FileContextStore::new();
+                match crate::app::context::MainBranch::load(&ctx_repo, &main_path) {
                     Ok(mut branch) => match branch.materialize().await {
                         Ok(messages) if !messages.is_empty() => {
                             let combined: String = messages
@@ -283,7 +284,7 @@ impl AgentProcess {
                                 budget = ctx_domain.main_budget_tokens.unwrap_or(10000),
                                 "injected materialized context"
                             );
-                            if let Err(e) = branch.save(&main_path) {
+                            if let Err(e) = branch.save(&ctx_repo, &main_path) {
                                 warn!(agent = %name, error = %e, "failed to save context cache");
                             }
                         }

--- a/src/app/commands/sm.rs
+++ b/src/app/commands/sm.rs
@@ -6,6 +6,7 @@ use tracing::warn;
 use crate::app::cli::SmAction;
 use crate::app::{statemachine, workflow};
 use crate::config;
+use crate::ports::bus::MessageBus;
 
 use super::truncate;
 
@@ -136,9 +137,13 @@ pub async fn handle(
                     socket
                 });
                 if std::path::Path::new(&bus_socket).exists()
-                    && let Err(e) = workflow::notify_moved(&bus_socket, &id, "cli").await
+                    && let Ok(bus) =
+                        crate::infra::unix_bus::UnixBus::connect(&bus_socket).await
                 {
-                    warn!(instance = %id, error = %e, "failed to notify workflow engine");
+                    let _ = bus.register("cli-sm-notify", &[]).await;
+                    if let Err(e) = workflow::notify_moved(&bus, &id, "cli").await {
+                        warn!(instance = %id, error = %e, "failed to notify workflow engine");
+                    }
                 }
             }
         }

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -4,21 +4,20 @@
 //! persistence (load/save via ContextRepository) and materialization
 //! (execute live nodes).
 
-use crate::infra::context_store::FileContextStore;
 use crate::ports::store::ContextRepository;
 
 // Re-export all domain types for backward compatibility.
 pub use crate::domain::context::*;
 
 impl MainBranch {
-    /// Load from YAML file (convenience wrapper over ContextRepository).
-    pub fn load(path: &std::path::Path) -> anyhow::Result<Self> {
-        FileContextStore::new().load(path)
+    /// Load from file via the given repository.
+    pub fn load(repo: &dyn ContextRepository, path: &std::path::Path) -> anyhow::Result<Self> {
+        repo.load(path)
     }
 
-    /// Save to YAML file (convenience wrapper over ContextRepository).
-    pub fn save(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        FileContextStore::new().save(self, path)
+    /// Save to file via the given repository.
+    pub fn save(&self, repo: &dyn ContextRepository, path: &std::path::Path) -> anyhow::Result<()> {
+        repo.save(self, path)
     }
 
     /// Materialize: execute live nodes and produce message list for session injection
@@ -154,8 +153,9 @@ mod tests {
             tokens_estimate: 50,
         });
 
-        branch.save(&path).expect("save failed");
-        let loaded = MainBranch::load(&path).expect("load failed");
+        let repo = crate::infra::context_store::FileContextStore::new();
+        branch.save(&repo, &path).expect("save failed");
+        let loaded = MainBranch::load(&repo, &path).expect("load failed");
 
         assert_eq!(loaded.agent, "test-agent");
         assert_eq!(loaded.budget_tokens, 8000);

--- a/src/app/mcp_service.rs
+++ b/src/app/mcp_service.rs
@@ -16,6 +16,7 @@ use crate::app::unified_inbox;
 use crate::app::workflow;
 use crate::config::UserConfig;
 use crate::domain::events::DomainEvent;
+use crate::ports::bus::MessageBus;
 use crate::ports::store::{StateMachineRepository, TaskRepository};
 
 // ─── Reminder ────────────────────────────────────────────────────────────────
@@ -326,17 +327,22 @@ pub async fn sm_create(
     info!(agent = %agent_name, instance = %inst.id, model = %model_name, "sm_create");
 
     // Emit InstanceCreated event.
-    let _ = workflow::publish_event(
-        bus_socket,
-        agent_name,
-        &DomainEvent::InstanceCreated {
-            instance_id: inst.id.clone(),
-            model: model_name.to_string(),
-            title: title.to_string(),
-            created_by: agent_name.to_string(),
-        },
-    )
-    .await;
+    if let Ok(bus) = crate::infra::unix_bus::UnixBus::connect(bus_socket).await {
+        let _ = bus
+            .register(&format!("{}-event-pub", agent_name), &[])
+            .await;
+        let _ = workflow::publish_event(
+            &bus,
+            agent_name,
+            &DomainEvent::InstanceCreated {
+                instance_id: inst.id.clone(),
+                model: model_name.to_string(),
+                title: title.to_string(),
+                created_by: agent_name.to_string(),
+            },
+        )
+        .await;
+    }
 
     // If the initial state has an assignee, dispatch the first task via the bus.
     if !inst.assignee.is_empty() {
@@ -431,25 +437,30 @@ pub async fn sm_move(
     sm_store.move_to(&mut inst, &model, state, agent_name, note, None, None)?;
     info!(agent = %agent_name, instance = %id, from = %from, to = %state, "sm_move");
 
-    // Emit TransitionApplied event.
-    let _ = workflow::publish_event(
-        bus_socket,
-        agent_name,
-        &DomainEvent::TransitionApplied {
-            instance_id: id.to_string(),
-            from: from.clone(),
-            to: state.to_string(),
-            trigger: agent_name.to_string(),
-        },
-    )
-    .await;
+    // Emit TransitionApplied event and notify workflow engine via one-shot bus.
+    if let Ok(bus) = crate::infra::unix_bus::UnixBus::connect(bus_socket).await {
+        let _ = bus
+            .register(&format!("{}-event-pub", agent_name), &[])
+            .await;
+        let _ = workflow::publish_event(
+            &bus,
+            agent_name,
+            &DomainEvent::TransitionApplied {
+                instance_id: id.to_string(),
+                from: from.clone(),
+                to: state.to_string(),
+                trigger: agent_name.to_string(),
+            },
+        )
+        .await;
 
-    // Notify workflow engine to dispatch if the new state has an assignee.
-    if !inst.assignee.is_empty()
-        && !statemachine::is_terminal(&model, &inst)
-        && let Err(e) = crate::app::workflow::notify_moved(bus_socket, id, agent_name).await
-    {
-        tracing::warn!(agent = %agent_name, instance = %id, error = %e, "failed to notify workflow engine after sm_move");
+        // Notify workflow engine to dispatch if the new state has an assignee.
+        if !inst.assignee.is_empty()
+            && !statemachine::is_terminal(&model, &inst)
+            && let Err(e) = crate::app::workflow::notify_moved(&bus, id, agent_name).await
+        {
+            tracing::warn!(agent = %agent_name, instance = %id, error = %e, "failed to notify workflow engine after sm_move");
+        }
     }
 
     Ok(SmMoved {

--- a/src/app/timeout_sweep.rs
+++ b/src/app/timeout_sweep.rs
@@ -19,6 +19,7 @@ use crate::app::workflow;
 use crate::domain::events::DomainEvent;
 use crate::domain::statemachine::ModelDef;
 use crate::domain::task::TaskStatus;
+use crate::ports::bus::MessageBus;
 
 /// Parse a human-readable duration string into [`Duration`].
 ///
@@ -193,15 +194,18 @@ async fn sweep_once(models: &[ModelDef], bus_socket: &str) -> anyhow::Result<()>
         );
 
         // Emit TaskTimedOut event.
-        let _ = workflow::publish_event(
-            bus_socket,
-            "timeout-sweep",
-            &DomainEvent::TaskTimedOut {
-                task_id: task.id.clone(),
-                instance_id: Some(sm_id),
-            },
-        )
-        .await;
+        if let Ok(bus) = crate::infra::unix_bus::UnixBus::connect(bus_socket).await {
+            let _ = bus.register("timeout-sweep-event-pub", &[]).await;
+            let _ = workflow::publish_event(
+                &bus,
+                "timeout-sweep",
+                &DomainEvent::TaskTimedOut {
+                    task_id: task.id.clone(),
+                    instance_id: Some(sm_id),
+                },
+            )
+            .await;
+        }
     }
 
     Ok(())

--- a/src/app/workflow.rs
+++ b/src/app/workflow.rs
@@ -35,9 +35,7 @@ async fn emit_event(bus: &dyn MessageBus, event: &DomainEvent) {
 ///
 /// Used by callers outside the workflow engine (e.g. MCP handlers) to emit
 /// events without holding a persistent bus connection.
-pub async fn publish_event(bus_socket: &str, source: &str, event: &DomainEvent) -> Result<()> {
-    let bus = crate::infra::unix_bus::UnixBus::connect(bus_socket).await?;
-    bus.register(&format!("{}-event-pub", source), &[]).await?;
+pub async fn publish_event(bus: &dyn MessageBus, source: &str, event: &DomainEvent) -> Result<()> {
     let msg = Message {
         id: Uuid::new_v4().to_string(),
         source: source.to_string(),
@@ -55,11 +53,9 @@ pub async fn publish_event(bus_socket: &str, source: &str, event: &DomainEvent) 
 
 /// Notify the workflow engine that an SM instance was moved.
 ///
-/// Connects to the bus, sends an `action: "moved"` message to `sm:<id>`,
-/// and disconnects. The workflow engine picks this up and dispatches if needed.
-pub async fn notify_moved(bus_socket: &str, instance_id: &str, source: &str) -> Result<()> {
-    let bus = crate::infra::unix_bus::UnixBus::connect(bus_socket).await?;
-    bus.register(&format!("{}-sm-notify", source), &[]).await?;
+/// Sends an `action: "moved"` message to `sm:<id>` on the given bus.
+/// The workflow engine picks this up and dispatches if needed.
+pub async fn notify_moved(bus: &dyn MessageBus, instance_id: &str, source: &str) -> Result<()> {
     let msg = Message {
         id: Uuid::new_v4().to_string(),
         source: source.to_string(),

--- a/tests/workflow_transitions.rs
+++ b/tests/workflow_transitions.rs
@@ -14,6 +14,8 @@ use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
+use deskd::ports::bus::MessageBus;
+
 fn temp_socket() -> String {
     format!(
         "/tmp/deskd-test-wf-{}.sock",
@@ -537,7 +539,9 @@ async fn test_sm_move_notifies_workflow_engine() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Simulate what sm_move does: send "moved" notification via bus.
-    deskd::app::workflow::notify_moved(&socket, &inst.id, "cli")
+    let bus = deskd::infra::unix_bus::UnixBus::connect(&socket).await.unwrap();
+    bus.register("cli-sm-notify", &[]).await.unwrap();
+    deskd::app::workflow::notify_moved(&bus, &inst.id, "cli")
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- `publish_event` and `notify_moved` now accept `&dyn MessageBus` instead of hardcoding `UnixBus::connect()`
- `MainBranch::load/save` now accept `&dyn ContextRepository` instead of hardcoding `FileContextStore`
- Concrete infra construction moved to composition-root-adjacent callers (mcp_service, timeout_sweep, commands/sm, agent_process)

Closes #291

## Test plan
- [x] All existing unit tests pass
- [x] Integration tests updated and pass (`workflow_transitions`)
- [x] `cargo fmt + clippy + test` quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)