### PR TITLE
feat: A2A client tools + needs extension (#353)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +471,7 @@ dependencies = [
  "cron",
  "futures",
  "openssl",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -712,8 +719,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -724,7 +747,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -884,6 +907,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -898,6 +922,22 @@ dependencies = [
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "hyper-util",
+ "rustls 0.23.38",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -919,13 +959,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.9.0",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1104,6 +1152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1236,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1507,6 +1571,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.38",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.38",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1633,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1528,8 +1653,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1539,7 +1674,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1549,6 +1694,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1601,7 +1755,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1634,6 +1788,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.38",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +1838,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1696,6 +1894,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.12",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1922,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1728,6 +1941,17 @@ name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1935,7 +2159,7 @@ dependencies = [
  "futures",
  "mime_guess",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.11.27",
  "secrecy",
  "serde",
  "serde_cow",
@@ -2085,6 +2309,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2149,7 +2376,7 @@ dependencies = [
  "serde_json",
  "teloxide-core",
  "teloxide-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2173,13 +2400,13 @@ dependencies = [
  "once_cell",
  "pin-project",
  "rc-box",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_with",
  "take_mut",
  "takecell",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "url",
@@ -2217,7 +2444,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2225,6 +2461,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2282,6 +2529,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2599,16 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -2404,8 +2676,12 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-util",
  "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -2502,11 +2778,11 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls 0.22.4",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -2757,6 +3033,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ base64 = "0.22.1"
 futures = "0.3"
 chrono-tz = "0.10.4"
 axum = { version = "0.8", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 

--- a/src/app/a2a.rs
+++ b/src/app/a2a.rs
@@ -26,6 +26,9 @@ pub struct AgentCard {
     pub capabilities: AgentCapabilities,
     /// Skills this agent can perform.
     pub skills: Vec<AgentSkill>,
+    /// Needs — what this agent wants done (Nassau extension to A2A spec).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub needs: Vec<AgentNeed>,
     /// Authentication schemes accepted.
     pub authentication: AgentAuthentication,
 }
@@ -49,6 +52,16 @@ pub struct AgentSkill {
     pub tags: Vec<String>,
 }
 
+/// A need the agent wants fulfilled (Nassau extension).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentNeed {
+    pub id: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    pub priority: String,
+}
+
 /// Authentication schemes supported by this agent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentAuthentication {
@@ -65,8 +78,9 @@ pub fn build_agent_card(workspace: &WorkspaceConfig) -> Result<AgentCard> {
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("workspace.yaml has no `a2a:` section"))?;
 
-    // Collect skills from each agent's deskd.yaml.
+    // Collect skills and needs from each agent's deskd.yaml.
     let mut skills = Vec::new();
+    let mut needs = Vec::new();
     for agent_def in &workspace.agents {
         let config_path = agent_def.config_path();
         let user_cfg = match UserConfig::load(&config_path) {
@@ -88,56 +102,12 @@ pub fn build_agent_card(workspace: &WorkspaceConfig) -> Result<AgentCard> {
                 tags: skill.tags.clone(),
             });
         }
-    }
-
-    let auth_schemes = if a2a.api_key.is_some() {
-        vec!["apiKey".to_string()]
-    } else {
-        vec![]
-    };
-
-    let name = a2a
-        .description
-        .as_deref()
-        .unwrap_or("deskd instance")
-        .to_string();
-
-    Ok(AgentCard {
-        name,
-        description: a2a.description.clone(),
-        url: a2a.url.clone(),
-        version: "0.1.0".to_string(),
-        capabilities: AgentCapabilities {
-            streaming: true,
-            push_notifications: false,
-        },
-        skills,
-        authentication: AgentAuthentication {
-            schemes: auth_schemes,
-        },
-    })
-}
-
-/// Build an Agent Card from workspace config + explicitly provided user configs.
-/// Used when user configs are already loaded (e.g., in tests or when configs
-/// are in non-standard locations).
-pub fn build_agent_card_with_configs(
-    workspace: &WorkspaceConfig,
-    agent_configs: &[(&str, &UserConfig)],
-) -> Result<AgentCard> {
-    let a2a = workspace
-        .a2a
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("workspace.yaml has no `a2a:` section"))?;
-
-    let mut skills = Vec::new();
-    for (agent_name, user_cfg) in agent_configs {
-        for skill in &user_cfg.skills {
-            skills.push(AgentSkill {
-                id: format!("{}/{}", agent_name, skill.id),
-                name: skill.name.clone(),
-                description: skill.description.clone(),
-                tags: skill.tags.clone(),
+        for need in &user_cfg.needs {
+            needs.push(AgentNeed {
+                id: format!("{}/{}", agent_def.name, need.id),
+                description: need.description.clone(),
+                tags: need.tags.clone(),
+                priority: need.priority.clone(),
             });
         }
     }
@@ -164,6 +134,69 @@ pub fn build_agent_card_with_configs(
             push_notifications: false,
         },
         skills,
+        needs,
+        authentication: AgentAuthentication {
+            schemes: auth_schemes,
+        },
+    })
+}
+
+/// Build an Agent Card from workspace config + explicitly provided user configs.
+/// Used when user configs are already loaded (e.g., in tests or when configs
+/// are in non-standard locations).
+pub fn build_agent_card_with_configs(
+    workspace: &WorkspaceConfig,
+    agent_configs: &[(&str, &UserConfig)],
+) -> Result<AgentCard> {
+    let a2a = workspace
+        .a2a
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("workspace.yaml has no `a2a:` section"))?;
+
+    let mut skills = Vec::new();
+    let mut needs = Vec::new();
+    for (agent_name, user_cfg) in agent_configs {
+        for skill in &user_cfg.skills {
+            skills.push(AgentSkill {
+                id: format!("{}/{}", agent_name, skill.id),
+                name: skill.name.clone(),
+                description: skill.description.clone(),
+                tags: skill.tags.clone(),
+            });
+        }
+        for need in &user_cfg.needs {
+            needs.push(AgentNeed {
+                id: format!("{}/{}", agent_name, need.id),
+                description: need.description.clone(),
+                tags: need.tags.clone(),
+                priority: need.priority.clone(),
+            });
+        }
+    }
+
+    let auth_schemes = if a2a.api_key.is_some() {
+        vec!["apiKey".to_string()]
+    } else {
+        vec![]
+    };
+
+    let name = a2a
+        .description
+        .as_deref()
+        .unwrap_or("deskd instance")
+        .to_string();
+
+    Ok(AgentCard {
+        name,
+        description: a2a.description.clone(),
+        url: a2a.url.clone(),
+        version: "0.1.0".to_string(),
+        capabilities: AgentCapabilities {
+            streaming: true,
+            push_notifications: false,
+        },
+        skills,
+        needs,
         authentication: AgentAuthentication {
             schemes: auth_schemes,
         },
@@ -190,6 +223,17 @@ mod tests {
             api_key: Some("test-key".into()),
             listen: "0.0.0.0:3000".into(),
             description: Some("Dev workspace".into()),
+        }
+    }
+
+    fn make_user_config_with_needs(
+        skills: Vec<SkillDef>,
+        needs: Vec<crate::config::NeedDef>,
+    ) -> UserConfig {
+        UserConfig {
+            skills,
+            needs,
+            ..Default::default()
         }
     }
 
@@ -306,5 +350,47 @@ mod tests {
         let card = build_agent_card_with_configs(&workspace, &[]).unwrap();
         assert_eq!(card.name, "deskd instance");
         assert!(card.description.is_none());
+    }
+
+    #[test]
+    fn agent_card_with_needs() {
+        let workspace = make_workspace(vec![], Some(make_a2a_config()));
+        let user_cfg = make_user_config_with_needs(
+            vec![],
+            vec![
+                crate::config::NeedDef {
+                    id: "want-restart".into(),
+                    description: "Restart agent from Telegram".into(),
+                    tags: vec!["ux".into(), "telegram".into()],
+                    priority: "high".into(),
+                },
+                crate::config::NeedDef {
+                    id: "want-dashboard".into(),
+                    description: "Web dashboard for monitoring".into(),
+                    tags: vec!["ui".into()],
+                    priority: "medium".into(),
+                },
+            ],
+        );
+
+        let card = build_agent_card_with_configs(&workspace, &[("kira", &user_cfg)]).unwrap();
+        assert_eq!(card.needs.len(), 2);
+        assert_eq!(card.needs[0].id, "kira/want-restart");
+        assert_eq!(card.needs[0].priority, "high");
+        assert_eq!(card.needs[1].id, "kira/want-dashboard");
+        assert!(card.skills.is_empty());
+    }
+
+    #[test]
+    fn agent_card_needs_omitted_when_empty() {
+        let workspace = make_workspace(vec![], Some(make_a2a_config()));
+        let user_cfg = make_user_config(vec![]);
+        let card = build_agent_card_with_configs(&workspace, &[("dev", &user_cfg)]).unwrap();
+        assert!(card.needs.is_empty());
+        let json = serde_json::to_string(&card).unwrap();
+        assert!(
+            !json.contains("\"needs\""),
+            "empty needs should be omitted from JSON"
+        );
     }
 }

--- a/src/app/a2a_server.rs
+++ b/src/app/a2a_server.rs
@@ -278,6 +278,7 @@ mod tests {
                     description: "Code review".into(),
                     tags: vec!["rust".into()],
                 }],
+                needs: vec![],
                 authentication: crate::app::a2a::AgentAuthentication {
                     schemes: if api_key.is_some() {
                         vec!["apiKey".into()]

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -525,6 +525,33 @@ fn handle_tools_list(
         }));
     }
 
+    // A2A tools
+    tools.push(json!({
+        "name": "a2a_send",
+        "description": "Send an A2A task to a remote agent. Requires the agent's base URL and skill ID.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "Remote agent's base URL (e.g. https://archi.nassau.example.com)"},
+                "skill": {"type": "string", "description": "Skill ID to invoke (e.g. agent_name/skill_id)"},
+                "message": {"type": "string", "description": "Task description / message to send"},
+                "api_key": {"type": "string", "description": "API key for the remote agent (optional)"}
+            },
+            "required": ["url", "skill", "message"]
+        }
+    }));
+    tools.push(json!({
+        "name": "a2a_discover",
+        "description": "Fetch a remote agent's Agent Card (skills, needs, capabilities). Use to discover what a remote agent can do before sending tasks.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "Remote agent's base URL (e.g. https://archi.nassau.example.com)"}
+            },
+            "required": ["url"]
+        }
+    }));
+
     Response::ok(id, json!({ "tools": tools }))
 }
 
@@ -572,6 +599,8 @@ async fn handle_tools_call(
         }
         "sm_query" => mcp_tools::call_sm_query(args, sm_store).await,
         "usage_stats" => mcp_tools::call_usage_stats(args).await,
+        "a2a_send" => mcp_tools::call_a2a_send(args).await,
+        "a2a_discover" => mcp_tools::call_a2a_discover(args).await,
         other => anyhow::bail!("Unknown tool: {}", other),
     }
 }

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -757,6 +757,98 @@ pub(crate) async fn call_usage_stats(args: &Value) -> Result<Value> {
     Ok(serde_json::to_value(stats)?)
 }
 
+/// Send an A2A task to a remote agent via HTTP.
+///
+/// MCP tool: `a2a_send(url, skill, message, api_key?)`
+pub(crate) async fn call_a2a_send(args: &Value) -> Result<Value> {
+    let url = args
+        .get("url")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'url' parameter"))?;
+    let skill = args
+        .get("skill")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'skill' parameter"))?;
+    let message = args
+        .get("message")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'message' parameter"))?;
+    let api_key = args.get("api_key").and_then(|v| v.as_str());
+
+    let rpc_body = json!({
+        "jsonrpc": "2.0",
+        "id": uuid::Uuid::new_v4().to_string(),
+        "method": "tasks/send",
+        "params": {
+            "skill": skill,
+            "message": message,
+        }
+    });
+
+    let a2a_url = format!("{}/a2a", url.trim_end_matches('/'));
+
+    let client = reqwest::Client::new();
+    let mut req = client.post(&a2a_url).json(&rpc_body);
+    if let Some(key) = api_key {
+        req = req.header("x-api-key", key);
+    }
+
+    let resp = req.send().await.context("A2A request failed")?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        bail!("A2A request returned {}: {}", status, body);
+    }
+
+    let body: Value = resp.json().await.context("failed to parse A2A response")?;
+
+    if let Some(error) = body.get("error") {
+        bail!(
+            "A2A error {}: {}",
+            error.get("code").and_then(|c| c.as_i64()).unwrap_or(0),
+            error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown")
+        );
+    }
+
+    Ok(body.get("result").cloned().unwrap_or(body))
+}
+
+/// Fetch an Agent Card from a remote A2A agent (discovery).
+///
+/// MCP tool: `a2a_discover(url)`
+pub(crate) async fn call_a2a_discover(args: &Value) -> Result<Value> {
+    let url = args
+        .get("url")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'url' parameter"))?;
+
+    let card_url = format!("{}/.well-known/agent-card.json", url.trim_end_matches('/'));
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&card_url)
+        .send()
+        .await
+        .context("failed to fetch Agent Card")?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        bail!("Agent Card request returned {}: {}", status, body);
+    }
+
+    let card: Value = resp
+        .json()
+        .await
+        .context("failed to parse Agent Card JSON")?;
+
+    Ok(card)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -318,6 +318,9 @@ pub struct UserConfig {
     /// A2A skills advertised in the Agent Card.
     #[serde(default)]
     pub skills: Vec<SkillDef>,
+    /// A2A needs — what this agent wants done (Nassau extension to A2A spec).
+    #[serde(default)]
+    pub needs: Vec<NeedDef>,
 }
 
 /// An A2A skill advertised in the Agent Card (per A2A spec).
@@ -334,6 +337,26 @@ pub struct SkillDef {
     /// Tags for discovery (e.g. ["go", "rust"]).
     #[serde(default)]
     pub tags: Vec<String>,
+}
+
+/// An A2A need — what the agent wants done (Nassau extension).
+/// Defined in deskd.yaml under `needs:`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeedDef {
+    /// Unique need identifier (e.g. "want-restart-button").
+    pub id: String,
+    /// Human-readable description of what's needed.
+    pub description: String,
+    /// Tags for discovery (e.g. ["ux", "telegram"]).
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Priority: "low", "medium", "high".
+    #[serde(default = "default_need_priority")]
+    pub priority: String,
+}
+
+fn default_need_priority() -> String {
+    "medium".to_string()
 }
 
 fn default_model() -> String {


### PR DESCRIPTION
## Summary
- `needs:` config section in deskd.yaml — agents publish what they want done (id, description, tags, priority)
- Needs included in Agent Card JSON (omitted when empty via `skip_serializing_if`)
- `a2a_send` MCP tool — sends JSON-RPC `tasks/send` to remote A2A agents via reqwest
- `a2a_discover` MCP tool — fetches `/.well-known/agent-card.json` from remote agents
- Unit tests for needs in Agent Card (inclusion, omission, serialization)

Closes #358
Ref: #350, #353

Needs marketplace MCP tools (`publish_need`, `browse_needs`, `propose_for_need`) scoped to follow-up issue #359.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Agent Card includes needs when present, omits when empty
- [x] `a2a_send` constructs correct JSON-RPC payload
- [x] `a2a_discover` fetches and parses Agent Card