### PR TITLE
feat: TUI Dashboard + Bus Stream — first useful views

### DIFF
--- a/tui/src/hooks/useAgents.ts
+++ b/tui/src/hooks/useAgents.ts
@@ -1,0 +1,131 @@
+/**
+ * Hook: agent state tracking from bus messages.
+ *
+ * Listens for bus messages about agents and maintains an up-to-date
+ * map of agent states including status, model, current task, and cost.
+ */
+
+import { useState, useEffect } from "react";
+import type { BusClient, BusMessage } from "../bus.js";
+
+export interface AgentState {
+  name: string;
+  status: "online" | "busy" | "idle" | "offline";
+  model?: string;
+  currentTask?: string;
+  costUsd: number;
+  lastSeen: number;
+}
+
+function extractAgentInfo(msg: BusMessage): Partial<AgentState> | null {
+  const payload = msg.payload as Record<string, unknown> | undefined;
+  if (!payload) return null;
+
+  // Agent registration / heartbeat
+  if (msg.type === "register" || msg.type === "heartbeat") {
+    return {
+      name: (msg.source ?? msg.name as string) || undefined,
+      status: "online",
+      model: payload.model as string | undefined,
+      lastSeen: Date.now(),
+    };
+  }
+
+  // Agent status update
+  if (msg.type === "status" || payload.action === "status") {
+    return {
+      name: msg.source || undefined,
+      status: (payload.status as AgentState["status"]) || "online",
+      model: payload.model as string | undefined,
+      currentTask: payload.task as string | undefined,
+      costUsd: typeof payload.cost === "number" ? payload.cost : undefined,
+      lastSeen: Date.now(),
+    };
+  }
+
+  // Task assignment — mark agent as busy
+  if (msg.type === "message" && msg.target?.startsWith("agent:")) {
+    const agentName = msg.target.slice(6);
+    const task =
+      typeof payload.task === "string"
+        ? payload.task
+        : typeof payload.text === "string"
+          ? payload.text
+          : undefined;
+    if (task) {
+      return {
+        name: agentName,
+        status: "busy",
+        currentTask:
+          task.length > 60 ? task.slice(0, 57) + "..." : task,
+        lastSeen: Date.now(),
+      };
+    }
+  }
+
+  // Task result — mark agent back to idle
+  if (
+    msg.type === "message" &&
+    msg.source &&
+    payload.result !== undefined
+  ) {
+    return {
+      name: msg.source,
+      status: "idle",
+      currentTask: undefined,
+      lastSeen: Date.now(),
+    };
+  }
+
+  // Cost update
+  if (payload.cost_usd !== undefined && msg.source) {
+    return {
+      name: msg.source,
+      costUsd: payload.cost_usd as number,
+      lastSeen: Date.now(),
+    };
+  }
+
+  return null;
+}
+
+export function useAgents(bus: BusClient): AgentState[] {
+  const [agents, setAgents] = useState<Map<string, AgentState>>(new Map());
+
+  useEffect(() => {
+    const onMessage = (msg: BusMessage) => {
+      const info = extractAgentInfo(msg);
+      if (!info || !info.name) return;
+
+      setAgents((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(info.name!) ?? {
+          name: info.name!,
+          status: "offline" as const,
+          costUsd: 0,
+          lastSeen: 0,
+        };
+        next.set(info.name!, {
+          ...existing,
+          ...Object.fromEntries(
+            Object.entries(info).filter(([, v]) => v !== undefined),
+          ),
+        } as AgentState);
+        return next;
+      });
+    };
+
+    bus.on("message", onMessage);
+
+    // Request client list
+    bus.send({ type: "list" });
+
+    return () => {
+      bus.off("message", onMessage);
+    };
+  }, [bus]);
+
+  return Array.from(agents.values()).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+}

--- a/tui/src/hooks/useBus.ts
+++ b/tui/src/hooks/useBus.ts
@@ -1,0 +1,103 @@
+/**
+ * Hook: raw bus message ring buffer.
+ *
+ * Subscribes to all bus messages and maintains a capped ring buffer
+ * of the most recent 2000 messages. Provides filtering utilities.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { BusClient, BusMessage } from "../bus.js";
+
+const RING_BUFFER_CAP = 2000;
+
+export interface BusFilter {
+  source?: string;
+  target?: string;
+  type?: string;
+  freetext?: string;
+}
+
+/** Parse filter string like "source:tui target:agent:dev some text" */
+export function parseFilter(input: string): BusFilter {
+  const filter: BusFilter = {};
+  const freeWords: string[] = [];
+
+  const tokens = input.trim().split(/\s+/);
+  for (const token of tokens) {
+    if (token.startsWith("source:")) {
+      filter.source = token.slice(7);
+    } else if (token.startsWith("target:")) {
+      filter.target = token.slice(7);
+    } else if (token.startsWith("type:")) {
+      filter.type = token.slice(5);
+    } else {
+      freeWords.push(token);
+    }
+  }
+
+  if (freeWords.length > 0) {
+    filter.freetext = freeWords.join(" ");
+  }
+
+  return filter;
+}
+
+/** Check if a message matches a filter. */
+export function matchesFilter(msg: BusMessage, filter: BusFilter): boolean {
+  if (filter.source && msg.source !== filter.source) return false;
+  if (filter.target && msg.target !== filter.target) return false;
+  if (filter.type && msg.type !== filter.type) return false;
+  if (filter.freetext) {
+    const text = JSON.stringify(msg).toLowerCase();
+    if (!text.includes(filter.freetext.toLowerCase())) return false;
+  }
+  return true;
+}
+
+export interface UseBusResult {
+  messages: BusMessage[];
+  filtered: (filter: BusFilter) => BusMessage[];
+  tail: (count: number) => BusMessage[];
+}
+
+export function useBus(bus: BusClient): UseBusResult {
+  const [messages, setMessages] = useState<BusMessage[]>([]);
+  const messagesRef = useRef<BusMessage[]>([]);
+
+  useEffect(() => {
+    // Seed with existing messages from bus client
+    const existing = [...bus.messages];
+    messagesRef.current = existing;
+    setMessages(existing);
+
+    const onMessage = (msg: BusMessage) => {
+      const next = [...messagesRef.current, msg];
+      if (next.length > RING_BUFFER_CAP) {
+        next.splice(0, next.length - RING_BUFFER_CAP);
+      }
+      messagesRef.current = next;
+      setMessages(next);
+    };
+
+    bus.on("message", onMessage);
+    return () => {
+      bus.off("message", onMessage);
+    };
+  }, [bus]);
+
+  const filtered = useCallback(
+    (filter: BusFilter): BusMessage[] => {
+      return messages.filter((m) => matchesFilter(m, filter));
+    },
+    [messages],
+  );
+
+  const tail = useCallback(
+    (count: number): BusMessage[] => {
+      return messages.slice(-count);
+    },
+    [messages],
+  );
+
+  return { messages, filtered, tail };
+}

--- a/tui/src/hooks/useTasks.ts
+++ b/tui/src/hooks/useTasks.ts
@@ -1,0 +1,139 @@
+/**
+ * Hook: task state tracking from bus messages.
+ *
+ * Listens for bus messages about tasks and maintains a list of recent
+ * tasks with their status, assignee, and timestamps.
+ */
+
+import { useState, useEffect } from "react";
+import type { BusClient, BusMessage } from "../bus.js";
+
+export type TaskStatus = "pending" | "running" | "done" | "failed" | "cancelled";
+
+export interface TaskState {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  assignee?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+const MAX_TASKS = 100;
+
+function extractTaskInfo(msg: BusMessage): Partial<TaskState> | null {
+  const payload = msg.payload as Record<string, unknown> | undefined;
+  if (!payload) return null;
+
+  // Task creation
+  if (payload.action === "task_create" || msg.type === "task_create") {
+    const task = (payload.task ?? payload.text ?? payload.title) as string;
+    return {
+      id: (payload.task_id as string) || msg.id || `task-${Date.now()}`,
+      title: typeof task === "string"
+        ? task.length > 80 ? task.slice(0, 77) + "..." : task
+        : "untitled",
+      status: "pending",
+      assignee: (payload.assignee as string) || msg.target?.replace("agent:", ""),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  }
+
+  // Task sent to agent — infer as running
+  if (
+    msg.type === "message" &&
+    msg.target?.startsWith("agent:") &&
+    (payload.task || payload.text)
+  ) {
+    const task = (payload.task ?? payload.text) as string;
+    return {
+      id: (payload.task_id as string) || msg.id || `task-${Date.now()}`,
+      title: typeof task === "string"
+        ? task.length > 80 ? task.slice(0, 77) + "..." : task
+        : "untitled",
+      status: "running",
+      assignee: msg.target.slice(6),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  }
+
+  // Task result — completed
+  if (payload.result !== undefined && msg.source) {
+    const taskId = (payload.task_id as string) || msg.id;
+    if (taskId) {
+      return {
+        id: taskId,
+        status: payload.error ? "failed" : "done",
+        updatedAt: Date.now(),
+      };
+    }
+  }
+
+  // Explicit status update
+  if (payload.action === "task_status" || msg.type === "task_status") {
+    return {
+      id: (payload.task_id as string) || msg.id || "",
+      status: (payload.status as TaskStatus) || "running",
+      updatedAt: Date.now(),
+    };
+  }
+
+  return null;
+}
+
+export function useTasks(bus: BusClient): TaskState[] {
+  const [tasks, setTasks] = useState<Map<string, TaskState>>(new Map());
+
+  useEffect(() => {
+    const onMessage = (msg: BusMessage) => {
+      const info = extractTaskInfo(msg);
+      if (!info || !info.id) return;
+
+      setTasks((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(info.id!);
+
+        if (existing) {
+          next.set(info.id!, {
+            ...existing,
+            ...Object.fromEntries(
+              Object.entries(info).filter(([, v]) => v !== undefined),
+            ),
+          } as TaskState);
+        } else if (info.title) {
+          next.set(info.id!, {
+            id: info.id!,
+            title: info.title,
+            status: info.status ?? "pending",
+            assignee: info.assignee,
+            createdAt: info.createdAt ?? Date.now(),
+            updatedAt: info.updatedAt ?? Date.now(),
+          });
+        }
+
+        // Cap at MAX_TASKS — remove oldest
+        if (next.size > MAX_TASKS) {
+          const entries = Array.from(next.entries()).sort(
+            (a, b) => a[1].updatedAt - b[1].updatedAt,
+          );
+          for (let i = 0; i < entries.length - MAX_TASKS; i++) {
+            next.delete(entries[i]![0]);
+          }
+        }
+
+        return next;
+      });
+    };
+
+    bus.on("message", onMessage);
+    return () => {
+      bus.off("message", onMessage);
+    };
+  }, [bus]);
+
+  return Array.from(tasks.values()).sort(
+    (a, b) => b.updatedAt - a.updatedAt,
+  );
+}

--- a/tui/src/hooks/useWorkflows.ts
+++ b/tui/src/hooks/useWorkflows.ts
@@ -1,0 +1,132 @@
+/**
+ * Hook: workflow / state machine tracking from bus messages.
+ *
+ * Listens for bus messages about graph executions and workflow state
+ * machines, maintaining a list of active instances.
+ */
+
+import { useState, useEffect } from "react";
+import type { BusClient, BusMessage } from "../bus.js";
+
+export interface WorkflowState {
+  id: string;
+  name: string;
+  currentState: string;
+  costUsd: number;
+  startedAt: number;
+  updatedAt: number;
+}
+
+const MAX_WORKFLOWS = 50;
+
+function extractWorkflowInfo(msg: BusMessage): Partial<WorkflowState> | null {
+  const payload = msg.payload as Record<string, unknown> | undefined;
+  if (!payload) return null;
+
+  // Graph/workflow start
+  if (
+    msg.type === "graph_start" ||
+    payload.action === "graph_start" ||
+    payload.action === "workflow_start"
+  ) {
+    return {
+      id: (payload.graph_id as string) || (payload.workflow_id as string) || msg.id || `wf-${Date.now()}`,
+      name: (payload.name as string) || (payload.file as string) || "unnamed",
+      currentState: "started",
+      costUsd: 0,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  }
+
+  // State transition
+  if (
+    msg.type === "graph_step" ||
+    payload.action === "graph_step" ||
+    payload.action === "workflow_transition"
+  ) {
+    const id = (payload.graph_id as string) || (payload.workflow_id as string) || msg.id;
+    if (id) {
+      return {
+        id,
+        currentState: (payload.state as string) || (payload.node as string) || "unknown",
+        costUsd: typeof payload.cost === "number" ? payload.cost : undefined,
+        updatedAt: Date.now(),
+      };
+    }
+  }
+
+  // Graph/workflow completion
+  if (
+    msg.type === "graph_complete" ||
+    payload.action === "graph_complete" ||
+    payload.action === "workflow_complete"
+  ) {
+    const id = (payload.graph_id as string) || (payload.workflow_id as string) || msg.id;
+    if (id) {
+      return {
+        id,
+        currentState: payload.error ? "failed" : "completed",
+        costUsd: typeof payload.cost === "number" ? payload.cost : undefined,
+        updatedAt: Date.now(),
+      };
+    }
+  }
+
+  return null;
+}
+
+export function useWorkflows(bus: BusClient): WorkflowState[] {
+  const [workflows, setWorkflows] = useState<Map<string, WorkflowState>>(new Map());
+
+  useEffect(() => {
+    const onMessage = (msg: BusMessage) => {
+      const info = extractWorkflowInfo(msg);
+      if (!info || !info.id) return;
+
+      setWorkflows((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(info.id!);
+
+        if (existing) {
+          next.set(info.id!, {
+            ...existing,
+            ...Object.fromEntries(
+              Object.entries(info).filter(([, v]) => v !== undefined),
+            ),
+          } as WorkflowState);
+        } else if (info.name) {
+          next.set(info.id!, {
+            id: info.id!,
+            name: info.name,
+            currentState: info.currentState ?? "unknown",
+            costUsd: info.costUsd ?? 0,
+            startedAt: info.startedAt ?? Date.now(),
+            updatedAt: info.updatedAt ?? Date.now(),
+          });
+        }
+
+        // Cap
+        if (next.size > MAX_WORKFLOWS) {
+          const entries = Array.from(next.entries()).sort(
+            (a, b) => a[1].updatedAt - b[1].updatedAt,
+          );
+          for (let i = 0; i < entries.length - MAX_WORKFLOWS; i++) {
+            next.delete(entries[i]![0]);
+          }
+        }
+
+        return next;
+      });
+    };
+
+    bus.on("message", onMessage);
+    return () => {
+      bus.off("message", onMessage);
+    };
+  }, [bus]);
+
+  return Array.from(workflows.values()).sort(
+    (a, b) => b.updatedAt - a.updatedAt,
+  );
+}

--- a/tui/src/views/BusStream.tsx
+++ b/tui/src/views/BusStream.tsx
@@ -1,24 +1,246 @@
-import { Box, Text } from "ink";
-import { colors } from "../theme.js";
-import type { ViewProps } from "./types.js";
+/**
+ * BusStream view (View 2) — full-screen live message tail.
+ *
+ * Features:
+ *   - Timestamp, source -> target, payload display
+ *   - Follow mode (auto-scroll, toggle with 'f')
+ *   - Filter syntax: source:X, target:X, type:event, freetext
+ *   - Compact mode toggle ('c') — 1 line vs multi-line per message
+ *   - Ring buffer of 2000 messages via useBus hook
+ */
 
-export function BusStream({ messages }: ViewProps) {
-  const recent = messages.slice(-20);
+import { useState, useMemo } from "react";
+import { Box, Text, useInput } from "ink";
+import { colors, symbols } from "../theme.js";
+import type { ViewProps } from "./types.js";
+import {
+  useBus,
+  parseFilter,
+  matchesFilter,
+} from "../hooks/useBus.js";
+import type { BusMessage } from "../bus.js";
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const h = d.getHours().toString().padStart(2, "0");
+  const m = d.getMinutes().toString().padStart(2, "0");
+  const s = d.getSeconds().toString().padStart(2, "0");
+  const ms = d.getMilliseconds().toString().padStart(3, "0");
+  return `${h}:${m}:${s}.${ms}`;
+}
+
+function formatPayload(payload: unknown, compact: boolean): string {
+  if (payload === undefined || payload === null) return "";
+  if (typeof payload === "string") return payload;
+  try {
+    if (compact) {
+      const s = JSON.stringify(payload);
+      return s.length > 80 ? s.slice(0, 77) + "..." : s;
+    }
+    return JSON.stringify(payload, null, 2);
+  } catch {
+    return String(payload);
+  }
+}
+
+interface MessageWithTimestamp {
+  msg: BusMessage;
+  receivedAt: number;
+}
+
+function CompactMessage({ entry }: { entry: MessageWithTimestamp }) {
+  const { msg, receivedAt } = entry;
+  const src = msg.source ?? "?";
+  const tgt = msg.target ?? "*";
+  const payloadStr = formatPayload(msg.payload, true);
 
   return (
-    <Box flexDirection="column" padding={1}>
-      <Text bold color={colors.primary}>
-        Bus Stream
+    <Text wrap="truncate">
+      <Text color={colors.textDim}>{formatTime(receivedAt)}</Text>
+      {" "}
+      <Text color={colors.secondary}>{src}</Text>
+      <Text color={colors.textDim}> {symbols.arrow} </Text>
+      <Text color={colors.primary}>{tgt}</Text>
+      {" "}
+      <Text color={colors.muted}>[{msg.type}]</Text>
+      {payloadStr ? (
+        <Text color={colors.text}> {payloadStr}</Text>
+      ) : null}
+    </Text>
+  );
+}
+
+function ExpandedMessage({ entry }: { entry: MessageWithTimestamp }) {
+  const { msg, receivedAt } = entry;
+  const src = msg.source ?? "?";
+  const tgt = msg.target ?? "*";
+  const payloadStr = formatPayload(msg.payload, false);
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text>
+        <Text color={colors.textDim}>{formatTime(receivedAt)}</Text>
+        {" "}
+        <Text color={colors.secondary} bold>{src}</Text>
+        <Text color={colors.textDim}> {symbols.arrow} </Text>
+        <Text color={colors.primary} bold>{tgt}</Text>
+        {" "}
+        <Text color={colors.muted}>[{msg.type}]</Text>
+        {msg.id ? <Text color={colors.textDim}> id:{msg.id}</Text> : null}
       </Text>
-      <Text color={colors.textDim}>Raw bus messages (last {recent.length})</Text>
-      <Box flexDirection="column" marginTop={1}>
-        {recent.map((msg, i) => (
-          <Text key={i} color={colors.text} wrap="truncate">
-            {JSON.stringify(msg)}
+      {payloadStr ? (
+        <Box paddingLeft={2}>
+          <Text color={colors.text}>{payloadStr}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+export function BusStream({ bus }: ViewProps) {
+  const [follow, setFollow] = useState(true);
+  const [compact, setCompact] = useState(true);
+  const [filterText, setFilterText] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  const { messages } = useBus(bus);
+
+  // Attach timestamps (approximate — use current time for display)
+  const timestamped: MessageWithTimestamp[] = useMemo(
+    () => messages.map((msg) => ({ msg, receivedAt: Date.now() })),
+    [messages],
+  );
+
+  // Apply filter
+  const filter = useMemo(() => parseFilter(filterText), [filterText]);
+  const filtered = useMemo(() => {
+    if (!filterText.trim()) return timestamped;
+    return timestamped.filter((e) => matchesFilter(e.msg, filter));
+  }, [timestamped, filterText, filter]);
+
+  // Visible messages
+  const maxVisible = compact ? 30 : 12;
+  const visible = useMemo(() => {
+    if (follow) {
+      return filtered.slice(-maxVisible);
+    }
+    const start = Math.max(0, filtered.length - maxVisible - scrollOffset);
+    return filtered.slice(start, start + maxVisible);
+  }, [filtered, follow, scrollOffset, maxVisible]);
+
+  useInput((input, key) => {
+    if (editing) {
+      if (key.return || key.escape) {
+        setEditing(false);
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setFilterText((prev) => prev.slice(0, -1));
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) {
+        setFilterText((prev) => prev + input);
+        return;
+      }
+      return;
+    }
+
+    if (input === "f") {
+      setFollow((prev) => !prev);
+      setScrollOffset(0);
+      return;
+    }
+    if (input === "c") {
+      setCompact((prev) => !prev);
+      return;
+    }
+    if (input === "/") {
+      setEditing(true);
+      return;
+    }
+    if (key.escape) {
+      setFilterText("");
+      return;
+    }
+    if (key.upArrow && !follow) {
+      setScrollOffset((prev) => Math.min(prev + 1, filtered.length - maxVisible));
+      return;
+    }
+    if (key.downArrow && !follow) {
+      setScrollOffset((prev) => Math.max(prev - 1, 0));
+      return;
+    }
+  });
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      {/* Header bar */}
+      <Box paddingX={1}>
+        <Text color={colors.primary} bold>Bus Stream</Text>
+        <Text color={colors.textDim}>
+          {"  "}|{"  "}
+          {filtered.length} msgs
+          {"  "}|{"  "}
+        </Text>
+        <Text color={follow ? colors.success : colors.textDim}>
+          {follow ? "FOLLOW" : "PAUSED"}
+        </Text>
+        <Text color={colors.textDim}>
+          {"  "}|{"  "}
+          {compact ? "compact" : "expanded"}
+        </Text>
+        {filterText ? (
+          <Text color={colors.accent}>{"  "}filter: {filterText}</Text>
+        ) : null}
+      </Box>
+
+      {/* Separator */}
+      <Box>
+        <Text color={colors.tabBorder}>
+          {symbols.horizontal.repeat(80)}
+        </Text>
+      </Box>
+
+      {/* Message list */}
+      <Box flexDirection="column" flexGrow={1} paddingX={1}>
+        {visible.length === 0 ? (
+          <Text color={colors.textDim}>
+            {filterText
+              ? "No messages match filter"
+              : "Waiting for bus messages..."}
           </Text>
-        ))}
-        {recent.length === 0 && (
-          <Text color={colors.textDim}>No messages yet</Text>
+        ) : (
+          visible.map((entry, i) =>
+            compact ? (
+              <CompactMessage key={i} entry={entry} />
+            ) : (
+              <ExpandedMessage key={i} entry={entry} />
+            ),
+          )
+        )}
+      </Box>
+
+      {/* Filter / status bar */}
+      <Box
+        borderStyle="single"
+        borderColor={colors.tabBorder}
+        borderTop
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        paddingX={1}
+      >
+        {editing ? (
+          <Text>
+            <Text color={colors.accent}>filter: </Text>
+            <Text color={colors.text}>{filterText}</Text>
+            <Text color={colors.accent}>_</Text>
+          </Text>
+        ) : (
+          <Text color={colors.textDim}>
+            /:filter  f:follow  c:compact  Esc:clear  {symbols.arrow}/{symbols.arrow}:scroll
+          </Text>
         )}
       </Box>
     </Box>

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -1,14 +1,319 @@
-import { Box, Text } from "ink";
-import { colors } from "../theme.js";
-import type { ViewProps } from "./types.js";
+/**
+ * Dashboard view (View 1) — 2x2 grid layout.
+ *
+ * Panels: Agents, Tasks, Workflows, Bus Tail.
+ * Status bar at bottom with daily aggregates.
+ * Tab cycles focus between panels, Enter for drill-down.
+ */
 
-export function Dashboard(_props: ViewProps) {
+import { useState, useMemo } from "react";
+import { Box, Text, useInput } from "ink";
+import { colors, symbols } from "../theme.js";
+import type { ViewProps } from "./types.js";
+import { useAgents, type AgentState } from "../hooks/useAgents.js";
+import { useTasks, type TaskState, type TaskStatus } from "../hooks/useTasks.js";
+import { useWorkflows, type WorkflowState } from "../hooks/useWorkflows.js";
+import { useBus } from "../hooks/useBus.js";
+import type { BusMessage } from "../bus.js";
+
+const PANEL_COUNT = 4;
+const BUS_TAIL_COUNT = 15;
+
+const statusBadge: Record<AgentState["status"], string> = {
+  online: symbols.connected,
+  busy: symbols.connected,
+  idle: symbols.disconnected,
+  offline: symbols.disconnected,
+};
+
+const statusColor: Record<AgentState["status"], string> = {
+  online: colors.statusConnected,
+  busy: colors.statusBusy,
+  idle: colors.statusIdle,
+  offline: colors.statusDisconnected,
+};
+
+const taskIcon: Record<TaskStatus, string> = {
+  pending: symbols.disconnected,
+  running: symbols.connected,
+  done: "\u2713",
+  failed: "\u2717",
+  cancelled: "\u2620",
+};
+
+const taskColor: Record<TaskStatus, string> = {
+  pending: colors.textDim,
+  running: colors.statusBusy,
+  done: colors.success,
+  failed: colors.error,
+  cancelled: colors.error,
+};
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const h = d.getHours().toString().padStart(2, "0");
+  const m = d.getMinutes().toString().padStart(2, "0");
+  const s = d.getSeconds().toString().padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}
+
+function formatBusMessage(msg: BusMessage): string {
+  const src = msg.source ?? "?";
+  const tgt = msg.target ?? "*";
+  const payload = msg.payload as Record<string, unknown> | undefined;
+  let summary = msg.type;
+  if (payload) {
+    const action = payload.action as string | undefined;
+    const task = payload.task as string | undefined;
+    const text = payload.text as string | undefined;
+    const detail = action || task || text;
+    if (detail) {
+      const short = typeof detail === "string" && detail.length > 30
+        ? detail.slice(0, 27) + "..."
+        : detail;
+      summary = `${msg.type}: ${short}`;
+    }
+  }
+  return `${src} ${symbols.arrow} ${tgt} ${summary}`;
+}
+
+function PanelHeader({ title, focused }: { title: string; focused: boolean }) {
   return (
-    <Box flexDirection="column" padding={1}>
-      <Text bold color={colors.primary}>
-        Dashboard
+    <Text bold color={focused ? colors.primary : colors.textDim}>
+      {focused ? symbols.arrow + " " : "  "}
+      {title}
+    </Text>
+  );
+}
+
+function AgentsPanel({
+  agents,
+  focused,
+}: {
+  agents: AgentState[];
+  focused: boolean;
+}) {
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={focused ? colors.primary : colors.tabBorder}
+      paddingX={1}
+      flexGrow={1}
+      flexBasis="50%"
+    >
+      <PanelHeader title="Agents" focused={focused} />
+      {agents.length === 0 ? (
+        <Text color={colors.textDim}>No agents connected</Text>
+      ) : (
+        agents.slice(0, 8).map((a) => (
+          <Text key={a.name} wrap="truncate">
+            <Text color={statusColor[a.status]}>
+              {statusBadge[a.status]}
+            </Text>
+            {" "}
+            <Text color={colors.text} bold>
+              {a.name}
+            </Text>
+            {a.model ? (
+              <Text color={colors.textDim}> [{a.model}]</Text>
+            ) : null}
+            {a.currentTask ? (
+              <Text color={colors.muted}> {a.currentTask}</Text>
+            ) : null}
+            {a.costUsd > 0 ? (
+              <Text color={colors.accent}> ${a.costUsd.toFixed(2)}</Text>
+            ) : null}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}
+
+function TasksPanel({
+  tasks,
+  focused,
+}: {
+  tasks: TaskState[];
+  focused: boolean;
+}) {
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={focused ? colors.primary : colors.tabBorder}
+      paddingX={1}
+      flexGrow={1}
+      flexBasis="50%"
+    >
+      <PanelHeader title="Tasks" focused={focused} />
+      {tasks.length === 0 ? (
+        <Text color={colors.textDim}>No tasks yet</Text>
+      ) : (
+        tasks.slice(0, 8).map((t) => (
+          <Text key={t.id} wrap="truncate">
+            <Text color={taskColor[t.status]}>{taskIcon[t.status]}</Text>
+            {" "}
+            <Text color={colors.text}>{t.title}</Text>
+            {t.assignee ? (
+              <Text color={colors.textDim}> @{t.assignee}</Text>
+            ) : null}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}
+
+function WorkflowsPanel({
+  workflows,
+  focused,
+}: {
+  workflows: WorkflowState[];
+  focused: boolean;
+}) {
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={focused ? colors.primary : colors.tabBorder}
+      paddingX={1}
+      flexGrow={1}
+      flexBasis="50%"
+    >
+      <PanelHeader title="Workflows" focused={focused} />
+      {workflows.length === 0 ? (
+        <Text color={colors.textDim}>No active workflows</Text>
+      ) : (
+        workflows.slice(0, 8).map((w) => (
+          <Text key={w.id} wrap="truncate">
+            <Text color={colors.secondary} bold>
+              {w.name}
+            </Text>
+            <Text color={colors.textDim}> [{w.currentState}]</Text>
+            {w.costUsd > 0 ? (
+              <Text color={colors.accent}> ${w.costUsd.toFixed(2)}</Text>
+            ) : null}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}
+
+function BusTailPanel({
+  messages,
+  focused,
+}: {
+  messages: BusMessage[];
+  focused: boolean;
+}) {
+  const recent = messages.slice(-BUS_TAIL_COUNT);
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={focused ? colors.primary : colors.tabBorder}
+      paddingX={1}
+      flexGrow={1}
+      flexBasis="50%"
+    >
+      <PanelHeader title="Bus Tail" focused={focused} />
+      {recent.length === 0 ? (
+        <Text color={colors.textDim}>No messages</Text>
+      ) : (
+        recent.map((msg, i) => (
+          <Text key={i} color={colors.text} wrap="truncate">
+            <Text color={colors.textDim}>
+              {formatTimestamp(Date.now())}
+            </Text>
+            {" "}
+            {formatBusMessage(msg)}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}
+
+function StatusBar({
+  tasks,
+  agents,
+}: {
+  tasks: TaskState[];
+  agents: AgentState[];
+}) {
+  const today = useMemo(() => {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    return start.getTime();
+  }, []);
+
+  const dailyTasks = tasks.filter((t) => t.createdAt >= today).length;
+  const doneTasks = tasks.filter(
+    (t) => t.status === "done" && t.updatedAt >= today,
+  ).length;
+  const totalCost = agents.reduce((sum, a) => sum + a.costUsd, 0);
+  const busyCount = agents.filter((a) => a.status === "busy").length;
+
+  return (
+    <Box paddingX={1}>
+      <Text color={colors.textDim}>
+        Tasks today: <Text color={colors.text}>{dailyTasks}</Text>
+        {" "}({doneTasks} done)
+        {"  "}|{"  "}
+        Agents: <Text color={colors.text}>{agents.length}</Text>
+        {" "}({busyCount} busy)
+        {"  "}|{"  "}
+        Cost: <Text color={colors.accent}>${totalCost.toFixed(2)}</Text>
+        {"  "}|{"  "}
+        <Text color={colors.textDim}>Tab:focus  Enter:detail  1-8:views  ?:help</Text>
       </Text>
-      <Text color={colors.textDim}>Agent overview, tasks, and system health</Text>
+    </Box>
+  );
+}
+
+export function Dashboard({ bus }: ViewProps) {
+  const [focusedPanel, setFocusedPanel] = useState(0);
+  const agents = useAgents(bus);
+  const tasks = useTasks(bus);
+  const workflows = useWorkflows(bus);
+  const { messages } = useBus(bus);
+
+  useInput((input, key) => {
+    if (key.tab) {
+      setFocusedPanel((prev) => (prev + 1) % PANEL_COUNT);
+      return;
+    }
+    // Enter — placeholder for drill-down navigation
+    if (key.return) {
+      // Future: emit navigation event based on focused panel
+      return;
+    }
+    // Suppress unused variable warning
+    void input;
+  });
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      {/* Top row: Agents + Tasks */}
+      <Box flexGrow={1}>
+        <AgentsPanel agents={agents} focused={focusedPanel === 0} />
+        <TasksPanel tasks={tasks} focused={focusedPanel === 1} />
+      </Box>
+
+      {/* Bottom row: Workflows + Bus Tail */}
+      <Box flexGrow={1}>
+        <WorkflowsPanel workflows={workflows} focused={focusedPanel === 2} />
+        <BusTailPanel messages={messages} focused={focusedPanel === 3} />
+      </Box>
+
+      {/* Status bar */}
+      <Box borderStyle="single" borderColor={colors.tabBorder} borderTop borderBottom={false} borderLeft={false} borderRight={false}>
+        <StatusBar tasks={tasks} agents={agents} />
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- **Dashboard view** (View 1): 2x2 grid with Agents, Tasks, Workflows, Bus Tail panels
- **Bus Stream view** (View 2): full-screen live message tail with filtering and follow mode
- **React hooks**: `useAgents()`, `useTasks()`, `useWorkflows()`, `useBus()` — subscribe to deskd bus messages and maintain reactive state

### Dashboard features
- Agents panel with status badges (online/busy/idle/offline), model, current task, cost
- Tasks panel with status icons (pending/running/done/failed/cancelled), assignee
- Workflows panel with current state and cost tracking
- Bus tail showing last 15 messages in compact format
- Status bar with daily task count, agent count, total cost
- Tab cycles focus between panels, Enter placeholder for drill-down

### Bus Stream features
- Timestamp + source -> target + payload display
- Follow mode (auto-scroll, toggle with `f`)
- Filter syntax: `source:X`, `target:X`, `type:event`, freetext (activate with `/`)
- Compact mode toggle (`c`) — 1 line vs multi-line per message
- Ring buffer of 2000 messages
- Scroll with arrow keys when follow is paused

### Quality
- TypeScript compiles clean (`npx tsc --noEmit`)
- Rust quality gate passes (`cargo fmt --check && cargo clippy -- -D warnings && cargo test`)

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)