### PR TITLE
fix: tui truncate panics on multi-byte UTF-8 characters (#308)

### DIFF
--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -237,12 +237,14 @@ pub mod app {
         truncate(&s, 80)
     }
 
-    fn truncate(s: &str, max: usize) -> String {
+    pub(crate) fn truncate(s: &str, max: usize) -> String {
         let clean: String = s.chars().filter(|c| !c.is_control()).collect();
-        if clean.len() <= max {
+        let char_count = clean.chars().count();
+        if char_count <= max {
             clean
         } else {
-            format!("{}…", &clean[..max])
+            let truncated: String = clean.chars().take(max).collect();
+            format!("{}…", truncated)
         }
     }
 
@@ -571,5 +573,47 @@ pub mod app {
         terminal.show_cursor()?;
 
         Ok(app.should_quit_all)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::truncate;
+
+        #[test]
+        fn test_truncate_short_string() {
+            assert_eq!(truncate("hello", 10), "hello");
+        }
+
+        #[test]
+        fn test_truncate_exact_length() {
+            assert_eq!(truncate("hello", 5), "hello");
+        }
+
+        #[test]
+        fn test_truncate_long_ascii() {
+            assert_eq!(truncate("hello world", 5), "hello…");
+        }
+
+        #[test]
+        fn test_truncate_multibyte_no_panic() {
+            // Each char is 4 bytes in UTF-8; byte-slicing at max would panic
+            let s = "🦀🦀🦀🦀🦀";
+            let result = truncate(s, 3);
+            assert_eq!(result, "🦀🦀🦀…");
+        }
+
+        #[test]
+        fn test_truncate_cyrillic() {
+            // Each Cyrillic char is 2 bytes; max=3 chars
+            let s = "привет"; // 6 chars, 12 bytes
+            let result = truncate(s, 3);
+            assert_eq!(result, "при…");
+        }
+
+        #[test]
+        fn test_truncate_strips_control_chars() {
+            let s = "ab\x00cd";
+            assert_eq!(truncate(s, 10), "abcd");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Replace byte-slice `&clean[..max]` with char-based truncation using `clean.chars().take(max).collect()`
- Fix the comparison from `clean.len()` (byte count) to `clean.chars().count()` (char count)
- Add 6 unit tests covering ASCII, multi-byte emoji (🦀), Cyrillic, and control char filtering

Fixes #308

## Root Cause

`tui.rs:246` used `&clean[..max]` where `max` is a character limit but was used as a byte index. For multi-byte UTF-8 strings (emoji, CJK, Cyrillic, etc.), this panics when `max` falls in the middle of a multi-byte sequence.

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` — all pass
- [x] `cargo test --features tui` — 6 new tui truncate tests pass
- [x] `test_truncate_multibyte_no_panic` — emoji string truncation no longer panics
- [x] `test_truncate_cyrillic` — Cyrillic (2-byte chars) truncated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)