### PR TITLE
Track session_start and expose claude_session_id (#338)

### DIFF
--- a/src/app/acp.rs
+++ b/src/app/acp.rs
@@ -4,6 +4,7 @@
 //! ACP-compatible agents (Gemini CLI, Goose, etc.).
 
 use anyhow::{Context, Result, bail};
+use chrono::Utc;
 use std::collections::HashMap;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
@@ -525,6 +526,9 @@ impl AcpProcess {
         // Update agent state.
         if let Ok(mut state) = agent::load_state(&self.name) {
             if state.config.session == ConfigSessionMode::Persistent {
+                if state.session_id != session_id {
+                    state.session_start = Some(Utc::now().to_rfc3339());
+                }
                 state.session_id = session_id;
             }
             // ACP doesn't report cost — we track turns only.

--- a/src/app/agent_process.rs
+++ b/src/app/agent_process.rs
@@ -4,6 +4,7 @@
 //! inject_message, kill, stop, and implements `Executor` trait.
 
 use anyhow::{Context, Result, bail};
+use chrono::Utc;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tracing::{debug, error, info, warn};
@@ -166,6 +167,7 @@ impl AgentProcess {
 
                 if let Ok(mut s) = load_state(name) {
                     s.session_id.clear();
+                    s.session_start = None;
                     save_state_pub(&s).ok();
                 }
 
@@ -715,6 +717,9 @@ impl AgentProcess {
                         if state.config.session == ConfigSessionMode::Persistent
                             && !result.session_id.is_empty()
                         {
+                            if state.session_id != result.session_id {
+                                state.session_start = Some(Utc::now().to_rfc3339());
+                            }
                             state.session_id = result.session_id.clone();
                         }
                         state.total_cost += cost_delta;

--- a/src/app/agent_registry.rs
+++ b/src/app/agent_registry.rs
@@ -74,6 +74,10 @@ pub struct AgentState {
     /// Name of the parent agent that spawned this sub-agent, if any.
     #[serde(default)]
     pub parent: Option<String>,
+    /// Timestamp (RFC 3339) of when the current Claude session started.
+    /// Updated whenever session_id changes (new session or resume).
+    #[serde(default)]
+    pub session_start: Option<String>,
 }
 
 fn default_status() -> String {
@@ -152,6 +156,7 @@ pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
         status: "idle".to_string(),
         current_task: String::new(),
         parent: None,
+        session_start: None,
     };
 
     save_state(&state)?;
@@ -181,6 +186,7 @@ pub async fn create_or_update_from_config(cfg: &AgentConfig) -> Result<AgentStat
         status: "idle".to_string(),
         current_task: String::new(),
         parent: None,
+        session_start: None,
     };
     save_state(&state)?;
     info!(agent = %cfg.name, "sub-agent created");
@@ -241,6 +247,7 @@ pub async fn create_or_recover(
         status: "idle".to_string(),
         current_task: String::new(),
         parent: None,
+        session_start: None,
     };
     save_state(&state)?;
     info!(agent = %def.name, "agent created");
@@ -467,6 +474,9 @@ async fn send_inner(
     let stderr_str = stderr_task.await.unwrap_or_default();
 
     if state.config.session == ConfigSessionMode::Persistent && !new_session_id.is_empty() {
+        if state.session_id != new_session_id {
+            state.session_start = Some(Utc::now().to_rfc3339());
+        }
         state.session_id = new_session_id;
     }
     state.total_cost += task_cost;
@@ -480,6 +490,7 @@ async fn send_inner(
         if !state.session_id.is_empty() {
             warn!(agent = %name, session_id = %state.session_id, "stale session_id — retrying without --resume");
             state.session_id = String::new();
+            state.session_start = None;
             save_state(&state)?;
             return Box::pin(send_inner(
                 name,
@@ -688,6 +699,7 @@ created_at: "2024-01-01T00:00:00Z"
             status: "idle".to_string(),
             current_task: String::new(),
             parent: None,
+            session_start: Some(Utc::now().to_rfc3339()),
         };
         let yaml = serde_yaml::to_string(&state).unwrap();
         let restored: AgentState = serde_yaml::from_str(&yaml).unwrap();
@@ -744,6 +756,7 @@ created_at: "2024-01-01T00:00:00Z"
             status: "idle".to_string(),
             current_task: String::new(),
             parent: Some("parent-agent".to_string()),
+            session_start: Some("2026-01-01T00:00:00Z".to_string()),
         };
 
         save_state(&state).unwrap();

--- a/src/app/bus_api.rs
+++ b/src/app/bus_api.rs
@@ -194,6 +194,8 @@ async fn handle_agent_detail(params: &Value) -> Result<Value> {
         "max_turns": state.config.max_turns,
         "pid": state.pid,
         "session_id": state.session_id,
+        "claude_session_id": state.session_id,
+        "session_start": state.session_start,
         "total_turns": state.total_turns,
         "total_cost": state.total_cost,
         "created_at": state.created_at,


### PR DESCRIPTION
## Summary
- Add `session_start` field to `AgentState` — records when the current Claude session began (updated whenever `session_id` changes)
- Expose `claude_session_id` and `session_start` in the `agent_detail` bus API response
- Clear `session_start` alongside `session_id` when stale sessions are detected

Closes #338

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all existing tests, including round-trip and crash recovery)
- [ ] Manual: verify `agent_detail` response includes `claude_session_id` and `session_start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)