### PR TITLE
feat: per-turn token stats and cache hit/miss (#335)

### DIFF
--- a/src/app/bus_api.rs
+++ b/src/app/bus_api.rs
@@ -136,6 +136,7 @@ async fn dispatch(
         "sm_detail" => handle_sm_detail(params, sm_store),
         "sm_models" => handle_sm_models(user_config),
         "usage_stats" => handle_usage_stats(params).await,
+        "agent_turn_stats" => handle_agent_turn_stats(params),
         "schedule_list" => handle_schedule_list(user_config),
         "inbox_list" => handle_inbox_list(),
         "inbox_read" => handle_inbox_read(params),
@@ -186,6 +187,26 @@ async fn handle_agent_detail(params: &Value) -> Result<Value> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow::anyhow!("missing 'name' parameter"))?;
     let state = crate::app::agent::load_state(name)?;
+
+    // Aggregate token breakdown from task logs.
+    let entries = crate::app::tasklog::read_logs(name, usize::MAX, None, None).unwrap_or_default();
+    let mut input_tokens: u64 = 0;
+    let mut output_tokens: u64 = 0;
+    let mut cache_creation_input_tokens: u64 = 0;
+    let mut cache_read_input_tokens: u64 = 0;
+    for e in &entries {
+        input_tokens += e.input_tokens.unwrap_or(0);
+        output_tokens += e.output_tokens.unwrap_or(0);
+        cache_creation_input_tokens += e.cache_creation_input_tokens.unwrap_or(0);
+        cache_read_input_tokens += e.cache_read_input_tokens.unwrap_or(0);
+    }
+    let total_all_input = input_tokens + cache_creation_input_tokens + cache_read_input_tokens;
+    let cache_hit_rate = if total_all_input > 0 {
+        cache_read_input_tokens as f64 / total_all_input as f64
+    } else {
+        0.0
+    };
+
     Ok(json!({
         "name": state.config.name,
         "model": state.config.model,
@@ -200,6 +221,11 @@ async fn handle_agent_detail(params: &Value) -> Result<Value> {
         "status": state.status,
         "current_task": state.current_task,
         "parent": state.parent,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_creation_input_tokens": cache_creation_input_tokens,
+        "cache_read_input_tokens": cache_read_input_tokens,
+        "cache_hit_rate": cache_hit_rate,
     }))
 }
 
@@ -288,6 +314,48 @@ async fn handle_usage_stats(params: &Value) -> Result<Value> {
     let agent = params.get("agent").and_then(|v| v.as_str());
     let stats = crate::app::commands::usage::compute_stats(period, agent)?;
     Ok(serde_json::to_value(stats)?)
+}
+
+fn handle_agent_turn_stats(params: &Value) -> Result<Value> {
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'name' parameter"))?;
+    let limit = params.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
+
+    let entries = crate::app::tasklog::read_logs(name, limit, None, None)?;
+
+    let turns: Vec<Value> = entries
+        .iter()
+        .map(|e| {
+            let input = e.input_tokens.unwrap_or(0);
+            let output = e.output_tokens.unwrap_or(0);
+            let cache_creation = e.cache_creation_input_tokens.unwrap_or(0);
+            let cache_read = e.cache_read_input_tokens.unwrap_or(0);
+            let total_input = input + cache_creation + cache_read;
+            let cache_hit_rate = if total_input > 0 {
+                cache_read as f64 / total_input as f64
+            } else {
+                0.0
+            };
+            json!({
+                "timestamp": e.ts,
+                "source": e.source,
+                "task": e.task,
+                "turns": e.turns,
+                "cost_usd": e.cost,
+                "duration_ms": e.duration_ms,
+                "status": e.status,
+                "input_tokens": input,
+                "output_tokens": output,
+                "cache_creation_input_tokens": cache_creation,
+                "cache_read_input_tokens": cache_read,
+                "cache_hit_rate": cache_hit_rate,
+            })
+        })
+        .collect();
+
+    Ok(json!(turns))
 }
 
 fn handle_schedule_list(user_config: Option<&UserConfig>) -> Result<Value> {
@@ -897,6 +965,22 @@ mod tests {
     fn test_agent_messages_returns_array() {
         // With a non-existent agent we get an empty array (no inbox files).
         let result = handle_agent_messages(&json!({"agent": "nonexistent-agent-xyz"}));
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert!(val.is_array());
+        assert_eq!(val.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_agent_turn_stats_missing_name() {
+        let result = handle_agent_turn_stats(&json!({}));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("missing 'name'"));
+    }
+
+    #[test]
+    fn test_agent_turn_stats_empty() {
+        let result = handle_agent_turn_stats(&json!({"name": "nonexistent-agent-xyz"}));
         assert!(result.is_ok());
         let val = result.unwrap();
         assert!(val.is_array());

--- a/src/app/commands/usage.rs
+++ b/src/app/commands/usage.rs
@@ -15,6 +15,8 @@ pub struct AgentStats {
     pub turns: u32,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    pub cache_read_input_tokens: u64,
     pub duration_ms: u64,
 }
 
@@ -27,6 +29,10 @@ pub struct UsageStats {
     pub total_turns: u32,
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
+    pub total_cache_creation_input_tokens: u64,
+    pub total_cache_read_input_tokens: u64,
+    /// Cache hit rate (0.0–1.0): cache_read / (cache_read + cache_creation + non-cache input).
+    pub cache_hit_rate: f64,
     pub total_duration_ms: u64,
     pub by_agent: Vec<AgentStats>,
 }
@@ -107,6 +113,8 @@ pub fn compute_stats(period: &str, agent_filter: Option<&str>) -> Result<UsageSt
                 turns: 0,
                 input_tokens: 0,
                 output_tokens: 0,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
                 duration_ms: 0,
             });
 
@@ -116,6 +124,8 @@ pub fn compute_stats(period: &str, agent_filter: Option<&str>) -> Result<UsageSt
             stats.turns += e.turns;
             stats.input_tokens += e.input_tokens.unwrap_or(0);
             stats.output_tokens += e.output_tokens.unwrap_or(0);
+            stats.cache_creation_input_tokens += e.cache_creation_input_tokens.unwrap_or(0);
+            stats.cache_read_input_tokens += e.cache_read_input_tokens.unwrap_or(0);
             stats.duration_ms += e.duration_ms;
         }
     }
@@ -131,9 +141,24 @@ pub fn compute_stats(period: &str, agent_filter: Option<&str>) -> Result<UsageSt
     let total_tasks = agent_list.iter().map(|a| a.tasks).sum();
     let total_cost_usd = agent_list.iter().map(|a| a.cost_usd).sum();
     let total_turns = agent_list.iter().map(|a| a.turns).sum();
-    let total_input_tokens = agent_list.iter().map(|a| a.input_tokens).sum();
+    let total_input_tokens: u64 = agent_list.iter().map(|a| a.input_tokens).sum();
     let total_output_tokens = agent_list.iter().map(|a| a.output_tokens).sum();
+    let total_cache_creation_input_tokens: u64 = agent_list
+        .iter()
+        .map(|a| a.cache_creation_input_tokens)
+        .sum();
+    let total_cache_read_input_tokens: u64 =
+        agent_list.iter().map(|a| a.cache_read_input_tokens).sum();
     let total_duration_ms = agent_list.iter().map(|a| a.duration_ms).sum();
+
+    // Cache hit rate: proportion of input tokens served from cache.
+    let total_all_input =
+        total_input_tokens + total_cache_creation_input_tokens + total_cache_read_input_tokens;
+    let cache_hit_rate = if total_all_input > 0 {
+        total_cache_read_input_tokens as f64 / total_all_input as f64
+    } else {
+        0.0
+    };
 
     Ok(UsageStats {
         period: period.to_string(),
@@ -142,6 +167,9 @@ pub fn compute_stats(period: &str, agent_filter: Option<&str>) -> Result<UsageSt
         total_turns,
         total_input_tokens,
         total_output_tokens,
+        total_cache_creation_input_tokens,
+        total_cache_read_input_tokens,
+        cache_hit_rate,
         total_duration_ms,
         by_agent: agent_list,
     })
@@ -289,6 +317,9 @@ mod tests {
             total_turns: 42,
             total_input_tokens: 100_000,
             total_output_tokens: 25_000,
+            total_cache_creation_input_tokens: 5_000,
+            total_cache_read_input_tokens: 80_000,
+            cache_hit_rate: 80_000.0 / (100_000.0 + 5_000.0 + 80_000.0),
             total_duration_ms: 300_000,
             by_agent: vec![AgentStats {
                 agent: "test".to_string(),
@@ -297,11 +328,16 @@ mod tests {
                 turns: 42,
                 input_tokens: 100_000,
                 output_tokens: 25_000,
+                cache_creation_input_tokens: 5_000,
+                cache_read_input_tokens: 80_000,
                 duration_ms: 300_000,
             }],
         };
         let json = serde_json::to_string(&stats).unwrap();
         assert!(json.contains("\"total_tasks\":10"));
         assert!(json.contains("\"total_cost_usd\":5.5"));
+        assert!(json.contains("\"total_cache_creation_input_tokens\":5000"));
+        assert!(json.contains("\"total_cache_read_input_tokens\":80000"));
+        assert!(json.contains("\"cache_hit_rate\":"));
     }
 }

--- a/src/app/tasklog.rs
+++ b/src/app/tasklog.rs
@@ -40,6 +40,12 @@ pub struct TaskLog {
     /// Output tokens produced.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_tokens: Option<u64>,
+    /// Tokens used to create cache entries.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cache_creation_input_tokens: Option<u64>,
+    /// Tokens read from cache.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cache_read_input_tokens: Option<u64>,
 }
 
 /// Return the path to the task log file for a given agent.
@@ -444,6 +450,8 @@ mod tests {
             github_pr: None,
             input_tokens: None,
             output_tokens: None,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
         }
     }
 
@@ -495,6 +503,8 @@ mod tests {
                     github_pr: None,
                     input_tokens: None,
                     output_tokens: None,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
                 };
                 let line = serde_json::to_string(&entry).unwrap();
                 writeln!(file, "{}", line).unwrap();

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -289,6 +289,8 @@ pub async fn run(
                     github_pr: msg.payload.get("github_pr").and_then(|p| p.as_u64()),
                     input_tokens: None,
                     output_tokens: None,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
                 };
                 if let Err(e) = tasklog::log_task(name, &empty_log) {
                     warn!(agent = %name, error = %e, "failed to write task log");
@@ -768,6 +770,8 @@ fn log_skip(name: &str, msg: &Message, ctx: &TaskContext, status: &str, error: O
         github_pr: ctx.github_pr,
         input_tokens: None,
         output_tokens: None,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
     };
     if let Err(e) = tasklog::log_task(name, &log_entry) {
         warn!(agent = %name, error = %e, "failed to write task log");
@@ -868,6 +872,8 @@ async fn handle_task_success(
         github_pr: ctx.github_pr,
         input_tokens: Some(turn.token_usage.input_tokens),
         output_tokens: Some(turn.token_usage.output_tokens),
+        cache_creation_input_tokens: Some(turn.token_usage.cache_creation_input_tokens),
+        cache_read_input_tokens: Some(turn.token_usage.cache_read_input_tokens),
     };
     if let Err(e) = tasklog::log_task(name, &log_entry) {
         warn!(agent = %name, error = %e, "failed to write task log");
@@ -959,6 +965,8 @@ async fn handle_task_failure(
         github_pr: ctx.github_pr,
         input_tokens: None,
         output_tokens: None,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
     };
     if let Err(le) = tasklog::log_task(name, &log_entry) {
         warn!(agent = %name, error = %le, "failed to write task log");

--- a/tests/budget_enforcement.rs
+++ b/tests/budget_enforcement.rs
@@ -166,6 +166,8 @@ async fn test_budget_exceeded_sends_error_and_logs() {
         github_pr: None,
         input_tokens: None,
         output_tokens: None,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
     };
     deskd::app::tasklog::log_task_to_path(&log_path, &log_entry).unwrap();
 

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -313,6 +313,8 @@ async fn test_tasklog_records_crash_error() {
         github_pr: Some(42),
         input_tokens: Some(1500),
         output_tokens: Some(200),
+        cache_creation_input_tokens: Some(500),
+        cache_read_input_tokens: Some(800),
     };
 
     let log_file = log_dir.join("crash-test-agent.jsonl");


### PR DESCRIPTION
## Summary

- Add `cache_creation_input_tokens` and `cache_read_input_tokens` fields to `TaskLog`, `AgentStats`, and `UsageStats` structs
- Compute and expose `cache_hit_rate` in `usage_stats` and `agent_detail` bus API responses
- Add new `agent_turn_stats` bus API query returning per-task token breakdown with cache metrics
- Update worker to persist cache token data in task logs on successful completions

Closes #335

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all unit + integration tests)
- [x] New tests for `agent_turn_stats` handler (missing param, empty result)
- [ ] Manual: verify `usage_stats` response includes cache fields
- [ ] Manual: verify `agent_detail` response includes token breakdown
- [ ] Manual: verify `agent_turn_stats` returns per-task cache metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)