### PR TITLE
feat: formal room concept — namespace + context + agents

### DIFF
--- a/src/app/bus_api.rs
+++ b/src/app/bus_api.rs
@@ -355,6 +355,37 @@ async fn handle_room_list() -> Result<Value> {
     let serve_state = crate::config::ServeState::load()
         .ok_or_else(|| anyhow::anyhow!("no serve state found (deskd serve not running?)"))?;
 
+    // If formal rooms are defined, use them. Otherwise fall back to treating each
+    // top-level agent as a room (backward compatible).
+    if !serve_state.rooms.is_empty() {
+        let rooms: Vec<Value> = serve_state
+            .rooms
+            .iter()
+            .map(|room| {
+                let mut total_cost = 0.0;
+                let mut active_count = 0;
+                for agent_name in &room.agents {
+                    if let Ok(state) = crate::app::agent::load_state(agent_name) {
+                        total_cost += state.total_cost;
+                        if state.status == "active" || state.status == "idle" {
+                            active_count += 1;
+                        }
+                    }
+                }
+                json!({
+                    "name": room.name,
+                    "work_dir": room.work_dir,
+                    "context": room.context,
+                    "agent_count": room.agents.len(),
+                    "active_agents": active_count,
+                    "cost_usd": total_cost,
+                })
+            })
+            .collect();
+        return Ok(json!(rooms));
+    }
+
+    // Fallback: each top-level agent is a room.
     let mut rooms: Vec<Value> = Vec::new();
     for (name, agent_serve) in &serve_state.agents {
         let (status, cost_usd, _turns) = match crate::app::agent::load_state(name) {
@@ -387,6 +418,27 @@ fn handle_room_children(params: &Value) -> Result<Value> {
     let serve_state = crate::config::ServeState::load()
         .ok_or_else(|| anyhow::anyhow!("no serve state found (deskd serve not running?)"))?;
 
+    // If formal rooms are defined, look up children from the room definition.
+    if let Some(room_def) = serve_state.rooms.iter().find(|r| r.name == room) {
+        let children: Vec<Value> = room_def
+            .agents
+            .iter()
+            .map(|agent_name| {
+                let (status, model) = match crate::app::agent::load_state(agent_name) {
+                    Ok(state) => (state.status, state.config.model),
+                    Err(_) => ("configured".to_string(), String::new()),
+                };
+                json!({
+                    "name": agent_name,
+                    "model": model,
+                    "status": status,
+                })
+            })
+            .collect();
+        return Ok(json!(children));
+    }
+
+    // Fallback: look up room as an agent name, list its sub-agents.
     let agent_serve = serve_state
         .agent(room)
         .ok_or_else(|| anyhow::anyhow!("room '{}' not found in serve state", room))?;

--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -25,6 +25,7 @@ pub async fn serve(config_path: String) -> Result<()> {
             .into_owned(),
         started_at: chrono::Utc::now().to_rfc3339(),
         agents: std::collections::HashMap::new(),
+        rooms: workspace.rooms.clone(),
     };
     for def in &workspace.agents {
         serve_state.agents.insert(

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,9 +37,28 @@ fn default_budget_usd() -> f64 {
 pub struct WorkspaceConfig {
     #[serde(default)]
     pub agents: Vec<AgentDef>,
+    /// Named rooms — formal groupings of agents with shared context.
+    /// When present, `room_list` returns these instead of treating each agent as a room.
+    #[serde(default)]
+    pub rooms: Vec<RoomDef>,
     /// Telegram user IDs allowed to run admin commands (/restart, etc.).
     #[serde(default)]
     pub admin_telegram_ids: Vec<i64>,
+}
+
+/// A room is a named work context: namespace + context folder + set of agents.
+/// Rooms are the primary drill-down unit in dashboard navigation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoomDef {
+    pub name: String,
+    /// Working directory for the room (agents inherit this).
+    pub work_dir: String,
+    /// Path to a context file (e.g. CLAUDE.md) shared by all agents in the room.
+    #[serde(default)]
+    pub context: Option<String>,
+    /// Names of agents that belong to this room (must be defined in `agents` section).
+    #[serde(default)]
+    pub agents: Vec<String>,
 }
 
 /// Telegram bot adapter config. Defined per-agent — each agent has its own bot.
@@ -173,6 +192,9 @@ pub struct ServeState {
     /// Per-agent runtime info.
     #[serde(default)]
     pub agents: HashMap<String, AgentServeState>,
+    /// Formal room definitions from workspace config.
+    #[serde(default)]
+    pub rooms: Vec<RoomDef>,
 }
 
 /// Per-agent runtime info in serve state.
@@ -670,6 +692,47 @@ agents:
 "#;
         let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(cfg.agents[0].container.is_none());
+    }
+
+    #[test]
+    fn test_workspace_config_with_rooms() {
+        let yaml = r#"
+agents:
+  - name: kira
+    work_dir: /home/kira
+  - name: dev
+    work_dir: /home/dev
+rooms:
+  - name: features
+    work_dir: ~/work/project
+    context: ~/work/project/CLAUDE.md
+    agents: [kira]
+  - name: reviews
+    work_dir: ~/work/reviews
+    agents: [dev]
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.rooms.len(), 2);
+        assert_eq!(cfg.rooms[0].name, "features");
+        assert_eq!(cfg.rooms[0].work_dir, "~/work/project");
+        assert_eq!(
+            cfg.rooms[0].context.as_deref(),
+            Some("~/work/project/CLAUDE.md")
+        );
+        assert_eq!(cfg.rooms[0].agents, vec!["kira"]);
+        assert_eq!(cfg.rooms[1].name, "reviews");
+        assert!(cfg.rooms[1].context.is_none());
+    }
+
+    #[test]
+    fn test_workspace_config_rooms_default_empty() {
+        let yaml = r#"
+agents:
+  - name: kira
+    work_dir: /home/kira
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.rooms.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Added `RoomDef` struct to workspace config with `name`, `work_dir`, `context` (path to shared context file), and `agents` (list of agent names)
- `room_list` query returns formal rooms with aggregate stats (agent count, active agents, total cost) when `rooms:` section is defined in workspace.yaml
- `room_children` query looks up agents from the room definition
- Fully backward compatible: when no rooms are defined, falls back to treating each top-level agent as a room
- Rooms are persisted in ServeState so bus_api can serve them at runtime

## Config example
```yaml
rooms:
  - name: features
    work_dir: ~/work/project
    context: ~/work/project/CLAUDE.md
    agents: [kira, dev]
  - name: reviews
    work_dir: ~/work/reviews
    agents: [reviewer]
```

## Test plan
- [x] All 358 tests pass
- [x] Quality gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
- [x] New tests for rooms config parsing and default empty rooms
- [ ] Manual: verify `room_list` returns rooms when defined, falls back when not

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)