### PR TITLE
feat: context compaction foundation — token tracking, tags, partitioning

### DIFF
--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -119,6 +119,7 @@ mod tests {
             },
             label: "System prompt".into(),
             tokens_estimate: 500,
+            tags: Vec::new(),
         });
         branch.nodes.push(Node {
             id: "n2".into(),
@@ -128,6 +129,7 @@ mod tests {
             },
             label: "Governance".into(),
             tokens_estimate: 1200,
+            tags: Vec::new(),
         });
         assert_eq!(branch.total_tokens(), 1700);
     }
@@ -146,6 +148,7 @@ mod tests {
             },
             label: "Greeting".into(),
             tokens_estimate: 100,
+            tags: Vec::new(),
         });
         branch.nodes.push(Node {
             id: "l1".into(),
@@ -158,6 +161,7 @@ mod tests {
             },
             label: "Echo test".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         let repo = crate::app::context::new_context_store();
@@ -214,6 +218,7 @@ mod tests {
             },
             label: "System".into(),
             tokens_estimate: 100,
+            tags: Vec::new(),
         });
         branch.nodes.push(Node {
             id: "s2".into(),
@@ -223,6 +228,7 @@ mod tests {
             },
             label: "Context".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         let messages = branch.materialize().await.expect("materialize failed");
@@ -247,6 +253,7 @@ mod tests {
             },
             label: "Echo test".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         let messages = branch.materialize().await.expect("materialize failed");
@@ -269,6 +276,7 @@ mod tests {
             },
             label: "Cached echo".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         // First materialize — executes command
@@ -316,6 +324,7 @@ mod tests {
             },
             label: "Expiry test".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         let messages = branch.materialize().await.expect("materialize failed");
@@ -338,6 +347,7 @@ mod tests {
             },
             label: "Silent".into(),
             tokens_estimate: 10,
+            tags: Vec::new(),
         });
 
         let messages = branch.materialize().await.expect("materialize failed");

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -220,20 +220,24 @@ pub async fn run(
 
     // Memory agent: cumulative token estimate for compaction trigger.
     let mut memory_tokens_estimate: u64 = 0;
-    // Compaction threshold in tokens. Derive from compact_threshold (fraction 0.0–1.0)
-    // applied to a default context budget of 100_000 tokens (conservative for most models).
-    let compact_threshold_tokens: u64 = if agent_runtime == AgentRuntime::Memory {
-        let fraction = initial_state.config.compact_threshold.unwrap_or(0.8);
-        let context_budget: u64 = initial_state
+
+    // Cumulative session input tokens — tracks actual token usage from Claude responses.
+    // Used to trigger compaction for all agent types (not just memory agents).
+    let mut session_input_tokens: u64 = 0;
+
+    // Compaction threshold in tokens. Derive from context config or compact_threshold
+    // fraction applied to a default context budget of 100_000 tokens.
+    let compact_threshold_tokens: u64 = {
+        let from_config = initial_state
             .config
             .context
             .as_ref()
             .and_then(|c| c.compact_threshold_tokens)
-            .map(|t| t as u64)
-            .unwrap_or((100_000f64 * fraction) as u64);
-        context_budget
-    } else {
-        0
+            .map(|t| t as u64);
+        from_config.unwrap_or_else(|| {
+            let fraction = initial_state.config.compact_threshold.unwrap_or(0.8);
+            (100_000f64 * fraction) as u64
+        })
     };
 
     loop {
@@ -596,6 +600,9 @@ pub async fn run(
 
         match result {
             Ok(ref turn) => {
+                // Track cumulative session input tokens for compaction trigger.
+                session_input_tokens += turn.token_usage.input_tokens;
+
                 handle_task_success(
                     name,
                     &msg,
@@ -610,6 +617,51 @@ pub async fn run(
                     task_store,
                 )
                 .await;
+
+                // Check compaction trigger for all agent types.
+                // Memory agents have their own injection-based trigger above;
+                // this covers regular agents hitting context limits from tasks.
+                if agent_runtime != AgentRuntime::Memory
+                    && crate::domain::context::should_compact(
+                        session_input_tokens,
+                        compact_threshold_tokens,
+                    )
+                {
+                    info!(
+                        agent = %name,
+                        session_input_tokens = session_input_tokens,
+                        threshold = compact_threshold_tokens,
+                        "session compaction triggered — requesting context condensation"
+                    );
+                    let compact_prompt = "Your context is approaching capacity. \
+                        Summarize everything important from this session: decisions made, \
+                        current state of work, errors encountered, and next steps. \
+                        Be thorough but concise — this summary will be your working memory.";
+                    let compact_limits = agent::TaskLimits {
+                        max_turns: Some(3),
+                        budget_usd: Some(budget_usd),
+                    };
+                    match process
+                        .send_task(compact_prompt, None, None, &compact_limits)
+                        .await
+                    {
+                        Ok(compact_turn) => {
+                            info!(
+                                agent = %name,
+                                cost = compact_turn.cost_usd,
+                                output_tokens = compact_turn.token_usage.output_tokens,
+                                "session compaction completed"
+                            );
+                            // Reset — the session now has condensed history.
+                            session_input_tokens = 0;
+                        }
+                        Err(e) => {
+                            warn!(agent = %name, error = %e, "session compaction failed");
+                            // Halve to avoid re-triggering immediately.
+                            session_input_tokens /= 2;
+                        }
+                    }
+                }
             }
             Err(ref e) => {
                 let needs_restart =

--- a/src/domain/context.rs
+++ b/src/domain/context.rs
@@ -31,6 +31,7 @@ pub struct Node {
     pub kind: NodeKind,
     pub label: String,        // human-readable description
     pub tokens_estimate: u32, // approximate token count
+    pub tags: Vec<String>,    // topic tags for partitioning (#299)
 }
 
 /// The main branch — persistent context for an agent
@@ -69,6 +70,80 @@ impl MainBranch {
     pub fn total_tokens(&self) -> u32 {
         self.nodes.iter().map(|n| n.tokens_estimate).sum()
     }
+
+    /// Add a static content node to the branch.
+    pub fn add_static(&mut self, id: &str, label: &str, role: &str, content: &str) {
+        let tokens_estimate = (content.len() as u32) / 4;
+        self.nodes.push(Node {
+            id: id.to_string(),
+            kind: NodeKind::Static {
+                role: role.to_string(),
+                content: content.to_string(),
+            },
+            label: label.to_string(),
+            tokens_estimate,
+            tags: Vec::new(),
+        });
+    }
+
+    /// Add a static content node with tags.
+    pub fn add_static_tagged(
+        &mut self,
+        id: &str,
+        label: &str,
+        role: &str,
+        content: &str,
+        tags: Vec<String>,
+    ) {
+        let tokens_estimate = (content.len() as u32) / 4;
+        self.nodes.push(Node {
+            id: id.to_string(),
+            kind: NodeKind::Static {
+                role: role.to_string(),
+                content: content.to_string(),
+            },
+            label: label.to_string(),
+            tokens_estimate,
+            tags,
+        });
+    }
+
+    /// Serialize all static nodes into a single system prompt string.
+    ///
+    /// Used for context transfer: when spawning a child agent, this
+    /// produces the prompt that carries the parent's context subset.
+    pub fn to_system_prompt(&self) -> String {
+        let mut sections = Vec::new();
+        for node in &self.nodes {
+            if let NodeKind::Static { content, .. } = &node.kind {
+                sections.push(format!("## {}\n{}", node.label, content));
+            }
+        }
+        sections.join("\n\n")
+    }
+
+    /// Partition nodes by tag groups, returning a new MainBranch per group.
+    ///
+    /// Each group is a set of tags. A node matches a group if it has any
+    /// overlapping tag. Untagged nodes are included in all partitions.
+    pub fn partition_by_tags(&self, groups: &[Vec<String>]) -> Vec<MainBranch> {
+        groups
+            .iter()
+            .enumerate()
+            .map(|(i, group_tags)| {
+                let matching_nodes: Vec<Node> = self
+                    .nodes
+                    .iter()
+                    .filter(|n| n.tags.is_empty() || n.tags.iter().any(|t| group_tags.contains(t)))
+                    .cloned()
+                    .collect();
+                let mut branch =
+                    MainBranch::new(&format!("{}-split-{}", self.agent, i), self.budget_tokens);
+                branch.nodes = matching_nodes;
+                branch
+            })
+            .collect()
+    }
 }
 
 /// Check if session should be compacted based on cumulative token usage
@@ -82,4 +157,109 @@ pub fn default_main_path(work_dir: &str) -> std::path::PathBuf {
         .join(".deskd")
         .join("context")
         .join("main.yaml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_static_node() {
+        let mut branch = MainBranch::new("test-agent", 10_000);
+        branch.add_static("n1", "System Role", "system", "You are a helpful agent.");
+        assert_eq!(branch.nodes.len(), 1);
+        assert_eq!(branch.nodes[0].id, "n1");
+        assert!(branch.nodes[0].tokens_estimate > 0);
+        assert!(branch.nodes[0].tags.is_empty());
+    }
+
+    #[test]
+    fn test_add_static_tagged() {
+        let mut branch = MainBranch::new("test-agent", 10_000);
+        branch.add_static_tagged(
+            "n1",
+            "Rust Context",
+            "system",
+            "Rust codebase info",
+            vec!["rust".into(), "code".into()],
+        );
+        assert_eq!(branch.nodes[0].tags, vec!["rust", "code"]);
+    }
+
+    #[test]
+    fn test_to_system_prompt() {
+        let mut branch = MainBranch::new("test-agent", 10_000);
+        branch.add_static("n1", "Role", "system", "You are helpful.");
+        branch.add_static("n2", "Context", "user", "Work on deskd.");
+        let prompt = branch.to_system_prompt();
+        assert!(prompt.contains("## Role\nYou are helpful."));
+        assert!(prompt.contains("## Context\nWork on deskd."));
+    }
+
+    #[test]
+    fn test_to_system_prompt_skips_live_nodes() {
+        let mut branch = MainBranch::new("test-agent", 10_000);
+        branch.add_static("n1", "Role", "system", "Be helpful.");
+        branch.nodes.push(Node {
+            id: "live1".into(),
+            kind: NodeKind::Live {
+                command: "echo".into(),
+                args: vec!["hello".into()],
+                max_age_secs: None,
+                inject_as: "user".into(),
+                cached_result: None,
+            },
+            label: "Live Node".into(),
+            tokens_estimate: 10,
+            tags: Vec::new(),
+        });
+        let prompt = branch.to_system_prompt();
+        assert!(prompt.contains("Be helpful."));
+        assert!(!prompt.contains("Live Node"));
+    }
+
+    #[test]
+    fn test_partition_by_tags() {
+        let mut branch = MainBranch::new("parent", 10_000);
+        branch.add_static_tagged("n1", "Rust", "system", "Rust code", vec!["rust".into()]);
+        branch.add_static_tagged("n2", "Go", "system", "Go code", vec!["go".into()]);
+        branch.add_static("n3", "Shared", "system", "Shared context"); // untagged
+
+        let partitions = branch.partition_by_tags(&[vec!["rust".into()], vec!["go".into()]]);
+
+        assert_eq!(partitions.len(), 2);
+
+        // Rust partition: n1 (rust) + n3 (untagged)
+        assert_eq!(partitions[0].nodes.len(), 2);
+        assert_eq!(partitions[0].agent, "parent-split-0");
+
+        // Go partition: n2 (go) + n3 (untagged)
+        assert_eq!(partitions[1].nodes.len(), 2);
+        assert_eq!(partitions[1].agent, "parent-split-1");
+    }
+
+    #[test]
+    fn test_partition_node_in_multiple_groups() {
+        let mut branch = MainBranch::new("agent", 5_000);
+        branch.add_static_tagged(
+            "n1",
+            "Both",
+            "system",
+            "Relevant to both",
+            vec!["rust".into(), "go".into()],
+        );
+
+        let partitions = branch.partition_by_tags(&[vec!["rust".into()], vec!["go".into()]]);
+
+        // Node with both tags appears in both partitions.
+        assert_eq!(partitions[0].nodes.len(), 1);
+        assert_eq!(partitions[1].nodes.len(), 1);
+    }
+
+    #[test]
+    fn test_token_estimate_from_content_length() {
+        let mut branch = MainBranch::new("agent", 10_000);
+        branch.add_static("n1", "Test", "system", "a]bc"); // 4 chars → 1 token
+        assert_eq!(branch.nodes[0].tokens_estimate, 1);
+    }
 }

--- a/src/infra/context_store.rs
+++ b/src/infra/context_store.rs
@@ -62,6 +62,7 @@ mod tests {
             },
             label: "Greeting".into(),
             tokens_estimate: 100,
+            tags: Vec::new(),
         });
 
         store.save(&branch, &path).expect("save failed");

--- a/src/infra/dto/context.rs
+++ b/src/infra/dto/context.rs
@@ -24,6 +24,8 @@ pub struct StoredNode {
     pub kind: StoredNodeKind,
     pub label: String,
     pub tokens_estimate: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 /// Storage format for node kinds.
@@ -84,6 +86,7 @@ impl From<StoredNode> for Node {
             kind: dto.kind.into(),
             label: dto.label,
             tokens_estimate: dto.tokens_estimate,
+            tags: dto.tags,
         }
     }
 }
@@ -95,6 +98,7 @@ impl From<&Node> for StoredNode {
             kind: (&n.kind).into(),
             label: n.label.clone(),
             tokens_estimate: n.tokens_estimate,
+            tags: n.tags.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Foundation for #299 (context splitting). Adds the building blocks needed before context can be split into child agents:

- **Cumulative session token tracking** for all agent types — tracks input tokens across tasks, triggers compaction when threshold exceeded
- **Node tags** — `tags: Vec<String>` on context nodes for topic-based partitioning
- **MainBranch builder API** — `add_static()`, `add_static_tagged()` for runtime context construction (no longer requires YAML on disk)
- **`partition_by_tags()`** — splits a MainBranch into multiple branches by tag groups (untagged nodes included in all partitions)
- **`to_system_prompt()`** — serializes static nodes into a prompt string for context transfer to child agents
- **DTO tags support** — `tags` field in StoredNode with `skip_serializing_if = "Vec::is_empty"` for backward compat

### Worker loop changes

Regular agents now accumulate `session_input_tokens` after each task. When cumulative input tokens exceed `compact_threshold_tokens`, a condensation task is sent to the agent automatically (same pattern as memory agent compaction, but triggered by actual Claude token usage instead of injected event estimates).

### What's next (follow-up PRs)

- Split decision policy (config-driven: when to split vs compress)
- Child agent spawning with transferred context
- Context extraction from conversation via LLM clustering

Closes #368

## Test plan

- [x] New unit tests for MainBranch builder, tags, partition_by_tags, to_system_prompt
- [x] Existing context tests updated with tags field
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)