### PR TITLE
arch: remove tokio channel from Executor port trait (#295)

### DIFF
--- a/src/app/acp.rs
+++ b/src/app/acp.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
 
 use crate::app::agent::{
-    self, AgentConfig, Executor, TaskLimits, TokenUsage, TurnResult, build_command,
+    self, AgentConfig, Executor, ProgressSink, TaskLimits, TokenUsage, TurnResult, build_command,
 };
 use crate::app::jsonrpc::{
     JsonRpcRequest, JsonRpcResponse, MessageKind, classify_message, parse_response,
@@ -347,7 +347,7 @@ impl AcpProcess {
     async fn send_request(
         &self,
         req: &JsonRpcRequest,
-        progress_tx: Option<&tokio::sync::mpsc::UnboundedSender<String>>,
+        progress: Option<&ProgressSink>,
     ) -> Result<JsonRpcResponse> {
         let line = req.to_line()?;
         self.stdin_tx
@@ -376,8 +376,8 @@ impl AcpProcess {
                     let _ = self.stdin_tx.send(approval);
                 }
                 Some(AcpEvent::TextBlock(text)) => {
-                    if let Some(tx) = progress_tx {
-                        let _ = tx.send(text);
+                    if let Some(sink) = progress {
+                        sink(text);
                     }
                 }
                 Some(AcpEvent::SessionComplete) => {
@@ -447,7 +447,7 @@ impl AcpProcess {
     pub async fn send_task(
         &self,
         message: &str,
-        progress_tx: Option<&tokio::sync::mpsc::UnboundedSender<String>>,
+        progress: Option<&ProgressSink>,
         limits: &TaskLimits,
     ) -> Result<TurnResult> {
         let session_id = self
@@ -494,8 +494,8 @@ impl AcpProcess {
                         );
                     }
 
-                    if let Some(tx) = progress_tx {
-                        let _ = tx.send(text.clone());
+                    if let Some(sink) = progress {
+                        sink(text.clone());
                     }
                     response_text.push_str(&text);
                 }
@@ -587,7 +587,7 @@ impl Executor for AcpProcess {
     fn send_task<'a>(
         &'a self,
         message: &'a str,
-        progress_tx: Option<&'a tokio::sync::mpsc::UnboundedSender<String>>,
+        progress: Option<&'a ProgressSink>,
         image: Option<(&'a str, &'a str)>,
         limits: &'a TaskLimits,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<TurnResult>> + Send + 'a>> {
@@ -601,8 +601,7 @@ impl Executor for AcpProcess {
             } else {
                 message.to_string()
             };
-            self.send_task(&effective_message, progress_tx, limits)
-                .await
+            self.send_task(&effective_message, progress, limits).await
         })
     }
 

--- a/src/app/agent.rs
+++ b/src/app/agent.rs
@@ -15,7 +15,7 @@ pub use super::agent_registry::{
 pub use super::process_builder::build_command;
 
 // Re-export executor port types — canonical definitions live in ports::executor.
-pub use crate::ports::executor::{Executor, TaskLimits, TokenUsage, TurnResult};
+pub use crate::ports::executor::{Executor, ProgressSink, TaskLimits, TokenUsage, TurnResult};
 
 // Tests for TokenUsage live in ports::executor. Only keep re-export-level tests here.
 #[cfg(test)]
@@ -32,43 +32,41 @@ mod tests {
     }
 
     #[test]
-    fn test_token_usage_accumulate() {
-        let mut usage = TokenUsage::default();
-
+    fn test_token_usage_from_json() {
         let json1 = serde_json::json!({
             "input_tokens": 100,
             "output_tokens": 50,
             "cache_creation_input_tokens": 10,
             "cache_read_input_tokens": 20
         });
-        usage.accumulate(&json1);
+        let usage = TokenUsage::from(&json1);
         assert_eq!(usage.input_tokens, 100);
         assert_eq!(usage.output_tokens, 50);
         assert_eq!(usage.cache_creation_input_tokens, 10);
         assert_eq!(usage.cache_read_input_tokens, 20);
 
+        // Merge a second parsed usage
         let json2 = serde_json::json!({
             "input_tokens": 200,
             "output_tokens": 100,
             "cache_creation_input_tokens": 5,
             "cache_read_input_tokens": 30
         });
-        usage.accumulate(&json2);
-        assert_eq!(usage.input_tokens, 300);
-        assert_eq!(usage.output_tokens, 150);
-        assert_eq!(usage.cache_creation_input_tokens, 15);
-        assert_eq!(usage.cache_read_input_tokens, 50);
+        let mut accumulated = usage;
+        accumulated.merge(&TokenUsage::from(&json2));
+        assert_eq!(accumulated.input_tokens, 300);
+        assert_eq!(accumulated.output_tokens, 150);
+        assert_eq!(accumulated.cache_creation_input_tokens, 15);
+        assert_eq!(accumulated.cache_read_input_tokens, 50);
     }
 
     #[test]
-    fn test_token_usage_accumulate_partial() {
-        let mut usage = TokenUsage::default();
-
+    fn test_token_usage_from_json_partial() {
         let json = serde_json::json!({
             "input_tokens": 100,
             "output_tokens": 50
         });
-        usage.accumulate(&json);
+        let usage = TokenUsage::from(&json);
         assert_eq!(usage.input_tokens, 100);
         assert_eq!(usage.output_tokens, 50);
         assert_eq!(usage.cache_creation_input_tokens, 0);

--- a/src/app/agent_process.rs
+++ b/src/app/agent_process.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tracing::{debug, error, info, warn};
 
 use crate::infra::dto::ConfigSessionMode;
-use crate::ports::executor::{Executor, TaskLimits, TokenUsage, TurnResult};
+use crate::ports::executor::{Executor, ProgressSink, TaskLimits, TokenUsage, TurnResult};
 
 use super::agent_registry::{
     format_user_message, load_state, rotate_stream_log, save_state, save_state_pub,
@@ -466,11 +466,10 @@ impl AgentProcess {
                                     }
                                 }
                             }
-                            let usage = v.get("message").and_then(|m| m.get("usage")).map(|u| {
-                                let mut tu = TokenUsage::default();
-                                tu.accumulate(u);
-                                tu
-                            });
+                            let usage = v
+                                .get("message")
+                                .and_then(|m| m.get("usage"))
+                                .map(TokenUsage::from);
                             if (!block_text.is_empty() || usage.is_some())
                                 && event_tx
                                     .send(StdoutEvent::TextBlock(block_text, usage))
@@ -540,7 +539,7 @@ impl AgentProcess {
     pub async fn send_task(
         &self,
         message: &str,
-        progress_tx: Option<&tokio::sync::mpsc::UnboundedSender<String>>,
+        progress: Option<&ProgressSink>,
         image: Option<(&str, &str)>,
         limits: &TaskLimits,
     ) -> Result<TurnResult> {
@@ -681,8 +680,8 @@ impl AgentProcess {
                             );
                         }
 
-                        if let Some(tx) = &progress_tx {
-                            let _ = tx.send(text.clone());
+                        if let Some(sink) = &progress {
+                            sink(text.clone());
                         }
                         response_text.push_str(&text);
                     }
@@ -694,8 +693,8 @@ impl AgentProcess {
                             len = trailing.len(),
                             "drained trailing text block after result event"
                         );
-                        if let Some(tx) = &progress_tx {
-                            let _ = tx.send(trailing.clone());
+                        if let Some(sink) = &progress {
+                            sink(trailing.clone());
                         }
                         response_text.push_str(&trailing);
                     }
@@ -792,11 +791,11 @@ impl Executor for AgentProcess {
     fn send_task<'a>(
         &'a self,
         message: &'a str,
-        progress_tx: Option<&'a tokio::sync::mpsc::UnboundedSender<String>>,
+        progress: Option<&'a ProgressSink>,
         image: Option<(&'a str, &'a str)>,
         limits: &'a TaskLimits,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<TurnResult>> + Send + 'a>> {
-        Box::pin(self.send_task(message, progress_tx, image, limits))
+        Box::pin(self.send_task(message, progress, image, limits))
     }
 
     fn inject_message(&self, message: &str) -> Result<()> {

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -407,9 +407,14 @@ pub async fn run(
 
         let task_start = std::time::Instant::now();
 
+        // Wrap the tokio channel sender in a closure for the Executor trait.
+        let progress_sink = move |text: String| {
+            let _ = progress_tx.send(text);
+        };
+
         // Use the persistent process. send_task writes to its stdin and reads
         // stdout events until the result event marks the turn complete.
-        let mut task_fut = Box::pin(process.send_task(task, Some(&progress_tx), image, &limits));
+        let mut task_fut = Box::pin(process.send_task(task, Some(&progress_sink), image, &limits));
 
         // Concurrently await task completion OR new bus messages for injection.
         let result = loop {
@@ -462,9 +467,10 @@ pub async fn run(
             }
         };
 
-        // Drop the future to release borrows on process and progress_tx.
+        // Drop the future to release borrows on process and progress_sink,
+        // then drop the sink itself to close the underlying channel.
         drop(task_fut);
-        drop(progress_tx);
+        drop(progress_sink);
         let full_response = fwd_task.await.unwrap_or_default();
 
         // Stop Telegram progress indicators.

--- a/src/infra/dto/bus.rs
+++ b/src/infra/dto/bus.rs
@@ -178,6 +178,39 @@ impl From<&DomainEvent> for serde_json::Value {
     }
 }
 
+// ─── TokenUsage JSON parsing ────────────────────────────────────────────────
+
+use crate::ports::executor::TokenUsage;
+
+/// Parse a Claude `usage` JSON object into a [`TokenUsage`] struct.
+///
+/// Expects the `usage` object from Claude's assistant message, e.g.:
+/// ```json
+/// { "input_tokens": 100, "output_tokens": 50, "cache_read_input_tokens": 10 }
+/// ```
+impl From<&serde_json::Value> for TokenUsage {
+    fn from(usage: &serde_json::Value) -> Self {
+        Self {
+            input_tokens: usage
+                .get("input_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+            output_tokens: usage
+                .get("output_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+            cache_creation_input_tokens: usage
+                .get("cache_creation_input_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+            cache_read_input_tokens: usage
+                .get("cache_read_input_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ports/executor.rs
+++ b/src/ports/executor.rs
@@ -8,6 +8,12 @@ use anyhow::Result;
 use std::future::Future;
 use std::pin::Pin;
 
+/// Callback for streaming progress text chunks from the executor.
+///
+/// Implementations call this with each text chunk as it arrives.
+/// The concrete channel/mechanism is chosen by the caller, not the port.
+pub type ProgressSink = dyn Fn(String) + Send + Sync;
+
 /// Accumulated token usage across all messages in a task.
 #[derive(Debug, Clone, Default)]
 pub struct TokenUsage {
@@ -24,29 +30,6 @@ impl TokenUsage {
         self.output_tokens += other.output_tokens;
         self.cache_creation_input_tokens += other.cache_creation_input_tokens;
         self.cache_read_input_tokens += other.cache_read_input_tokens;
-    }
-
-    /// Accumulate usage from a parsed JSON value.
-    /// Expects the `usage` object from a Claude assistant message.
-    pub fn accumulate(&mut self, usage: &serde_json::Value) {
-        if let Some(v) = usage.get("input_tokens").and_then(|v| v.as_u64()) {
-            self.input_tokens += v;
-        }
-        if let Some(v) = usage.get("output_tokens").and_then(|v| v.as_u64()) {
-            self.output_tokens += v;
-        }
-        if let Some(v) = usage
-            .get("cache_creation_input_tokens")
-            .and_then(|v| v.as_u64())
-        {
-            self.cache_creation_input_tokens += v;
-        }
-        if let Some(v) = usage
-            .get("cache_read_input_tokens")
-            .and_then(|v| v.as_u64())
-        {
-            self.cache_read_input_tokens += v;
-        }
     }
 }
 
@@ -78,12 +61,12 @@ pub struct TurnResult {
 pub trait Executor: Send {
     /// Send a task to the executor and wait for completion.
     ///
-    /// `progress_tx` receives streaming text chunks for real-time progress.
+    /// `progress` receives streaming text chunks for real-time progress.
     /// `image` is an optional (base64_data, media_type) pair for image attachments.
     fn send_task<'a>(
         &'a self,
         message: &'a str,
-        progress_tx: Option<&'a tokio::sync::mpsc::UnboundedSender<String>>,
+        progress: Option<&'a ProgressSink>,
         image: Option<(&'a str, &'a str)>,
         limits: &'a TaskLimits,
     ) -> Pin<Box<dyn Future<Output = Result<TurnResult>> + Send + 'a>>;


### PR DESCRIPTION
## Summary
- Replace `tokio::sync::mpsc::UnboundedSender<String>` in `Executor::send_task` with `ProgressSink` (`dyn Fn(String) + Send + Sync`) — ports no longer depend on tokio
- Move `TokenUsage::accumulate()` JSON parsing from ports to infra DTO layer as `From<&serde_json::Value> for TokenUsage`
- Executor port now imports zero infra/framework crates
- Worker wraps tokio channel in a closure at the call site (composition root)

Closes #295

## Test plan
- [x] All unit tests pass (including updated TokenUsage tests)
- [x] All integration tests pass
- [x] `cargo fmt + clippy + test` quality gate passes
- [x] `src/ports/executor.rs` has no tokio or serde_json imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)