### PR TITLE
feat: send_message text param + agent_messages query

### DIFF
--- a/src/app/bus_api.rs
+++ b/src/app/bus_api.rs
@@ -479,14 +479,14 @@ fn handle_agent_messages(params: &Value) -> Result<Value> {
         .ok_or_else(|| anyhow::anyhow!("missing 'agent' parameter"))?;
     let limit = params.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
 
-    let messages = crate::app::unified_inbox::agent_messages(agent, limit)?;
+    let messages = crate::app::unified_inbox::read_messages(agent, limit, None)?;
     let result: Vec<Value> = messages
         .iter()
         .map(|m| {
             json!({
-                "role": m.role,
+                "role": m.from,
                 "text": m.text,
-                "timestamp": m.timestamp,
+                "timestamp": m.ts,
             })
         })
         .collect();
@@ -500,10 +500,17 @@ async fn handle_send_message(params: &Value, bus_socket: &str, agent_name: &str)
         .get("target")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow::anyhow!("missing 'target' parameter"))?;
-    let payload = params
-        .get("payload")
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("missing 'payload' parameter"))?;
+
+    // Support `text` shorthand: wraps as {"task": text} matching MCP send_message format.
+    // Falls back to `payload` for callers needing arbitrary JSON.
+    let payload = if let Some(text) = params.get("text").and_then(|v| v.as_str()) {
+        json!({"task": text})
+    } else {
+        params
+            .get("payload")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("missing 'text' or 'payload' parameter"))?
+    };
     let fresh = params
         .get("fresh")
         .and_then(|v| v.as_bool())

--- a/src/app/bus_api.rs
+++ b/src/app/bus_api.rs
@@ -144,6 +144,7 @@ async fn dispatch(
         "room_list" => handle_room_list().await,
         "room_children" => handle_room_children(params),
         "agent_requests" => handle_agent_requests(params, task_store),
+        "agent_messages" => handle_agent_messages(params),
         "agent_config_list" => handle_agent_config_list(),
 
         // ── Mutations ───────────────────────────────────────────────────
@@ -469,6 +470,27 @@ fn handle_agent_config_list() -> Result<Value> {
     }
 
     Ok(json!(configs))
+}
+
+fn handle_agent_messages(params: &Value) -> Result<Value> {
+    let agent = params
+        .get("agent")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'agent' parameter"))?;
+    let limit = params.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
+
+    let messages = crate::app::unified_inbox::agent_messages(agent, limit)?;
+    let result: Vec<Value> = messages
+        .iter()
+        .map(|m| {
+            json!({
+                "role": m.role,
+                "text": m.text,
+                "timestamp": m.timestamp,
+            })
+        })
+        .collect();
+    Ok(json!(result))
 }
 
 // ─── Mutation handlers ──────────────────────────────────────────────────────
@@ -803,5 +825,22 @@ mod tests {
         let result = handle_inbox_search(&json!({}));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("missing 'query'"));
+    }
+
+    #[test]
+    fn test_agent_messages_missing_agent() {
+        let result = handle_agent_messages(&json!({}));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("missing 'agent'"));
+    }
+
+    #[test]
+    fn test_agent_messages_returns_array() {
+        // With a non-existent agent we get an empty array (no inbox files).
+        let result = handle_agent_messages(&json!({"agent": "nonexistent-agent-xyz"}));
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert!(val.is_array());
+        assert_eq!(val.as_array().unwrap().len(), 0);
     }
 }


### PR DESCRIPTION
## Summary
- Add `text` param support to `send_message` command: wraps text as `{"task": text}` for agent compatibility
- Add `agent_messages` query handler: returns conversation history for an agent from unified inbox

Closes #329
Closes #327

## Quality gate
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean  
- [x] `cargo test` — all 356 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)