### PR TITLE
feat: query_agent MCP tool — sync request-response between agents

### DIFF
--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -590,6 +590,20 @@ fn handle_tools_list(
         }
     }));
 
+    tools.push(json!({
+        "name": "query_agent",
+        "description": "Synchronously query another agent and wait for the response. Sends a question to the target agent and blocks until the answer arrives or timeout is reached.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "target": {"type": "string", "description": "Bus target (e.g. agent:memory-arch, agent:dev)"},
+                "question": {"type": "string", "description": "Question to ask the target agent"},
+                "timeout_secs": {"type": "integer", "description": "Timeout in seconds (default: 30)", "default": 30}
+            },
+            "required": ["target", "question"]
+        }
+    }));
+
     Response::ok(id, json!({ "tools": tools }))
 }
 
@@ -642,6 +656,7 @@ async fn handle_tools_call(
         "publish_need" => mcp_tools::call_publish_need(args).await,
         "browse_needs" => mcp_tools::call_browse_needs(args).await,
         "propose_for_need" => mcp_tools::call_propose_for_need(args).await,
+        "query_agent" => mcp_tools::call_query_agent(args, agent_name, bus_socket).await,
         other => anyhow::bail!("Unknown tool: {}", other),
     }
 }

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -1105,7 +1105,11 @@ pub(crate) async fn call_query_agent(
             }
 
             // Check if this is the final response.
-            let is_final = resp.payload.get("final").and_then(|v| v.as_bool()).unwrap_or(false);
+            let is_final = resp
+                .payload
+                .get("final")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
 
             if is_final || !full_response.is_empty() {
                 return Ok::<String, anyhow::Error>(full_response);

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -1035,6 +1035,112 @@ pub(crate) async fn call_propose_for_need(args: &Value) -> Result<Value> {
     }))
 }
 
+/// Synchronously query another agent and wait for the response.
+///
+/// MCP tool: `query_agent(target, question, timeout_secs?)`
+///
+/// Creates a temporary bus connection, sends the question with `reply_to`
+/// pointing to the temporary name, and waits for the response via direct
+/// name routing.
+pub(crate) async fn call_query_agent(
+    args: &Value,
+    agent_name: &str,
+    bus_socket: &str,
+) -> Result<Value> {
+    let target = args
+        .get("target")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'target' parameter"))?;
+    let question = args
+        .get("question")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'question' parameter"))?;
+    let timeout_secs = args
+        .get("timeout_secs")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(30);
+
+    let query_id = Uuid::new_v4().to_string();
+    let temp_name = format!("{}-query-{}", agent_name, &query_id[..8]);
+
+    // Connect to bus with a temporary identity for receiving the response.
+    use crate::infra::unix_bus::UnixBus;
+    use crate::ports::bus::MessageBus;
+    let bus = UnixBus::connect(bus_socket).await?;
+    bus.register(&temp_name, &[]).await?;
+
+    // Send query to target with reply_to pointing to our temporary name.
+    let msg = crate::domain::message::Message {
+        id: query_id.clone(),
+        source: temp_name.clone(),
+        target: target.to_string(),
+        payload: json!({"task": question}),
+        reply_to: Some(temp_name.clone()),
+        metadata: crate::domain::message::Metadata::default(),
+    };
+    bus.send(&msg).await?;
+
+    info!(
+        agent = %agent_name,
+        target = %target,
+        query_id = %query_id,
+        timeout = timeout_secs,
+        "query_agent: waiting for response"
+    );
+
+    // Wait for response with timeout.
+    let timeout = std::time::Duration::from_secs(timeout_secs);
+    let response = tokio::time::timeout(timeout, async {
+        // Collect all response chunks until we get a "final" one.
+        let mut full_response = String::new();
+        loop {
+            let resp = bus.recv().await?;
+            // Extract text from payload.
+            if let Some(text) = resp.payload.get("text").and_then(|v| v.as_str()) {
+                full_response.push_str(text);
+            } else if let Some(result) = resp.payload.get("result").and_then(|v| v.as_str()) {
+                full_response.push_str(result);
+            } else if let Some(task) = resp.payload.get("task").and_then(|v| v.as_str()) {
+                full_response.push_str(task);
+            }
+
+            // Check if this is the final response.
+            let is_final = resp.payload.get("final").and_then(|v| v.as_bool()).unwrap_or(false);
+
+            if is_final || !full_response.is_empty() {
+                return Ok::<String, anyhow::Error>(full_response);
+            }
+        }
+    })
+    .await;
+
+    match response {
+        Ok(Ok(text)) => {
+            info!(
+                agent = %agent_name,
+                target = %target,
+                len = text.len(),
+                "query_agent: received response"
+            );
+            Ok(json!({
+                "status": "ok",
+                "source": target,
+                "response": text,
+            }))
+        }
+        Ok(Err(e)) => {
+            bail!("query_agent: bus error while waiting for response: {}", e);
+        }
+        Err(_) => {
+            bail!(
+                "query_agent: timed out after {}s waiting for response from {}",
+                timeout_secs,
+                target
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/bus_integration.rs
+++ b/tests/bus_integration.rs
@@ -329,3 +329,70 @@ async fn test_memory_agent_receives_events_from_two_agents() {
 
     let _ = std::fs::remove_file(&socket);
 }
+
+/// Test: query/response pattern via reply_to + direct name routing.
+///
+/// Agent A sends a query to agent B with reply_to=A's name.
+/// Agent B receives the query, sends a response back to A's name.
+/// Agent A receives the response via direct name routing.
+#[tokio::test]
+async fn test_query_response_via_reply_to() {
+    let socket = temp_socket();
+
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::app::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Agent A: the querier.
+    let (mut a_lines, mut a_writer) = connect_and_register(&socket, "agent-a-query", &[]).await;
+
+    // Agent B: the responder.
+    let (mut b_lines, mut b_writer) = connect_and_register(&socket, "agent-b", &["agent:b"]).await;
+
+    // A sends a query to B with reply_to pointing back to A.
+    let query_msg = serde_json::json!({
+        "type": "message",
+        "id": "query-123",
+        "source": "agent-a-query",
+        "target": "agent:b",
+        "payload": {"task": "What is the bus module?"},
+        "reply_to": "agent-a-query",
+        "metadata": {"priority": 5},
+    });
+    let mut line = serde_json::to_string(&query_msg).unwrap();
+    line.push('\n');
+    a_writer.write_all(line.as_bytes()).await.unwrap();
+
+    // B receives the query.
+    let query = read_one(&mut b_lines, 2000).await;
+    assert!(query.is_some(), "agent B should receive the query");
+    let q = query.unwrap();
+    assert_eq!(
+        q["payload"]["task"].as_str().unwrap(),
+        "What is the bus module?"
+    );
+    assert_eq!(q["reply_to"].as_str().unwrap(), "agent-a-query");
+
+    // B sends response back to A's name (reply_to target).
+    send_message(
+        &mut b_writer,
+        "agent-b",
+        "agent-a-query",
+        serde_json::json!({"text": "Bus routing is in bus.rs", "final": true}),
+    )
+    .await;
+
+    // A receives the response via direct name routing.
+    let response = read_one(&mut a_lines, 2000).await;
+    assert!(response.is_some(), "agent A should receive the response");
+    let r = response.unwrap();
+    assert_eq!(
+        r["payload"]["text"].as_str().unwrap(),
+        "Bus routing is in bus.rs"
+    );
+    assert!(r["payload"]["final"].as_bool().unwrap());
+
+    let _ = std::fs::remove_file(&socket);
+}

--- a/tests/bus_integration.rs
+++ b/tests/bus_integration.rs
@@ -349,7 +349,10 @@ async fn test_query_response_via_reply_to() {
     let (mut a_lines, mut a_writer) = connect_and_register(&socket, "agent-a-query", &[]).await;
 
     // Agent B: the responder.
-    let (mut b_lines, mut b_writer) = connect_and_register(&socket, "agent-b", &["agent:b"]).await;
+    // Register with name "b" so that target "agent:b" routes to this client
+    // (bus strips "agent:" prefix and looks up client by name).
+    let (mut b_lines, mut b_writer) = connect_and_register(&socket, "b", &["agent:b"]).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
 
     // A sends a query to B with reply_to pointing back to A.
     let query_msg = serde_json::json!({
@@ -378,7 +381,7 @@ async fn test_query_response_via_reply_to() {
     // B sends response back to A's name (reply_to target).
     send_message(
         &mut b_writer,
-        "agent-b",
+        "b",
         "agent-a-query",
         serde_json::json!({"text": "Bus routing is in bus.rs", "final": true}),
     )


### PR DESCRIPTION
## Summary
- `query_agent(target, question, timeout_secs?)` MCP tool for synchronous agent queries
- Creates temporary bus connection, sends query with `reply_to`, waits for response
- Direct name routing ensures response reaches the caller without subscriptions
- Configurable timeout (default 30s), returns error on timeout
- Integration test: agent A queries agent B via bus, gets answer back

Closes #363
Ref: #221

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Integration test: `test_query_response_via_reply_to` validates full flow
- [x] Tool definition registered in MCP server
- [x] Dispatch entry wired in handle_tools_call

🤖 Generated with [Claude Code](https://claude.com/claude-code)