### PR TITLE
feat: session-scoped metrics — cost, turns, duration (#339)

### DIFF
--- a/src/app/acp.rs
+++ b/src/app/acp.rs
@@ -528,11 +528,14 @@ impl AcpProcess {
             if state.config.session == ConfigSessionMode::Persistent {
                 if state.session_id != session_id {
                     state.session_start = Some(Utc::now().to_rfc3339());
+                    state.session_cost = 0.0;
+                    state.session_turns = 0;
                 }
                 state.session_id = session_id;
             }
             // ACP doesn't report cost — we track turns only.
             state.total_turns += assistant_turns;
+            state.session_turns += assistant_turns;
             let _ = agent::save_state_pub(&state);
 
             // Check budget (cost-based; ACP doesn't report cost, so this is

--- a/src/app/agent_process.rs
+++ b/src/app/agent_process.rs
@@ -168,6 +168,8 @@ impl AgentProcess {
                 if let Ok(mut s) = load_state(name) {
                     s.session_id.clear();
                     s.session_start = None;
+                    s.session_cost = 0.0;
+                    s.session_turns = 0;
                     save_state_pub(&s).ok();
                 }
 
@@ -719,11 +721,15 @@ impl AgentProcess {
                         {
                             if state.session_id != result.session_id {
                                 state.session_start = Some(Utc::now().to_rfc3339());
+                                state.session_cost = 0.0;
+                                state.session_turns = 0;
                             }
                             state.session_id = result.session_id.clone();
                         }
                         state.total_cost += cost_delta;
                         state.total_turns += turns_delta;
+                        state.session_cost += cost_delta;
+                        state.session_turns += turns_delta;
                         let _ = save_state(&state);
 
                         if let Some(budget) = limits.budget_usd

--- a/src/app/agent_registry.rs
+++ b/src/app/agent_registry.rs
@@ -78,6 +78,12 @@ pub struct AgentState {
     /// Updated whenever session_id changes (new session or resume).
     #[serde(default)]
     pub session_start: Option<String>,
+    /// Cost accumulated in the current session (resets on session_id change).
+    #[serde(default)]
+    pub session_cost: f64,
+    /// Turns accumulated in the current session (resets on session_id change).
+    #[serde(default)]
+    pub session_turns: u32,
 }
 
 fn default_status() -> String {
@@ -157,6 +163,8 @@ pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
         current_task: String::new(),
         parent: None,
         session_start: None,
+        session_cost: 0.0,
+        session_turns: 0,
     };
 
     save_state(&state)?;
@@ -187,6 +195,8 @@ pub async fn create_or_update_from_config(cfg: &AgentConfig) -> Result<AgentStat
         current_task: String::new(),
         parent: None,
         session_start: None,
+        session_cost: 0.0,
+        session_turns: 0,
     };
     save_state(&state)?;
     info!(agent = %cfg.name, "sub-agent created");
@@ -248,6 +258,8 @@ pub async fn create_or_recover(
         current_task: String::new(),
         parent: None,
         session_start: None,
+        session_cost: 0.0,
+        session_turns: 0,
     };
     save_state(&state)?;
     info!(agent = %def.name, "agent created");
@@ -476,11 +488,15 @@ async fn send_inner(
     if state.config.session == ConfigSessionMode::Persistent && !new_session_id.is_empty() {
         if state.session_id != new_session_id {
             state.session_start = Some(Utc::now().to_rfc3339());
+            state.session_cost = 0.0;
+            state.session_turns = 0;
         }
         state.session_id = new_session_id;
     }
     state.total_cost += task_cost;
     state.total_turns += task_turns;
+    state.session_cost += task_cost;
+    state.session_turns += task_turns;
     save_state(&state)?;
 
     if response_text.is_empty() {
@@ -491,6 +507,8 @@ async fn send_inner(
             warn!(agent = %name, session_id = %state.session_id, "stale session_id — retrying without --resume");
             state.session_id = String::new();
             state.session_start = None;
+            state.session_cost = 0.0;
+            state.session_turns = 0;
             save_state(&state)?;
             return Box::pin(send_inner(
                 name,
@@ -700,6 +718,8 @@ created_at: "2024-01-01T00:00:00Z"
             current_task: String::new(),
             parent: None,
             session_start: Some(Utc::now().to_rfc3339()),
+            session_cost: 0.0,
+            session_turns: 0,
         };
         let yaml = serde_yaml::to_string(&state).unwrap();
         let restored: AgentState = serde_yaml::from_str(&yaml).unwrap();
@@ -757,6 +777,8 @@ created_at: "2024-01-01T00:00:00Z"
             current_task: String::new(),
             parent: Some("parent-agent".to_string()),
             session_start: Some("2026-01-01T00:00:00Z".to_string()),
+            session_cost: 0.5,
+            session_turns: 3,
         };
 
         save_state(&state).unwrap();

--- a/src/app/bus_api.rs
+++ b/src/app/bus_api.rs
@@ -208,6 +208,19 @@ async fn handle_agent_detail(params: &Value) -> Result<Value> {
         0.0
     };
 
+    // Compute session duration dynamically from session_start.
+    let session_duration_ms = state
+        .session_start
+        .as_ref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|start| {
+            let now = chrono::Utc::now();
+            (now - start.with_timezone(&chrono::Utc))
+                .num_milliseconds()
+                .max(0) as u64
+        })
+        .unwrap_or(0);
+
     Ok(json!({
         "name": state.config.name,
         "model": state.config.model,
@@ -218,6 +231,11 @@ async fn handle_agent_detail(params: &Value) -> Result<Value> {
         "session_id": state.session_id,
         "claude_session_id": state.session_id,
         "session_start": state.session_start,
+        "session_cost_usd": state.session_cost,
+        "session_turns": state.session_turns,
+        "session_duration_ms": session_duration_ms,
+        "lifetime_cost_usd": state.total_cost,
+        "lifetime_turns": state.total_turns,
         "total_turns": state.total_turns,
         "total_cost": state.total_cost,
         "created_at": state.created_at,


### PR DESCRIPTION
## Summary
- Add `session_cost` (f64) and `session_turns` (u32) fields to `AgentState`, reset when `session_id` changes
- Increment session metrics alongside lifetime metrics in all three execution paths (execute_once, agent_process, ACP)
- Expose `session_cost_usd`, `session_turns`, `session_duration_ms`, `lifetime_cost_usd`, `lifetime_turns` in `agent_detail` bus API response
- `session_duration_ms` computed dynamically from `session_start`
- Backward-compatible: new fields use `#[serde(default)]`, existing `total_cost`/`total_turns` preserved

Closes #339

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass (including existing state round-trip tests)
- [ ] Manual: verify `agent_detail` response includes new session fields
- [ ] Manual: verify session metrics reset on session_id change

🤖 Generated with [Claude Code](https://claude.com/claude-code)