### PR TITLE
Fix layer violations: app no longer imports from infra (#347)

### DIFF
--- a/src/app/acp.rs
+++ b/src/app/acp.rs
@@ -15,7 +15,7 @@ use crate::app::agent::{
 use crate::app::jsonrpc::{
     JsonRpcRequest, JsonRpcResponse, MessageKind, classify_message, parse_response,
 };
-use crate::infra::dto::ConfigSessionMode;
+use crate::domain::config_types::ConfigSessionMode;
 
 // ─── ACP message helpers ─────────────────────────────────────────────────────
 

--- a/src/app/agent_process.rs
+++ b/src/app/agent_process.rs
@@ -9,7 +9,7 @@ use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tracing::{debug, error, info, warn};
 
-use crate::infra::dto::ConfigSessionMode;
+use crate::domain::config_types::ConfigSessionMode;
 use crate::ports::executor::{Executor, ProgressSink, TaskLimits, TokenUsage, TurnResult};
 
 use super::agent_registry::{
@@ -271,7 +271,7 @@ impl AgentProcess {
                 .map(std::path::PathBuf::from)
                 .unwrap_or_else(|| crate::app::context::default_main_path(&state.config.work_dir));
             if main_path.exists() {
-                let ctx_repo = crate::infra::context_store::FileContextStore::new();
+                let ctx_repo = crate::app::context::new_context_store();
                 match crate::app::context::MainBranch::load(&ctx_repo, &main_path) {
                     Ok(mut branch) => match branch.materialize().await {
                         Ok(messages) if !messages.is_empty() => {

--- a/src/app/agent_registry.rs
+++ b/src/app/agent_registry.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
 
 use crate::config::{self, ContainerConfig, UserConfig};
-use crate::infra::dto::{ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode};
+use crate::domain::config_types::{ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode};
 
 use super::process_builder::{build_command, inject_required_flags};
 

--- a/src/app/bus.rs
+++ b/src/app/bus.rs
@@ -1,3 +1,16 @@
-//! Backward-compatible re-export — implementation moved to `infra::bus_server`.
+//! Bus application layer — re-exports bus server and provides bus construction.
+//!
+//! The bus server implementation lives in `infra::bus_server`. This module
+//! re-exports it for convenience and adds app-level helpers (e.g. `connect_bus`).
 
-pub use crate::infra::bus_server::*;
+pub use crate::infra::bus_server::serve;
+
+use crate::infra::unix_bus::UnixBus;
+
+/// Connect to a bus socket, returning a trait-erased `MessageBus`.
+///
+/// This is the composition-root factory for bus clients. Application code
+/// should call this instead of importing `UnixBus` directly.
+pub async fn connect_bus(socket_path: &str) -> anyhow::Result<impl crate::ports::bus::MessageBus> {
+    UnixBus::connect(socket_path).await
+}

--- a/src/app/bus_api.rs
+++ b/src/app/bus_api.rs
@@ -30,7 +30,6 @@ use tracing::{info, warn};
 
 use crate::app::mcp_service;
 use crate::config::UserConfig;
-use crate::infra::unix_bus::UnixBus;
 use crate::ports::bus::MessageBus;
 use crate::ports::store::{StateMachineRepository, TaskRepository};
 
@@ -47,7 +46,7 @@ pub async fn run(
     user_config: Option<&UserConfig>,
     agent_name: &str,
 ) -> Result<()> {
-    let bus = UnixBus::connect(bus_socket).await?;
+    let bus = crate::app::bus::connect_bus(bus_socket).await?;
     bus.register(
         API_CLIENT_NAME,
         &["deskd:query".to_string(), "deskd:command".to_string()],
@@ -699,7 +698,7 @@ async fn handle_send_message(params: &Value, bus_socket: &str, agent_name: &str)
         .unwrap_or(false);
 
     // Use a one-shot bus connection to send the message.
-    let sender = UnixBus::connect(bus_socket).await?;
+    let sender = crate::app::bus::connect_bus(bus_socket).await?;
     sender
         .register(&format!("{}-api-send", agent_name), &[])
         .await?;
@@ -980,7 +979,7 @@ async fn handle_agent_compress(params: &Value, bus_socket: &str, caller: &str) -
         .ok_or_else(|| anyhow::anyhow!("missing 'agent' parameter"))?;
 
     // Send a summarization task to the agent before restarting.
-    let sender = UnixBus::connect(bus_socket).await?;
+    let sender = crate::app::bus::connect_bus(bus_socket).await?;
     sender
         .register(&format!("{}-compress", caller), &[])
         .await?;

--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -36,8 +36,8 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 },
                 config_path: None,
                 container: None,
-                session: crate::infra::dto::ConfigSessionMode::default(),
-                runtime: crate::infra::dto::ConfigAgentRuntime::default(),
+                session: crate::domain::config_types::ConfigSessionMode::default(),
+                runtime: crate::domain::config_types::ConfigAgentRuntime::default(),
                 context: None,
             };
             let state = agent::create(&cfg).await?;

--- a/src/app/commands/sm.rs
+++ b/src/app/commands/sm.rs
@@ -137,7 +137,7 @@ pub async fn handle(
                     socket
                 });
                 if std::path::Path::new(&bus_socket).exists()
-                    && let Ok(bus) = crate::infra::unix_bus::UnixBus::connect(&bus_socket).await
+                    && let Ok(bus) = crate::app::bus::connect_bus(&bus_socket).await
                 {
                     let _ = bus.register("cli-sm-notify", &[]).await;
                     if let Err(e) = workflow::notify_moved(&bus, &id, "cli").await {

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -9,6 +9,13 @@ use crate::ports::store::ContextRepository;
 // Re-export all domain types for backward compatibility.
 pub use crate::domain::context::*;
 
+/// Create a new file-backed context store.
+///
+/// Application code should call this instead of importing `FileContextStore` from infra.
+pub fn new_context_store() -> impl ContextRepository {
+    crate::infra::context_store::FileContextStore::new()
+}
+
 impl MainBranch {
     /// Load from file via the given repository.
     pub fn load(repo: &dyn ContextRepository, path: &std::path::Path) -> anyhow::Result<Self> {
@@ -153,7 +160,7 @@ mod tests {
             tokens_estimate: 50,
         });
 
-        let repo = crate::infra::context_store::FileContextStore::new();
+        let repo = crate::app::context::new_context_store();
         branch.save(&repo, &path).expect("save failed");
         let loaded = MainBranch::load(&repo, &path).expect("load failed");
 
@@ -362,7 +369,7 @@ mod tests {
 
     #[test]
     fn test_context_config_serde() {
-        use crate::infra::dto::ConfigContextConfig;
+        use crate::domain::config_types::ConfigContextConfig;
         let yaml = r#"
 enabled: true
 main_budget_tokens: 12000

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -20,7 +20,7 @@ use crate::app::mcp_protocol::{
 };
 use crate::app::mcp_tools::{self, InternalBus, build_send_message_description};
 use crate::config::UserConfig;
-use crate::infra::dto::BusMessage;
+use crate::ports::bus_wire::BusMessage;
 
 // ─── Main entry point ────────────────────────────────────────────────────────
 

--- a/src/app/mcp_protocol.rs
+++ b/src/app/mcp_protocol.rs
@@ -11,7 +11,7 @@ use tokio::net::UnixStream;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
-use crate::infra::dto::BusMessage;
+use crate::ports::bus_wire::BusMessage;
 
 // --- MCP Protocol types ---
 

--- a/src/app/mcp_service.rs
+++ b/src/app/mcp_service.rs
@@ -327,7 +327,7 @@ pub async fn sm_create(
     info!(agent = %agent_name, instance = %inst.id, model = %model_name, "sm_create");
 
     // Emit InstanceCreated event.
-    if let Ok(bus) = crate::infra::unix_bus::UnixBus::connect(bus_socket).await {
+    if let Ok(bus) = crate::app::bus::connect_bus(bus_socket).await {
         let _ = bus
             .register(&format!("{}-event-pub", agent_name), &[])
             .await;
@@ -438,7 +438,7 @@ pub async fn sm_move(
     info!(agent = %agent_name, instance = %id, from = %from, to = %state, "sm_move");
 
     // Emit TransitionApplied event and notify workflow engine via one-shot bus.
-    if let Ok(bus) = crate::infra::unix_bus::UnixBus::connect(bus_socket).await {
+    if let Ok(bus) = crate::app::bus::connect_bus(bus_socket).await {
         let _ = bus
             .register(&format!("{}-event-pub", agent_name), &[])
             .await;
@@ -479,7 +479,7 @@ pub fn sm_query(
 ) -> Result<Value> {
     if let Some(id) = id {
         let inst = sm_store.load(id)?;
-        let dto: crate::infra::dto::StoredInstance = (&inst).into();
+        let dto: crate::app::statemachine::StoredInstance = (&inst).into();
         return Ok(serde_json::to_value(&dto)?);
     }
 

--- a/src/app/process_builder.rs
+++ b/src/app/process_builder.rs
@@ -209,7 +209,7 @@ pub fn split_command(command: &[String]) -> (&str, &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::infra::dto::{ConfigAgentRuntime, ConfigSessionMode};
+    use crate::domain::config_types::{ConfigAgentRuntime, ConfigSessionMode};
     use std::collections::HashMap;
 
     #[test]

--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -5,7 +5,6 @@ use tracing::info;
 
 use crate::app::{adapters, agent, bus, bus_api, schedule, worker, workflow};
 use crate::config;
-use crate::infra::paths;
 
 /// Start per-agent buses and workers for all agents in workspace config.
 /// Each agent has its own isolated bus at {work_dir}/.deskd/bus.sock.
@@ -56,7 +55,7 @@ pub async fn serve(config_path: String) -> Result<()> {
 
         // Ensure {work_dir}/.deskd/ exists and is owned by the agent's unix user.
         let bus_dir = std::path::Path::new(&def.work_dir).join(".deskd");
-        paths::ensure_dir_owned(&bus_dir, def.unix_user.as_deref())?;
+        config::ensure_dir_owned(&bus_dir, def.unix_user.as_deref())?;
 
         // Start the agent's isolated bus.
         {
@@ -240,7 +239,7 @@ pub async fn serve(config_path: String) -> Result<()> {
             let sm_store = crate::app::statemachine::StateMachineStore::default_for_home();
             let task_store = crate::app::task::TaskStore::default_for_home();
             tokio::spawn(async move {
-                let bus_client = match crate::infra::unix_bus::UnixBus::connect(&bus).await {
+                let bus_client = match crate::app::bus::connect_bus(&bus).await {
                     Ok(b) => b,
                     Err(e) => {
                         tracing::error!(

--- a/src/app/statemachine.rs
+++ b/src/app/statemachine.rs
@@ -1,3 +1,8 @@
-//! Backward-compatible re-export — implementation moved to `infra::sm_store`.
+//! State machine store application layer — re-exports store and DTO types.
+//!
+//! The state machine store implementation lives in `infra::sm_store`. This module
+//! re-exports it for backward compatibility. The `StoredInstance` DTO is also
+//! re-exported for serialization needs.
 
+pub use crate::infra::dto::StoredInstance;
 pub use crate::infra::sm_store::*;

--- a/src/app/task.rs
+++ b/src/app/task.rs
@@ -1,3 +1,6 @@
-//! Backward-compatible re-export — implementation moved to `infra::task_store`.
+//! Task store application layer — re-exports task store types.
+//!
+//! The task store implementation lives in `infra::task_store`. This module
+//! re-exports it for backward compatibility.
 
 pub use crate::infra::task_store::*;

--- a/src/app/timeout_sweep.rs
+++ b/src/app/timeout_sweep.rs
@@ -194,7 +194,7 @@ async fn sweep_once(models: &[ModelDef], bus_socket: &str) -> anyhow::Result<()>
         );
 
         // Emit TaskTimedOut event.
-        if let Ok(bus) = crate::infra::unix_bus::UnixBus::connect(bus_socket).await {
+        if let Ok(bus) = crate::app::bus::connect_bus(bus_socket).await {
             let _ = bus.register("timeout-sweep-event-pub", &[]).await;
             let _ = workflow::publish_event(
                 &bus,

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -11,8 +11,8 @@ use crate::app::message::Message;
 use crate::app::tasklog;
 use crate::app::unified_inbox;
 use crate::domain::agent::AgentRuntime;
+use crate::domain::config_types::ConfigSessionMode;
 use crate::domain::events::DomainEvent;
-use crate::infra::dto::ConfigSessionMode;
 
 /// Create an executor for the given runtime type.
 ///
@@ -257,7 +257,7 @@ pub async fn run(
             continue;
         }
 
-        let msg: Message = match serde_json::from_str::<crate::infra::dto::BusMessage>(&line) {
+        let msg: Message = match serde_json::from_str::<crate::ports::bus_wire::BusMessage>(&line) {
             Ok(dto) => dto.into(),
             Err(e) => {
                 warn!(agent = %name, error = %e, "invalid message from bus");
@@ -442,7 +442,7 @@ pub async fn run(
                     if bus_line.is_empty() {
                         continue;
                     }
-                    if let Ok(dto) = serde_json::from_str::<crate::infra::dto::BusMessage>(&bus_line) {
+                    if let Ok(dto) = serde_json::from_str::<crate::ports::bus_wire::BusMessage>(&bus_line) {
                         let inject_msg: Message = dto.into();
                         let inject_task = inject_msg
                             .payload

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,14 @@
-use crate::infra::dto::{
-    ConfigAgentRuntime, ConfigContextConfig, ConfigModelDef, ConfigSessionMode,
-};
+use crate::domain::config_types::{ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode};
+use crate::infra::dto::ConfigModelDef;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 // Re-export path helpers (infra layer — filesystem layout concerns).
-pub use crate::infra::paths::{agent_bus_socket, log_dir, reminders_dir, state_dir};
+pub use crate::infra::paths::{
+    agent_bus_socket, ensure_dir_owned, log_dir, reminders_dir, state_dir,
+};
 
 /// A one-shot reminder that fires at a specific time and posts a message to the bus.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/domain/config_types.rs
+++ b/src/domain/config_types.rs
@@ -1,0 +1,99 @@
+//! Configuration value types — serde-enabled enums for YAML parsing.
+//!
+//! These types are used across layers (config, app, infra) so they live
+//! in the domain layer as shared vocabulary types. Conversion impls
+//! to/from domain enums live alongside these types.
+
+use serde::{Deserialize, Serialize};
+
+use super::agent::{AgentRuntime, SessionMode};
+use super::context::ContextConfig;
+
+// ─── SessionMode / AgentRuntime ─────────────────────────────────────────────
+
+/// Config-level session mode (serde for YAML parsing).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigSessionMode {
+    #[default]
+    Persistent,
+    Ephemeral,
+}
+
+/// Config-level agent runtime (serde for YAML parsing).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigAgentRuntime {
+    #[default]
+    Claude,
+    Acp,
+}
+
+impl From<ConfigSessionMode> for SessionMode {
+    fn from(dto: ConfigSessionMode) -> Self {
+        match dto {
+            ConfigSessionMode::Persistent => SessionMode::Persistent,
+            ConfigSessionMode::Ephemeral => SessionMode::Ephemeral,
+        }
+    }
+}
+
+impl From<&SessionMode> for ConfigSessionMode {
+    fn from(mode: &SessionMode) -> Self {
+        match mode {
+            SessionMode::Persistent => ConfigSessionMode::Persistent,
+            SessionMode::Ephemeral => ConfigSessionMode::Ephemeral,
+        }
+    }
+}
+
+impl From<ConfigAgentRuntime> for AgentRuntime {
+    fn from(dto: ConfigAgentRuntime) -> Self {
+        match dto {
+            ConfigAgentRuntime::Claude => AgentRuntime::Claude,
+            ConfigAgentRuntime::Acp => AgentRuntime::Acp,
+        }
+    }
+}
+
+impl From<&AgentRuntime> for ConfigAgentRuntime {
+    fn from(rt: &AgentRuntime) -> Self {
+        match rt {
+            AgentRuntime::Claude => ConfigAgentRuntime::Claude,
+            AgentRuntime::Acp => ConfigAgentRuntime::Acp,
+        }
+    }
+}
+
+// ─── ContextConfig ─────────────────────────────────────────────────────────
+
+/// Config-level context configuration (serde for YAML parsing).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConfigContextConfig {
+    pub enabled: bool,
+    pub main_budget_tokens: Option<u32>,
+    pub compact_threshold_tokens: Option<u32>,
+    pub main_path: Option<String>,
+}
+
+impl From<ConfigContextConfig> for ContextConfig {
+    fn from(dto: ConfigContextConfig) -> Self {
+        Self {
+            enabled: dto.enabled,
+            main_budget_tokens: dto.main_budget_tokens,
+            compact_threshold_tokens: dto.compact_threshold_tokens,
+            main_path: dto.main_path,
+        }
+    }
+}
+
+impl From<&ContextConfig> for ConfigContextConfig {
+    fn from(c: &ContextConfig) -> Self {
+        Self {
+            enabled: c.enabled,
+            main_budget_tokens: c.main_budget_tokens,
+            compact_threshold_tokens: c.compact_threshold_tokens,
+            main_path: c.main_path.clone(),
+        }
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -4,6 +4,7 @@
 //! `infra`, `app`, `adapters`, or any other outer layer.
 
 pub mod agent;
+pub mod config_types;
 pub mod context;
 pub mod events;
 pub mod message;

--- a/src/infra/dto/bus.rs
+++ b/src/infra/dto/bus.rs
@@ -1,101 +1,13 @@
 //! Bus wire-format DTOs and domain conversions.
-
-use serde::{Deserialize, Serialize};
+//!
+//! Wire types (`BusMessage`, `BusMetadata`, `BusRegister`, `BusEnvelope`) have moved
+//! to `ports::bus_wire`. This module re-exports them for backward compatibility within
+//! infra, and provides additional conversions (DomainEvent → JSON, TokenUsage parsing).
 
 use crate::domain::events::DomainEvent;
-use crate::domain::message::{Envelope, Message, Metadata, Register};
 
-// ─── Wire types ─────────────────────────────────────────────────────────────
-
-/// Wire format for messages on the Unix socket bus.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BusMessage {
-    pub id: String,
-    pub source: String,
-    pub target: String,
-    pub payload: serde_json::Value,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reply_to: Option<String>,
-    #[serde(default)]
-    pub metadata: BusMetadata,
-}
-
-/// Wire format for message metadata.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct BusMetadata {
-    #[serde(default = "default_priority")]
-    pub priority: u8,
-    #[serde(default)]
-    pub fresh: bool,
-}
-
-fn default_priority() -> u8 {
-    5
-}
-
-/// Wire format for the registration handshake.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BusRegister {
-    pub name: String,
-    #[serde(default)]
-    pub subscriptions: Vec<String>,
-}
-
-/// Wire-level envelope: tagged union for all bus protocol messages.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
-pub enum BusEnvelope {
-    Register(BusRegister),
-    Message(BusMessage),
-    List,
-}
-
-// ─── Domain ↔ Bus conversions ───────────────────────────────────────────────
-
-impl From<BusMessage> for Message {
-    fn from(dto: BusMessage) -> Self {
-        Self {
-            id: dto.id,
-            source: dto.source,
-            target: dto.target,
-            payload: dto.payload,
-            reply_to: dto.reply_to,
-            metadata: Metadata {
-                priority: dto.metadata.priority,
-                fresh: dto.metadata.fresh,
-            },
-        }
-    }
-}
-
-impl From<&Message> for BusMessage {
-    fn from(msg: &Message) -> Self {
-        Self {
-            id: msg.id.clone(),
-            source: msg.source.clone(),
-            target: msg.target.clone(),
-            payload: msg.payload.clone(),
-            reply_to: msg.reply_to.clone(),
-            metadata: BusMetadata {
-                priority: msg.metadata.priority,
-                fresh: msg.metadata.fresh,
-            },
-        }
-    }
-}
-
-impl From<BusEnvelope> for Envelope {
-    fn from(dto: BusEnvelope) -> Self {
-        match dto {
-            BusEnvelope::Register(r) => Envelope::Register(Register {
-                name: r.name,
-                subscriptions: r.subscriptions,
-            }),
-            BusEnvelope::Message(m) => Envelope::Message(m.into()),
-            BusEnvelope::List => Envelope::List,
-        }
-    }
-}
+// Re-export wire types from ports.
+pub use crate::ports::bus_wire::{BusEnvelope, BusMessage, BusMetadata, BusRegister};
 
 // ─── Domain Event → JSON ────────────────────────────────────────────────────
 
@@ -214,6 +126,7 @@ impl From<&serde_json::Value> for TokenUsage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::message::Message;
 
     #[test]
     fn test_bus_message_to_domain_roundtrip() {
@@ -243,9 +156,9 @@ mod tests {
     fn test_bus_envelope_deserialize_message() {
         let json = r#"{"type":"message","id":"1","source":"a","target":"b","payload":{}}"#;
         let env: BusEnvelope = serde_json::from_str(json).unwrap();
-        let domain: Envelope = env.into();
+        let domain: crate::domain::message::Envelope = env.into();
         match domain {
-            Envelope::Message(m) => assert_eq!(m.source, "a"),
+            crate::domain::message::Envelope::Message(m) => assert_eq!(m.source, "a"),
             _ => panic!("expected Message"),
         }
     }
@@ -254,9 +167,9 @@ mod tests {
     fn test_bus_envelope_deserialize_register() {
         let json = r#"{"type":"register","name":"cli","subscriptions":["agent:cli"]}"#;
         let env: BusEnvelope = serde_json::from_str(json).unwrap();
-        let domain: Envelope = env.into();
+        let domain: crate::domain::message::Envelope = env.into();
         match domain {
-            Envelope::Register(r) => assert_eq!(r.name, "cli"),
+            crate::domain::message::Envelope::Register(r) => assert_eq!(r.name, "cli"),
             _ => panic!("expected Register"),
         }
     }

--- a/src/infra/dto/config.rs
+++ b/src/infra/dto/config.rs
@@ -1,66 +1,17 @@
 //! Configuration DTOs — YAML parsing types and domain conversions.
+//!
+//! Config value types (`ConfigSessionMode`, `ConfigAgentRuntime`, `ConfigContextConfig`)
+//! have moved to `domain::config_types`. This module re-exports them for backward
+//! compatibility within infra, and provides additional config DTOs for state machine
+//! model definitions and transition parsing.
 
 use serde::{Deserialize, Serialize};
 
-use crate::domain::agent::{AgentRuntime, SessionMode};
 use crate::domain::statemachine::{ModelDef, TransitionDef};
 use crate::domain::task::TaskCriteria;
 
-// ─── SessionMode / AgentRuntime ─────────────────────────────────────────────
-
-/// Config-level session mode (serde for YAML parsing).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum ConfigSessionMode {
-    #[default]
-    Persistent,
-    Ephemeral,
-}
-
-/// Config-level agent runtime (serde for YAML parsing).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum ConfigAgentRuntime {
-    #[default]
-    Claude,
-    Acp,
-}
-
-impl From<ConfigSessionMode> for SessionMode {
-    fn from(dto: ConfigSessionMode) -> Self {
-        match dto {
-            ConfigSessionMode::Persistent => SessionMode::Persistent,
-            ConfigSessionMode::Ephemeral => SessionMode::Ephemeral,
-        }
-    }
-}
-
-impl From<&SessionMode> for ConfigSessionMode {
-    fn from(mode: &SessionMode) -> Self {
-        match mode {
-            SessionMode::Persistent => ConfigSessionMode::Persistent,
-            SessionMode::Ephemeral => ConfigSessionMode::Ephemeral,
-        }
-    }
-}
-
-impl From<ConfigAgentRuntime> for AgentRuntime {
-    fn from(dto: ConfigAgentRuntime) -> Self {
-        match dto {
-            ConfigAgentRuntime::Claude => AgentRuntime::Claude,
-            ConfigAgentRuntime::Acp => AgentRuntime::Acp,
-        }
-    }
-}
-
-impl From<&AgentRuntime> for ConfigAgentRuntime {
-    fn from(rt: &AgentRuntime) -> Self {
-        match rt {
-            AgentRuntime::Claude => ConfigAgentRuntime::Claude,
-            AgentRuntime::Acp => ConfigAgentRuntime::Acp,
-        }
-    }
-}
+// Re-export config value types from domain.
+pub use crate::domain::config_types::{ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode};
 
 // ─── ModelDef / TransitionDef ───────────────────────────────────────────────
 

--- a/src/infra/dto/context.rs
+++ b/src/infra/dto/context.rs
@@ -2,42 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::domain::context::{
-    CachedResult, ContextConfig, MainBranch, MaterializedMessage, Node, NodeKind,
-};
+use crate::domain::context::{CachedResult, MainBranch, MaterializedMessage, Node, NodeKind};
 
-// ─── Config format ──────────────────────────────────────────────────────────
-
-/// Config-level context configuration (serde for YAML parsing).
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ConfigContextConfig {
-    pub enabled: bool,
-    pub main_budget_tokens: Option<u32>,
-    pub compact_threshold_tokens: Option<u32>,
-    pub main_path: Option<String>,
-}
-
-impl From<ConfigContextConfig> for ContextConfig {
-    fn from(dto: ConfigContextConfig) -> Self {
-        Self {
-            enabled: dto.enabled,
-            main_budget_tokens: dto.main_budget_tokens,
-            compact_threshold_tokens: dto.compact_threshold_tokens,
-            main_path: dto.main_path,
-        }
-    }
-}
-
-impl From<&ContextConfig> for ConfigContextConfig {
-    fn from(c: &ContextConfig) -> Self {
-        Self {
-            enabled: c.enabled,
-            main_budget_tokens: c.main_budget_tokens,
-            compact_threshold_tokens: c.compact_threshold_tokens,
-            main_path: c.main_path.clone(),
-        }
-    }
-}
+// Re-export config type from domain.
+pub use crate::domain::config_types::ConfigContextConfig;
 
 // ─── Persistence format ─────────────────────────────────────────────────────
 

--- a/src/ports/bus_wire.rs
+++ b/src/ports/bus_wire.rs
@@ -1,0 +1,101 @@
+//! Bus wire-format types — shared protocol types for bus communication.
+//!
+//! These types define the serialization format for messages on the bus.
+//! Used by both infrastructure (bus_server, unix_bus) and application
+//! (mcp, worker) layers.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::message::{Envelope, Message, Metadata, Register};
+
+// ─── Wire types ─────────────────────────────────────────────────────────────
+
+/// Wire format for messages on the Unix socket bus.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusMessage {
+    pub id: String,
+    pub source: String,
+    pub target: String,
+    pub payload: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+    #[serde(default)]
+    pub metadata: BusMetadata,
+}
+
+/// Wire format for message metadata.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BusMetadata {
+    #[serde(default = "default_priority")]
+    pub priority: u8,
+    #[serde(default)]
+    pub fresh: bool,
+}
+
+fn default_priority() -> u8 {
+    5
+}
+
+/// Wire format for the registration handshake.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusRegister {
+    pub name: String,
+    #[serde(default)]
+    pub subscriptions: Vec<String>,
+}
+
+/// Wire-level envelope: tagged union for all bus protocol messages.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum BusEnvelope {
+    Register(BusRegister),
+    Message(BusMessage),
+    List,
+}
+
+// ─── Domain ↔ Bus conversions ───────────────────────────────────────────────
+
+impl From<BusMessage> for Message {
+    fn from(dto: BusMessage) -> Self {
+        Self {
+            id: dto.id,
+            source: dto.source,
+            target: dto.target,
+            payload: dto.payload,
+            reply_to: dto.reply_to,
+            metadata: Metadata {
+                priority: dto.metadata.priority,
+                fresh: dto.metadata.fresh,
+            },
+        }
+    }
+}
+
+impl From<&Message> for BusMessage {
+    fn from(msg: &Message) -> Self {
+        Self {
+            id: msg.id.clone(),
+            source: msg.source.clone(),
+            target: msg.target.clone(),
+            payload: msg.payload.clone(),
+            reply_to: msg.reply_to.clone(),
+            metadata: BusMetadata {
+                priority: msg.metadata.priority,
+                fresh: msg.metadata.fresh,
+            },
+        }
+    }
+}
+
+impl From<BusEnvelope> for Envelope {
+    fn from(dto: BusEnvelope) -> Self {
+        match dto {
+            BusEnvelope::Register(r) => Envelope::Register(Register {
+                name: r.name,
+                subscriptions: r.subscriptions,
+            }),
+            BusEnvelope::Message(m) => Envelope::Message(m.into()),
+            BusEnvelope::List => Envelope::List,
+        }
+    }
+}

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -4,5 +4,6 @@
 //! infrastructure modules implement.
 
 pub mod bus;
+pub mod bus_wire;
 pub mod executor;
 pub mod store;


### PR DESCRIPTION
## Summary

- Move config DTOs (`ConfigSessionMode`, `ConfigAgentRuntime`, `ConfigContextConfig`) from `infra::dto` to `domain::config_types`
- Move bus wire types (`BusMessage`, `BusMetadata`, `BusRegister`, `BusEnvelope`) from `infra::dto::bus` to `ports::bus_wire`
- Replace all direct `crate::infra::` imports in `app/` files with `domain::`, `ports::`, or app-layer factory functions
- Add `app::bus::connect_bus()` factory to avoid direct `UnixBus` imports
- Add `app::context::new_context_store()` factory to avoid direct `FileContextStore` imports
- Re-export `ensure_dir_owned` through `config` module so `serve.rs` doesn't import `infra::paths`

## Remaining app->infra references (by design)

These are composition-root modules that bridge infra to app:
- `app/bus.rs` — wraps `infra::bus_server::serve` and `UnixBus::connect`
- `app/task.rs` — re-exports `infra::task_store::*`
- `app/statemachine.rs` — re-exports `infra::sm_store::*` and `StoredInstance`
- `app/context.rs` — factory wrapping `FileContextStore::new()`
- `app/workflow.rs` — test-only imports for `InMemoryBus`/`InMemoryStore`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 78 tests)
- [x] No non-composition-root `app/` file imports from `infra::` directly

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)