### PR TITLE
feat: agent output streaming via bus for dashboard live feed

### DIFF
--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -395,6 +395,20 @@ pub async fn run(
                         serde_json::json!({"result": text, "in_reply_to": msg_id_owned}),
                     )
                     .await;
+
+                    // Broadcast agent_output event for dashboard live feed (#328).
+                    write_bus_envelope(
+                        &writer_fwd,
+                        &name_owned,
+                        "broadcast",
+                        serde_json::json!({
+                            "event": "agent_output",
+                            "agent": name_owned,
+                            "line": text,
+                            "timestamp": chrono::Utc::now().to_rfc3339(),
+                        }),
+                    )
+                    .await;
                 }
             }
             full_response


### PR DESCRIPTION
## Summary

- Broadcast `agent_output` events on the bus when agents produce stdout output, enabling real-time output display in viewgraph's log widget
- Each text block from the agent is broadcast with agent name, line content, and RFC3339 timestamp
- Uses existing `broadcast` bus target so any connected client can subscribe

Closes #328

## Event format

```json
{"event": "agent_output", "agent": "worker-500", "line": "Running go test ./...", "timestamp": "2026-04-12T11:14:30Z"}
```

## Quality gate

- [x] `cargo fmt --check` -- pass
- [x] `cargo clippy -- -D warnings` -- pass
- [x] `cargo test` -- pass

## Test plan

- [ ] Start an agent via `deskd serve`, send a task, verify `agent_output` events appear on bus
- [ ] Connect a second bus client, confirm broadcast messages are received
- [ ] Verify viewgraph log widget can filter events by agent name

🤖 Generated with [Claude Code](https://claude.com/claude-code)