### PR TITLE
Add `deskd bus api` subcommand for standalone bus API

### DIFF
--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -412,4 +412,26 @@ pub enum BusAction {
         #[arg(long, default_value = DEFAULT_SOCKET)]
         socket: String,
     },
+    /// Start the bus API handler on an existing bus socket.
+    ///
+    /// Connects to a running bus and exposes the query/command API
+    /// (agent_list, task_list, sm_list, etc.) so external tools like
+    /// viewgraph can use the structured API without a full `deskd serve`.
+    ///
+    /// Examples:
+    ///   deskd bus api --socket /home/kira/.deskd/bus.sock
+    ///   DESKD_BUS_SOCKET=/tmp/bus.sock deskd bus api
+    Api {
+        /// Bus socket path. Defaults to $DESKD_BUS_SOCKET, or auto-discovered
+        /// from running serve state.
+        #[arg(long, env = "DESKD_BUS_SOCKET")]
+        socket: Option<String>,
+        /// Path to deskd.yaml for SM models and schedules.
+        /// Defaults to $DESKD_AGENT_CONFIG, or auto-discovered from serve state.
+        #[arg(long, env = "DESKD_AGENT_CONFIG")]
+        config: Option<String>,
+        /// Agent name for API responses. Defaults to $DESKD_AGENT_NAME or "cli".
+        #[arg(long, env = "DESKD_AGENT_NAME")]
+        agent: Option<String>,
+    },
 }

--- a/src/app/commands/bus.rs
+++ b/src/app/commands/bus.rs
@@ -3,11 +3,20 @@
 use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
+use tracing::info;
 
 use crate::app::cli::BusAction;
+use crate::config;
 
 pub async fn handle(action: BusAction) -> Result<()> {
     match action {
+        BusAction::Api {
+            socket,
+            config: config_opt,
+            agent,
+        } => {
+            return handle_api(socket, config_opt, agent).await;
+        }
         BusAction::Status { socket } => {
             if !std::path::Path::new(&socket).exists() {
                 println!("Bus is not running (socket not found: {})", socket);
@@ -139,4 +148,66 @@ pub async fn handle(action: BusAction) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Resolve the bus socket path from: explicit flag > serve state > error.
+fn resolve_bus_socket(explicit: Option<String>) -> Result<String> {
+    if let Some(path) = explicit {
+        return Ok(path);
+    }
+    if let Some(state) = config::ServeState::load()
+        && let Some(agent) = state.find_agent_config()
+    {
+        return Ok(agent.bus_socket.clone());
+    }
+    anyhow::bail!(
+        "no --socket provided, $DESKD_BUS_SOCKET not set, and no running serve state found"
+    )
+}
+
+/// Resolve the agent config (deskd.yaml) path from: explicit flag > serve state > None.
+fn resolve_config(explicit: Option<String>) -> Option<String> {
+    if let Some(path) = explicit {
+        return Some(path);
+    }
+    config::ServeState::load()
+        .and_then(|state| state.find_agent_config().map(|a| a.config_path.clone()))
+}
+
+async fn handle_api(
+    socket: Option<String>,
+    config_opt: Option<String>,
+    agent: Option<String>,
+) -> Result<()> {
+    let bus_socket = resolve_bus_socket(socket)?;
+    let agent_name = agent.unwrap_or_else(|| "cli".to_string());
+
+    if !std::path::Path::new(&bus_socket).exists() {
+        anyhow::bail!("Bus socket not found: {}", bus_socket);
+    }
+
+    let user_config = resolve_config(config_opt)
+        .and_then(|path| match config::UserConfig::load(&path) {
+            Ok(cfg) => {
+                info!(config = %path, "loaded user config");
+                Some(cfg)
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, path = %path, "failed to load user config, continuing without");
+                None
+            }
+        });
+
+    let task_store = crate::app::task::TaskStore::default_for_home();
+    let sm_store = crate::app::statemachine::StateMachineStore::default_for_home();
+
+    info!(socket = %bus_socket, agent = %agent_name, "starting bus API handler");
+    crate::app::bus_api::run(
+        &bus_socket,
+        &task_store,
+        &sm_store,
+        user_config.as_ref(),
+        &agent_name,
+    )
+    .await
 }

--- a/src/app/commands/sm.rs
+++ b/src/app/commands/sm.rs
@@ -137,8 +137,7 @@ pub async fn handle(
                     socket
                 });
                 if std::path::Path::new(&bus_socket).exists()
-                    && let Ok(bus) =
-                        crate::infra::unix_bus::UnixBus::connect(&bus_socket).await
+                    && let Ok(bus) = crate::infra::unix_bus::UnixBus::connect(&bus_socket).await
                 {
                     let _ = bus.register("cli-sm-notify", &[]).await;
                     if let Err(e) = workflow::notify_moved(&bus, &id, "cli").await {

--- a/tests/workflow_transitions.rs
+++ b/tests/workflow_transitions.rs
@@ -539,7 +539,9 @@ async fn test_sm_move_notifies_workflow_engine() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Simulate what sm_move does: send "moved" notification via bus.
-    let bus = deskd::infra::unix_bus::UnixBus::connect(&socket).await.unwrap();
+    let bus = deskd::infra::unix_bus::UnixBus::connect(&socket)
+        .await
+        .unwrap();
     bus.register("cli-sm-notify", &[]).await.unwrap();
     deskd::app::workflow::notify_moved(&bus, &inst.id, "cli")
         .await


### PR DESCRIPTION
## Summary

- Adds `deskd bus api` CLI subcommand that starts the bus_api handler on an existing bus socket
- Enables external tools (like viewgraph TUI) to connect to any running bus and use the structured query/command API without running a full `deskd serve`
- Auto-discovers bus socket from `$DESKD_BUS_SOCKET` env var or serve state; loads UserConfig from `$DESKD_AGENT_CONFIG` or serve state

## Test plan

- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` passes
- [ ] `deskd bus api --help` shows the new subcommand with socket/config/agent flags
- [ ] Running `deskd bus api --socket /path/to/bus.sock` connects to the bus and serves API queries
- [ ] Without `--socket`, falls back to `$DESKD_BUS_SOCKET` then serve state auto-discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)