### PR TITLE
feat: JWT auth for A2A — Ed25519 key pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,8 +470,10 @@ dependencies = [
  "clap",
  "cron",
  "futures",
+ "jsonwebtoken",
  "openssl",
  "reqwest 0.12.28",
+ "ring",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -912,20 +914,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -1193,6 +1181,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,10 +1347,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1445,6 +1467,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -1755,7 +1787,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1766,7 +1797,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1775,7 +1805,6 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -1783,7 +1812,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -1796,14 +1824,16 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1815,12 +1845,14 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -1865,18 +1897,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -1928,16 +1948,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
@@ -1984,16 +1994,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secrecy"
@@ -2159,7 +2159,7 @@ dependencies = [
  "futures",
  "mime_guess",
  "percent-encoding",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "secrecy",
  "serde",
  "serde_cow",
@@ -2213,6 +2213,18 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -2578,16 +2590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
  "tokio",
 ]
 
@@ -3047,12 +3049,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ axum = { version = "0.8", features = ["json"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
+jsonwebtoken = "9"
+ring = "0.17"
 
 [lib]
 name = "deskd"

--- a/src/app/a2a.rs
+++ b/src/app/a2a.rs
@@ -244,6 +244,7 @@ mod tests {
             description: Some("Dev workspace".into()),
             auth: "api_key".into(),
             private_key: None,
+            trusted_keys: vec![],
         }
     }
 

--- a/src/app/a2a.rs
+++ b/src/app/a2a.rs
@@ -66,6 +66,9 @@ pub struct AgentNeed {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentAuthentication {
     pub schemes: Vec<String>,
+    /// JWKS key set for JWT verification. Present when auth scheme is "jwt".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwks: Option<crate::app::a2a_jwt::Jwks>,
 }
 
 /// Build an Agent Card from workspace config + all user configs.
@@ -112,10 +115,16 @@ pub fn build_agent_card(workspace: &WorkspaceConfig) -> Result<AgentCard> {
         }
     }
 
-    let auth_schemes = if a2a.api_key.is_some() {
-        vec!["apiKey".to_string()]
-    } else {
-        vec![]
+    let auth_schemes = match a2a.auth.as_str() {
+        "jwt" => vec!["jwt".to_string()],
+        "none" => vec![],
+        _ => {
+            if a2a.api_key.is_some() {
+                vec!["apiKey".to_string()]
+            } else {
+                vec![]
+            }
+        }
     };
 
     let name = a2a
@@ -137,6 +146,7 @@ pub fn build_agent_card(workspace: &WorkspaceConfig) -> Result<AgentCard> {
         needs,
         authentication: AgentAuthentication {
             schemes: auth_schemes,
+            jwks: None,
         },
     })
 }
@@ -174,10 +184,16 @@ pub fn build_agent_card_with_configs(
         }
     }
 
-    let auth_schemes = if a2a.api_key.is_some() {
-        vec!["apiKey".to_string()]
-    } else {
-        vec![]
+    let auth_schemes = match a2a.auth.as_str() {
+        "jwt" => vec!["jwt".to_string()],
+        "none" => vec![],
+        _ => {
+            if a2a.api_key.is_some() {
+                vec!["apiKey".to_string()]
+            } else {
+                vec![]
+            }
+        }
     };
 
     let name = a2a
@@ -199,6 +215,7 @@ pub fn build_agent_card_with_configs(
         needs,
         authentication: AgentAuthentication {
             schemes: auth_schemes,
+            jwks: None,
         },
     })
 }
@@ -225,6 +242,8 @@ mod tests {
             api_key: Some("test-key".into()),
             listen: "0.0.0.0:3000".into(),
             description: Some("Dev workspace".into()),
+            auth: "api_key".into(),
+            private_key: None,
         }
     }
 

--- a/src/app/a2a_jwt.rs
+++ b/src/app/a2a_jwt.rs
@@ -1,0 +1,293 @@
+//! JWT authentication for A2A protocol.
+//!
+//! Each deskd instance has an Ed25519 key pair. The public key is published
+//! in the Agent Card JWKS. Outgoing requests are signed with JWT; incoming
+//! requests are verified against the sender's published public key.
+
+use anyhow::{Context, Result};
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use ring::signature::KeyPair as _;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// JWT claims for A2A requests.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct A2aClaims {
+    /// Issuer — the sender's A2A URL.
+    pub iss: String,
+    /// Issued-at timestamp (Unix seconds).
+    pub iat: u64,
+    /// Expiry timestamp (Unix seconds).
+    pub exp: u64,
+}
+
+/// A loaded Ed25519 key pair for signing JWTs.
+pub struct KeyPair {
+    /// DER-encoded PKCS#8 private key.
+    private_key_der: Vec<u8>,
+    /// Raw 32-byte public key.
+    public_key_bytes: Vec<u8>,
+}
+
+impl KeyPair {
+    /// Generate a new Ed25519 key pair.
+    pub fn generate() -> Result<Self> {
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng)
+            .map_err(|e| anyhow::anyhow!("key generation failed: {}", e))?;
+
+        let key_pair = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8.as_ref())
+            .map_err(|e| anyhow::anyhow!("key pair creation failed: {}", e))?;
+
+        Ok(Self {
+            private_key_der: pkcs8.as_ref().to_vec(),
+            public_key_bytes: key_pair.public_key().as_ref().to_vec(),
+        })
+    }
+
+    /// Load from PEM files on disk.
+    pub fn load(private_key_path: &Path) -> Result<Self> {
+        let pem_bytes = std::fs::read(private_key_path)
+            .with_context(|| format!("reading private key: {}", private_key_path.display()))?;
+
+        // Parse PEM to extract DER bytes.
+        let pem_str = String::from_utf8_lossy(&pem_bytes);
+        let der = pem_to_der(&pem_str).with_context(|| "invalid PEM format for private key")?;
+
+        let key_pair = ring::signature::Ed25519KeyPair::from_pkcs8(&der)
+            .map_err(|e| anyhow::anyhow!("invalid Ed25519 private key: {}", e))?;
+
+        Ok(Self {
+            private_key_der: der,
+            public_key_bytes: key_pair.public_key().as_ref().to_vec(),
+        })
+    }
+
+    /// Save key pair to PEM files.
+    pub fn save(&self, private_key_path: &Path) -> Result<()> {
+        if let Some(parent) = private_key_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let pem = der_to_pem(&self.private_key_der, "PRIVATE KEY");
+        std::fs::write(private_key_path, pem.as_bytes())?;
+
+        // Save public key alongside.
+        let pub_path = private_key_path.with_extension("pub");
+        let pub_pem = der_to_pem(&self.public_key_bytes, "PUBLIC KEY");
+        std::fs::write(pub_path, pub_pem.as_bytes())?;
+
+        Ok(())
+    }
+
+    /// Get the raw public key bytes (32 bytes for Ed25519).
+    pub fn public_key_bytes(&self) -> &[u8] {
+        &self.public_key_bytes
+    }
+
+    /// Get the public key as URL-safe base64 (for JWKS `x` field).
+    pub fn public_key_base64url(&self) -> String {
+        base64_url_encode(&self.public_key_bytes)
+    }
+
+    /// Sign a JWT with this key pair.
+    pub fn sign_jwt(&self, issuer: &str, ttl_secs: u64) -> Result<String> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let claims = A2aClaims {
+            iss: issuer.to_string(),
+            iat: now,
+            exp: now + ttl_secs,
+        };
+
+        let header = Header::new(Algorithm::EdDSA);
+        let key = EncodingKey::from_ed_der(&self.private_key_der);
+        let token = jsonwebtoken::encode(&header, &claims, &key)?;
+        Ok(token)
+    }
+}
+
+/// Verify a JWT token against a raw Ed25519 public key.
+pub fn verify_jwt(token: &str, public_key_bytes: &[u8]) -> Result<A2aClaims> {
+    let key = DecodingKey::from_ed_der(public_key_bytes);
+    let mut validation = Validation::new(Algorithm::EdDSA);
+    validation.validate_exp = true;
+    validation.required_spec_claims.clear();
+    validation.set_required_spec_claims(&["iss", "exp"]);
+
+    let data = jsonwebtoken::decode::<A2aClaims>(token, &key, &validation)?;
+    Ok(data.claims)
+}
+
+/// Verify a JWT using a base64url-encoded public key (from Agent Card JWKS).
+pub fn verify_jwt_base64(token: &str, public_key_b64: &str) -> Result<A2aClaims> {
+    let bytes = base64_url_decode(public_key_b64)?;
+    verify_jwt(token, &bytes)
+}
+
+/// JWKS key entry for Agent Card.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JwkKey {
+    pub kty: String,
+    pub crv: String,
+    /// Public key bytes, base64url-encoded.
+    pub x: String,
+}
+
+/// JWKS key set for Agent Card.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Jwks {
+    pub keys: Vec<JwkKey>,
+}
+
+impl Jwks {
+    /// Create JWKS from a public key.
+    pub fn from_public_key(public_key_bytes: &[u8]) -> Self {
+        Self {
+            keys: vec![JwkKey {
+                kty: "OKP".to_string(),
+                crv: "Ed25519".to_string(),
+                x: base64_url_encode(public_key_bytes),
+            }],
+        }
+    }
+}
+
+// ─── PEM helpers ────────────────────────────────────────────────────────────
+
+fn pem_to_der(pem: &str) -> Result<Vec<u8>> {
+    let b64: String = pem
+        .lines()
+        .filter(|l| !l.starts_with("-----"))
+        .collect::<Vec<_>>()
+        .join("");
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD
+        .decode(&b64)
+        .map_err(|e| anyhow::anyhow!("base64 decode failed: {}", e))
+}
+
+fn der_to_pem(der: &[u8], label: &str) -> String {
+    use base64::Engine;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(der);
+    let mut pem = format!("-----BEGIN {}-----\n", label);
+    for chunk in b64.as_bytes().chunks(64) {
+        pem.push_str(std::str::from_utf8(chunk).unwrap());
+        pem.push('\n');
+    }
+    pem.push_str(&format!("-----END {}-----\n", label));
+    pem
+}
+
+fn base64_url_encode(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn base64_url_decode(s: &str) -> Result<Vec<u8>> {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(s)
+        .map_err(|e| anyhow::anyhow!("base64url decode failed: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_and_sign_verify() {
+        let kp = KeyPair::generate().unwrap();
+        let token = kp.sign_jwt("https://test.example.com", 60).unwrap();
+
+        let claims = verify_jwt(&token, kp.public_key_bytes()).unwrap();
+        assert_eq!(claims.iss, "https://test.example.com");
+        assert!(claims.exp > claims.iat);
+        assert_eq!(claims.exp - claims.iat, 60);
+    }
+
+    #[test]
+    fn test_verify_with_wrong_key_fails() {
+        let kp1 = KeyPair::generate().unwrap();
+        let kp2 = KeyPair::generate().unwrap();
+        let token = kp1.sign_jwt("https://a.example.com", 60).unwrap();
+
+        let result = verify_jwt(&token, kp2.public_key_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_expired_token_rejected() {
+        let kp = KeyPair::generate().unwrap();
+        // Token that expired 100 seconds ago.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let claims = A2aClaims {
+            iss: "https://test.example.com".into(),
+            iat: now - 200,
+            exp: now - 100,
+        };
+        let header = Header::new(Algorithm::EdDSA);
+        let key = EncodingKey::from_ed_der(&kp.private_key_der);
+        let token = jsonwebtoken::encode(&header, &claims, &key).unwrap();
+
+        let result = verify_jwt(&token, kp.public_key_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_base64url_roundtrip() {
+        let kp = KeyPair::generate().unwrap();
+        let b64 = kp.public_key_base64url();
+        let token = kp.sign_jwt("https://test.example.com", 60).unwrap();
+
+        let claims = verify_jwt_base64(&token, &b64).unwrap();
+        assert_eq!(claims.iss, "https://test.example.com");
+    }
+
+    #[test]
+    fn test_jwks_from_public_key() {
+        let kp = KeyPair::generate().unwrap();
+        let jwks = Jwks::from_public_key(kp.public_key_bytes());
+        assert_eq!(jwks.keys.len(), 1);
+        assert_eq!(jwks.keys[0].kty, "OKP");
+        assert_eq!(jwks.keys[0].crv, "Ed25519");
+        assert!(!jwks.keys[0].x.is_empty());
+    }
+
+    #[test]
+    fn test_save_and_load_keypair() {
+        let dir = std::env::temp_dir().join("deskd-test-jwt");
+        let key_path = dir.join("test_key.pem");
+
+        let kp = KeyPair::generate().unwrap();
+        kp.save(&key_path).unwrap();
+
+        let loaded = KeyPair::load(&key_path).unwrap();
+
+        // Sign with original, verify with loaded.
+        let token = kp.sign_jwt("https://test.example.com", 60).unwrap();
+        let claims = verify_jwt(&token, loaded.public_key_bytes()).unwrap();
+        assert_eq!(claims.iss, "https://test.example.com");
+
+        // Sign with loaded, verify with original.
+        let token2 = loaded.sign_jwt("https://test2.example.com", 30).unwrap();
+        let claims2 = verify_jwt(&token2, kp.public_key_bytes()).unwrap();
+        assert_eq!(claims2.iss, "https://test2.example.com");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_pem_roundtrip() {
+        let original = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+        let pem = der_to_pem(&original, "TEST DATA");
+        let decoded = pem_to_der(&pem).unwrap();
+        assert_eq!(original, decoded);
+    }
+}

--- a/src/app/a2a_server.rs
+++ b/src/app/a2a_server.rs
@@ -26,6 +26,10 @@ pub struct A2aState {
     pub api_key: Option<String>,
     /// Bus socket path for routing tasks to local agents.
     pub bus_socket: String,
+    /// Authentication mode: "api_key", "jwt", or "none".
+    pub auth_mode: String,
+    /// JWKS public key bytes for JWT verification. None if not using JWT.
+    pub jwt_public_key: Option<Vec<u8>>,
 }
 
 /// Start the A2A HTTP server.
@@ -106,19 +110,12 @@ async fn handle_a2a_rpc(
     headers: axum::http::HeaderMap,
     Json(req): Json<JsonRpcRequest>,
 ) -> (StatusCode, Json<JsonRpcResponse>) {
-    // API key authentication.
-    if let Some(expected_key) = &state.api_key {
-        let provided = headers.get("x-api-key").and_then(|v| v.to_str().ok());
-        if provided != Some(expected_key.as_str()) {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(JsonRpcResponse::error(
-                    req.id,
-                    -32000,
-                    "unauthorized: invalid or missing API key".into(),
-                )),
-            );
-        }
+    // Authentication.
+    if let Some(auth_error) = check_auth(&state, &headers) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(JsonRpcResponse::error(req.id, -32000, auth_error)),
+        );
     }
 
     match req.method.as_str() {
@@ -254,6 +251,39 @@ fn handle_tasks_cancel(
     )
 }
 
+/// Check authentication based on the configured auth mode.
+/// Returns None if auth passes, Some(error_message) if auth fails.
+fn check_auth(state: &A2aState, headers: &axum::http::HeaderMap) -> Option<String> {
+    match state.auth_mode.as_str() {
+        "none" => None,
+        "jwt" => {
+            let public_key = state.jwt_public_key.as_ref()?;
+            let token = headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "));
+
+            match token {
+                None => Some("unauthorized: missing Bearer token".into()),
+                Some(t) => match crate::app::a2a_jwt::verify_jwt(t, public_key) {
+                    Ok(_claims) => None,
+                    Err(e) => Some(format!("unauthorized: invalid JWT — {e}")),
+                },
+            }
+        }
+        _ => {
+            // Default: api_key mode.
+            if let Some(expected_key) = &state.api_key {
+                let provided = headers.get("x-api-key").and_then(|v| v.to_str().ok());
+                if provided != Some(expected_key.as_str()) {
+                    return Some("unauthorized: invalid or missing API key".into());
+                }
+            }
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,10 +315,17 @@ mod tests {
                     } else {
                         vec![]
                     },
+                    jwks: None,
                 },
             },
             api_key: api_key.map(String::from),
             bus_socket: "/tmp/test.sock".into(),
+            auth_mode: if api_key.is_some() {
+                "api_key".into()
+            } else {
+                "none".into()
+            },
+            jwt_public_key: None,
         })
     }
 
@@ -380,5 +417,83 @@ mod tests {
                 .unwrap()
                 .contains("missing")
         );
+    }
+
+    fn make_jwt_state() -> (Arc<A2aState>, crate::app::a2a_jwt::KeyPair) {
+        let kp = crate::app::a2a_jwt::KeyPair::generate().unwrap();
+        let state = Arc::new(A2aState {
+            agent_card: crate::app::a2a::AgentCard {
+                name: "test".into(),
+                description: None,
+                url: "https://test.example.com".into(),
+                version: "0.1.0".into(),
+                capabilities: crate::app::a2a::AgentCapabilities {
+                    streaming: true,
+                    push_notifications: false,
+                },
+                skills: vec![],
+                needs: vec![],
+                authentication: crate::app::a2a::AgentAuthentication {
+                    schemes: vec!["jwt".into()],
+                    jwks: None,
+                },
+            },
+            api_key: None,
+            bus_socket: "/tmp/test.sock".into(),
+            auth_mode: "jwt".into(),
+            jwt_public_key: Some(kp.public_key_bytes().to_vec()),
+        });
+        (state, kp)
+    }
+
+    #[tokio::test]
+    async fn a2a_jwt_auth_valid() {
+        let (state, kp) = make_jwt_state();
+        let app = router(state);
+        let token = kp.sign_jwt("https://sender.example.com", 60).unwrap();
+
+        let req = Request::post("/a2a")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", token))
+            .body(Body::from(
+                r#"{"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"abc"}}"#,
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn a2a_jwt_auth_missing_token() {
+        let (state, _kp) = make_jwt_state();
+        let app = router(state);
+
+        let req = Request::post("/a2a")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"abc"}}"#,
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn a2a_jwt_auth_wrong_key() {
+        let (state, _kp) = make_jwt_state();
+        let app = router(state);
+        // Sign with a different key.
+        let other_kp = crate::app::a2a_jwt::KeyPair::generate().unwrap();
+        let token = other_kp.sign_jwt("https://evil.example.com", 60).unwrap();
+
+        let req = Request::post("/a2a")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", token))
+            .body(Body::from(
+                r#"{"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"abc"}}"#,
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/src/app/a2a_server.rs
+++ b/src/app/a2a_server.rs
@@ -28,8 +28,9 @@ pub struct A2aState {
     pub bus_socket: String,
     /// Authentication mode: "api_key", "jwt", or "none".
     pub auth_mode: String,
-    /// JWKS public key bytes for JWT verification. None if not using JWT.
-    pub jwt_public_key: Option<Vec<u8>>,
+    /// Trusted public keys for JWT verification (raw Ed25519 bytes).
+    /// Incoming JWTs are verified against each key until one matches.
+    pub trusted_keys: Vec<Vec<u8>>,
 }
 
 /// Start the A2A HTTP server.
@@ -257,7 +258,9 @@ fn check_auth(state: &A2aState, headers: &axum::http::HeaderMap) -> Option<Strin
     match state.auth_mode.as_str() {
         "none" => None,
         "jwt" => {
-            let public_key = state.jwt_public_key.as_ref()?;
+            if state.trusted_keys.is_empty() {
+                return Some("server misconfigured: no trusted keys for JWT verification".into());
+            }
             let token = headers
                 .get("authorization")
                 .and_then(|v| v.to_str().ok())
@@ -265,10 +268,15 @@ fn check_auth(state: &A2aState, headers: &axum::http::HeaderMap) -> Option<Strin
 
             match token {
                 None => Some("unauthorized: missing Bearer token".into()),
-                Some(t) => match crate::app::a2a_jwt::verify_jwt(t, public_key) {
-                    Ok(_claims) => None,
-                    Err(e) => Some(format!("unauthorized: invalid JWT — {e}")),
-                },
+                Some(t) => {
+                    // Try each trusted key — accept if any matches.
+                    for key in &state.trusted_keys {
+                        if crate::app::a2a_jwt::verify_jwt(t, key).is_ok() {
+                            return None;
+                        }
+                    }
+                    Some("unauthorized: JWT signature does not match any trusted key".into())
+                }
             }
         }
         _ => {
@@ -325,7 +333,7 @@ mod tests {
             } else {
                 "none".into()
             },
-            jwt_public_key: None,
+            trusted_keys: vec![],
         })
     }
 
@@ -419,8 +427,11 @@ mod tests {
         );
     }
 
+    /// Create a JWT-authenticated server state with a *sender* key pair.
+    /// The server trusts the sender's public key. The sender signs with its private key.
+    /// This mirrors real usage: sender and server have *different* identities.
     fn make_jwt_state() -> (Arc<A2aState>, crate::app::a2a_jwt::KeyPair) {
-        let kp = crate::app::a2a_jwt::KeyPair::generate().unwrap();
+        let sender_kp = crate::app::a2a_jwt::KeyPair::generate().unwrap();
         let state = Arc::new(A2aState {
             agent_card: crate::app::a2a::AgentCard {
                 name: "test".into(),
@@ -441,9 +452,9 @@ mod tests {
             api_key: None,
             bus_socket: "/tmp/test.sock".into(),
             auth_mode: "jwt".into(),
-            jwt_public_key: Some(kp.public_key_bytes().to_vec()),
+            trusted_keys: vec![sender_kp.public_key_bytes().to_vec()],
         });
-        (state, kp)
+        (state, sender_kp)
     }
 
     #[tokio::test]

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -468,4 +468,6 @@ pub enum A2aAction {
         #[arg(long)]
         listen: Option<String>,
     },
+    /// Generate an Ed25519 key pair for JWT authentication.
+    Keygen {},
 }

--- a/src/app/commands/a2a.rs
+++ b/src/app/commands/a2a.rs
@@ -40,25 +40,36 @@ pub async fn handle(action: A2aAction, config_path: &str) -> Result<()> {
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("workspace.yaml has no `a2a:` section"))?;
 
-            // Load JWT key pair if auth mode is JWT.
-            let (jwt_public_key, mut card) = if a2a_cfg.auth == "jwt" {
+            let mut card = a2a::build_agent_card(&workspace)?;
+
+            // Load own key pair for JWKS publication if JWT mode.
+            if a2a_cfg.auth == "jwt" {
                 let key_path = a2a_cfg
                     .private_key
                     .as_deref()
                     .map(std::path::PathBuf::from)
                     .unwrap_or_else(default_key_path);
                 let kp = a2a_jwt::KeyPair::load(&key_path)?;
-                let jwks = a2a_jwt::Jwks::from_public_key(kp.public_key_bytes());
-                let pub_bytes = kp.public_key_bytes().to_vec();
-                let card = a2a::build_agent_card(&workspace)?;
-                (Some((pub_bytes, jwks)), card)
-            } else {
-                (None, a2a::build_agent_card(&workspace)?)
-            };
+                card.authentication.jwks =
+                    Some(a2a_jwt::Jwks::from_public_key(kp.public_key_bytes()));
+            }
 
-            // Inject JWKS into the Agent Card if using JWT.
-            if let Some((_, ref jwks)) = jwt_public_key {
-                card.authentication.jwks = Some(jwks.clone());
+            // Decode trusted public keys from config (base64url → raw bytes).
+            let trusted_keys: Vec<Vec<u8>> = a2a_cfg
+                .trusted_keys
+                .iter()
+                .filter_map(|b64| {
+                    use base64::Engine;
+                    base64::engine::general_purpose::URL_SAFE_NO_PAD
+                        .decode(b64)
+                        .ok()
+                })
+                .collect();
+
+            if a2a_cfg.auth == "jwt" && trusted_keys.is_empty() {
+                tracing::warn!(
+                    "JWT auth enabled but no trusted_keys configured — all incoming requests will be rejected"
+                );
             }
 
             let listen_addr = listen.as_deref().unwrap_or(&a2a_cfg.listen);
@@ -74,7 +85,7 @@ pub async fn handle(action: A2aAction, config_path: &str) -> Result<()> {
                 api_key: a2a_cfg.api_key.clone(),
                 bus_socket,
                 auth_mode: a2a_cfg.auth.clone(),
-                jwt_public_key: jwt_public_key.map(|(bytes, _)| bytes),
+                trusted_keys,
             });
 
             a2a_server::serve(listen_addr, state).await

--- a/src/app/commands/a2a.rs
+++ b/src/app/commands/a2a.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use crate::app::cli::A2aAction;
-use crate::app::{a2a, a2a_server};
+use crate::app::{a2a, a2a_jwt, a2a_server};
 use crate::config::WorkspaceConfig;
 
 pub async fn handle(action: A2aAction, config_path: &str) -> Result<()> {
@@ -17,13 +17,49 @@ pub async fn handle(action: A2aAction, config_path: &str) -> Result<()> {
             println!("{json}");
             Ok(())
         }
+        A2aAction::Keygen {} => {
+            let key_path = default_key_path();
+            if key_path.exists() {
+                anyhow::bail!(
+                    "Key already exists at {}. Remove it first to regenerate.",
+                    key_path.display()
+                );
+            }
+            let kp = a2a_jwt::KeyPair::generate()?;
+            kp.save(&key_path)?;
+            println!("Generated Ed25519 key pair:");
+            println!("  Private: {}", key_path.display());
+            println!("  Public:  {}", key_path.with_extension("pub").display());
+            println!("  Base64:  {}", kp.public_key_base64url());
+            Ok(())
+        }
         A2aAction::Serve { listen, .. } => {
             let workspace = WorkspaceConfig::load(config_path)?;
-            let card = a2a::build_agent_card(&workspace)?;
             let a2a_cfg = workspace
                 .a2a
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("workspace.yaml has no `a2a:` section"))?;
+
+            // Load JWT key pair if auth mode is JWT.
+            let (jwt_public_key, mut card) = if a2a_cfg.auth == "jwt" {
+                let key_path = a2a_cfg
+                    .private_key
+                    .as_deref()
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(default_key_path);
+                let kp = a2a_jwt::KeyPair::load(&key_path)?;
+                let jwks = a2a_jwt::Jwks::from_public_key(kp.public_key_bytes());
+                let pub_bytes = kp.public_key_bytes().to_vec();
+                let card = a2a::build_agent_card(&workspace)?;
+                (Some((pub_bytes, jwks)), card)
+            } else {
+                (None, a2a::build_agent_card(&workspace)?)
+            };
+
+            // Inject JWKS into the Agent Card if using JWT.
+            if let Some((_, ref jwks)) = jwt_public_key {
+                card.authentication.jwks = Some(jwks.clone());
+            }
 
             let listen_addr = listen.as_deref().unwrap_or(&a2a_cfg.listen);
 
@@ -37,9 +73,18 @@ pub async fn handle(action: A2aAction, config_path: &str) -> Result<()> {
                 agent_card: card,
                 api_key: a2a_cfg.api_key.clone(),
                 bus_socket,
+                auth_mode: a2a_cfg.auth.clone(),
+                jwt_public_key: jwt_public_key.map(|(bytes, _)| bytes),
             });
 
             a2a_server::serve(listen_addr, state).await
         }
     }
+}
+
+fn default_key_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home)
+        .join(".deskd")
+        .join("a2a_key.pem")
 }

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -119,6 +119,7 @@ mod tests {
             },
             label: "System prompt".into(),
             tokens_estimate: 500,
+            tags: Vec::new(),
         });
         branch.nodes.push(Node {
             id: "n2".into(),
@@ -128,6 +129,7 @@ mod tests {
             },
             label: "Governance".into(),
             tokens_estimate: 1200,
+            tags: Vec::new(),
         });
         assert_eq!(branch.total_tokens(), 1700);
     }
@@ -146,6 +148,7 @@ mod tests {
             },
             label: "Greeting".into(),
             tokens_estimate: 100,
+            tags: Vec::new(),
         });
         branch.nodes.push(Node {
             id: "l1".into(),
@@ -158,6 +161,7 @@ mod tests {
             },
             label: "Echo test".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         let repo = crate::app::context::new_context_store();
@@ -214,6 +218,7 @@ mod tests {
             },
             label: "System".into(),
             tokens_estimate: 100,
+            tags: Vec::new(),
         });
         branch.nodes.push(Node {
             id: "s2".into(),
@@ -223,6 +228,7 @@ mod tests {
             },
             label: "Context".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         let messages = branch.materialize().await.expect("materialize failed");
@@ -247,6 +253,7 @@ mod tests {
             },
             label: "Echo test".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         let messages = branch.materialize().await.expect("materialize failed");
@@ -269,6 +276,7 @@ mod tests {
             },
             label: "Cached echo".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         // First materialize — executes command
@@ -316,6 +324,7 @@ mod tests {
             },
             label: "Expiry test".into(),
             tokens_estimate: 50,
+            tags: Vec::new(),
         });
 
         let messages = branch.materialize().await.expect("materialize failed");
@@ -338,6 +347,7 @@ mod tests {
             },
             label: "Silent".into(),
             tokens_estimate: 10,
+            tags: Vec::new(),
         });
 
         let messages = branch.materialize().await.expect("materialize failed");

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -757,9 +757,40 @@ pub(crate) async fn call_usage_stats(args: &Value) -> Result<Value> {
     Ok(serde_json::to_value(stats)?)
 }
 
+/// Apply authentication to an outgoing A2A HTTP request.
+///
+/// Supports two modes:
+/// - `api_key` param → `x-api-key` header
+/// - `jwt_key` param (path to private key PEM) → `Authorization: Bearer <jwt>`
+fn apply_a2a_auth(
+    mut req: reqwest::RequestBuilder,
+    args: &serde_json::Value,
+    url: &str,
+) -> reqwest::RequestBuilder {
+    if let Some(jwt_key_path) = args.get("jwt_key").and_then(|v| v.as_str()) {
+        let path = std::path::Path::new(jwt_key_path);
+        match crate::app::a2a_jwt::KeyPair::load(path) {
+            Ok(kp) => match kp.sign_jwt(url, 60) {
+                Ok(token) => {
+                    req = req.header("authorization", format!("Bearer {}", token));
+                }
+                Err(e) => {
+                    tracing::warn!("failed to sign JWT: {}", e);
+                }
+            },
+            Err(e) => {
+                tracing::warn!("failed to load JWT key from {}: {}", jwt_key_path, e);
+            }
+        }
+    } else if let Some(key) = args.get("api_key").and_then(|v| v.as_str()) {
+        req = req.header("x-api-key", key);
+    }
+    req
+}
+
 /// Send an A2A task to a remote agent via HTTP.
 ///
-/// MCP tool: `a2a_send(url, skill, message, api_key?)`
+/// MCP tool: `a2a_send(url, skill, message, api_key?, jwt_key?)`
 pub(crate) async fn call_a2a_send(args: &Value) -> Result<Value> {
     let url = args
         .get("url")
@@ -773,7 +804,6 @@ pub(crate) async fn call_a2a_send(args: &Value) -> Result<Value> {
         .get("message")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow::anyhow!("missing 'message' parameter"))?;
-    let api_key = args.get("api_key").and_then(|v| v.as_str());
 
     let rpc_body = json!({
         "jsonrpc": "2.0",
@@ -789,9 +819,7 @@ pub(crate) async fn call_a2a_send(args: &Value) -> Result<Value> {
 
     let client = reqwest::Client::new();
     let mut req = client.post(&a2a_url).json(&rpc_body);
-    if let Some(key) = api_key {
-        req = req.header("x-api-key", key);
-    }
+    req = apply_a2a_auth(req, args, url);
 
     let resp = req.send().await.context("A2A request failed")?;
 
@@ -983,7 +1011,6 @@ pub(crate) async fn call_propose_for_need(args: &Value) -> Result<Value> {
         .get("proposal")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow::anyhow!("missing 'proposal' parameter"))?;
-    let api_key = args.get("api_key").and_then(|v| v.as_str());
 
     let rpc_body = json!({
         "jsonrpc": "2.0",
@@ -1003,9 +1030,7 @@ pub(crate) async fn call_propose_for_need(args: &Value) -> Result<Value> {
 
     let client = reqwest::Client::new();
     let mut req = client.post(&a2a_url).json(&rpc_body);
-    if let Some(key) = api_key {
-        req = req.header("x-api-key", key);
-    }
+    req = apply_a2a_auth(req, args, url);
 
     let resp = req.send().await.context("A2A proposal request failed")?;
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,7 @@
 //! (domain types and port traits). Reduces lib.rs fan-out.
 
 pub mod a2a;
+pub mod a2a_jwt;
 pub mod a2a_server;
 pub mod acp;
 pub mod adapters;

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -220,20 +220,24 @@ pub async fn run(
 
     // Memory agent: cumulative token estimate for compaction trigger.
     let mut memory_tokens_estimate: u64 = 0;
-    // Compaction threshold in tokens. Derive from compact_threshold (fraction 0.0–1.0)
-    // applied to a default context budget of 100_000 tokens (conservative for most models).
-    let compact_threshold_tokens: u64 = if agent_runtime == AgentRuntime::Memory {
-        let fraction = initial_state.config.compact_threshold.unwrap_or(0.8);
-        let context_budget: u64 = initial_state
+
+    // Cumulative session input tokens — tracks actual token usage from Claude responses.
+    // Used to trigger compaction for all agent types (not just memory agents).
+    let mut session_input_tokens: u64 = 0;
+
+    // Compaction threshold in tokens. Derive from context config or compact_threshold
+    // fraction applied to a default context budget of 100_000 tokens.
+    let compact_threshold_tokens: u64 = {
+        let from_config = initial_state
             .config
             .context
             .as_ref()
             .and_then(|c| c.compact_threshold_tokens)
-            .map(|t| t as u64)
-            .unwrap_or((100_000f64 * fraction) as u64);
-        context_budget
-    } else {
-        0
+            .map(|t| t as u64);
+        from_config.unwrap_or_else(|| {
+            let fraction = initial_state.config.compact_threshold.unwrap_or(0.8);
+            (100_000f64 * fraction) as u64
+        })
     };
 
     loop {
@@ -596,6 +600,9 @@ pub async fn run(
 
         match result {
             Ok(ref turn) => {
+                // Track cumulative session input tokens for compaction trigger.
+                session_input_tokens += turn.token_usage.input_tokens;
+
                 handle_task_success(
                     name,
                     &msg,
@@ -610,6 +617,51 @@ pub async fn run(
                     task_store,
                 )
                 .await;
+
+                // Check compaction trigger for all agent types.
+                // Memory agents have their own injection-based trigger above;
+                // this covers regular agents hitting context limits from tasks.
+                if agent_runtime != AgentRuntime::Memory
+                    && crate::domain::context::should_compact(
+                        session_input_tokens,
+                        compact_threshold_tokens,
+                    )
+                {
+                    info!(
+                        agent = %name,
+                        session_input_tokens = session_input_tokens,
+                        threshold = compact_threshold_tokens,
+                        "session compaction triggered — requesting context condensation"
+                    );
+                    let compact_prompt = "Your context is approaching capacity. \
+                        Summarize everything important from this session: decisions made, \
+                        current state of work, errors encountered, and next steps. \
+                        Be thorough but concise — this summary will be your working memory.";
+                    let compact_limits = agent::TaskLimits {
+                        max_turns: Some(3),
+                        budget_usd: Some(budget_usd),
+                    };
+                    match process
+                        .send_task(compact_prompt, None, None, &compact_limits)
+                        .await
+                    {
+                        Ok(compact_turn) => {
+                            info!(
+                                agent = %name,
+                                cost = compact_turn.cost_usd,
+                                output_tokens = compact_turn.token_usage.output_tokens,
+                                "session compaction completed"
+                            );
+                            // Reset — the session now has condensed history.
+                            session_input_tokens = 0;
+                        }
+                        Err(e) => {
+                            warn!(agent = %name, error = %e, "session compaction failed");
+                            // Halve to avoid re-triggering immediately.
+                            session_input_tokens /= 2;
+                        }
+                    }
+                }
             }
             Err(ref e) => {
                 let needs_restart =

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,10 +68,21 @@ pub struct A2aConfig {
     /// Instance-level description shown in the Agent Card.
     #[serde(default)]
     pub description: Option<String>,
+    /// Authentication mode: "api_key" (default), "jwt", or "none".
+    #[serde(default = "default_a2a_auth")]
+    pub auth: String,
+    /// Path to Ed25519 private key PEM for JWT signing.
+    /// Default: ~/.deskd/a2a_key.pem
+    #[serde(default)]
+    pub private_key: Option<String>,
 }
 
 fn default_a2a_listen() -> String {
     "0.0.0.0:3000".to_string()
+}
+
+fn default_a2a_auth() -> String {
+    "api_key".to_string()
 }
 
 /// A room is a named work context: namespace + context folder + set of agents.

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,10 @@ pub struct A2aConfig {
     /// Default: ~/.deskd/a2a_key.pem
     #[serde(default)]
     pub private_key: Option<String>,
+    /// Trusted public keys for JWT verification (base64url-encoded Ed25519 keys).
+    /// Incoming JWTs are verified against these keys. Add remote agents' public keys here.
+    #[serde(default)]
+    pub trusted_keys: Vec<String>,
 }
 
 fn default_a2a_listen() -> String {

--- a/src/domain/context.rs
+++ b/src/domain/context.rs
@@ -31,6 +31,7 @@ pub struct Node {
     pub kind: NodeKind,
     pub label: String,        // human-readable description
     pub tokens_estimate: u32, // approximate token count
+    pub tags: Vec<String>,    // topic tags for partitioning (#299)
 }
 
 /// The main branch — persistent context for an agent
@@ -69,6 +70,80 @@ impl MainBranch {
     pub fn total_tokens(&self) -> u32 {
         self.nodes.iter().map(|n| n.tokens_estimate).sum()
     }
+
+    /// Add a static content node to the branch.
+    pub fn add_static(&mut self, id: &str, label: &str, role: &str, content: &str) {
+        let tokens_estimate = (content.len() as u32) / 4;
+        self.nodes.push(Node {
+            id: id.to_string(),
+            kind: NodeKind::Static {
+                role: role.to_string(),
+                content: content.to_string(),
+            },
+            label: label.to_string(),
+            tokens_estimate,
+            tags: Vec::new(),
+        });
+    }
+
+    /// Add a static content node with tags.
+    pub fn add_static_tagged(
+        &mut self,
+        id: &str,
+        label: &str,
+        role: &str,
+        content: &str,
+        tags: Vec<String>,
+    ) {
+        let tokens_estimate = (content.len() as u32) / 4;
+        self.nodes.push(Node {
+            id: id.to_string(),
+            kind: NodeKind::Static {
+                role: role.to_string(),
+                content: content.to_string(),
+            },
+            label: label.to_string(),
+            tokens_estimate,
+            tags,
+        });
+    }
+
+    /// Serialize all static nodes into a single system prompt string.
+    ///
+    /// Used for context transfer: when spawning a child agent, this
+    /// produces the prompt that carries the parent's context subset.
+    pub fn to_system_prompt(&self) -> String {
+        let mut sections = Vec::new();
+        for node in &self.nodes {
+            if let NodeKind::Static { content, .. } = &node.kind {
+                sections.push(format!("## {}\n{}", node.label, content));
+            }
+        }
+        sections.join("\n\n")
+    }
+
+    /// Partition nodes by tag groups, returning a new MainBranch per group.
+    ///
+    /// Each group is a set of tags. A node matches a group if it has any
+    /// overlapping tag. Untagged nodes are included in all partitions.
+    pub fn partition_by_tags(&self, groups: &[Vec<String>]) -> Vec<MainBranch> {
+        groups
+            .iter()
+            .enumerate()
+            .map(|(i, group_tags)| {
+                let matching_nodes: Vec<Node> = self
+                    .nodes
+                    .iter()
+                    .filter(|n| n.tags.is_empty() || n.tags.iter().any(|t| group_tags.contains(t)))
+                    .cloned()
+                    .collect();
+                let mut branch =
+                    MainBranch::new(&format!("{}-split-{}", self.agent, i), self.budget_tokens);
+                branch.nodes = matching_nodes;
+                branch
+            })
+            .collect()
+    }
 }
 
 /// Check if session should be compacted based on cumulative token usage
@@ -82,4 +157,109 @@ pub fn default_main_path(work_dir: &str) -> std::path::PathBuf {
         .join(".deskd")
         .join("context")
         .join("main.yaml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_static_node() {
+        let mut branch = MainBranch::new("test-agent", 10_000);
+        branch.add_static("n1", "System Role", "system", "You are a helpful agent.");
+        assert_eq!(branch.nodes.len(), 1);
+        assert_eq!(branch.nodes[0].id, "n1");
+        assert!(branch.nodes[0].tokens_estimate > 0);
+        assert!(branch.nodes[0].tags.is_empty());
+    }
+
+    #[test]
+    fn test_add_static_tagged() {
+        let mut branch = MainBranch::new("test-agent", 10_000);
+        branch.add_static_tagged(
+            "n1",
+            "Rust Context",
+            "system",
+            "Rust codebase info",
+            vec!["rust".into(), "code".into()],
+        );
+        assert_eq!(branch.nodes[0].tags, vec!["rust", "code"]);
+    }
+
+    #[test]
+    fn test_to_system_prompt() {
+        let mut branch = MainBranch::new("test-agent", 10_000);
+        branch.add_static("n1", "Role", "system", "You are helpful.");
+        branch.add_static("n2", "Context", "user", "Work on deskd.");
+        let prompt = branch.to_system_prompt();
+        assert!(prompt.contains("## Role\nYou are helpful."));
+        assert!(prompt.contains("## Context\nWork on deskd."));
+    }
+
+    #[test]
+    fn test_to_system_prompt_skips_live_nodes() {
+        let mut branch = MainBranch::new("test-agent", 10_000);
+        branch.add_static("n1", "Role", "system", "Be helpful.");
+        branch.nodes.push(Node {
+            id: "live1".into(),
+            kind: NodeKind::Live {
+                command: "echo".into(),
+                args: vec!["hello".into()],
+                max_age_secs: None,
+                inject_as: "user".into(),
+                cached_result: None,
+            },
+            label: "Live Node".into(),
+            tokens_estimate: 10,
+            tags: Vec::new(),
+        });
+        let prompt = branch.to_system_prompt();
+        assert!(prompt.contains("Be helpful."));
+        assert!(!prompt.contains("Live Node"));
+    }
+
+    #[test]
+    fn test_partition_by_tags() {
+        let mut branch = MainBranch::new("parent", 10_000);
+        branch.add_static_tagged("n1", "Rust", "system", "Rust code", vec!["rust".into()]);
+        branch.add_static_tagged("n2", "Go", "system", "Go code", vec!["go".into()]);
+        branch.add_static("n3", "Shared", "system", "Shared context"); // untagged
+
+        let partitions = branch.partition_by_tags(&[vec!["rust".into()], vec!["go".into()]]);
+
+        assert_eq!(partitions.len(), 2);
+
+        // Rust partition: n1 (rust) + n3 (untagged)
+        assert_eq!(partitions[0].nodes.len(), 2);
+        assert_eq!(partitions[0].agent, "parent-split-0");
+
+        // Go partition: n2 (go) + n3 (untagged)
+        assert_eq!(partitions[1].nodes.len(), 2);
+        assert_eq!(partitions[1].agent, "parent-split-1");
+    }
+
+    #[test]
+    fn test_partition_node_in_multiple_groups() {
+        let mut branch = MainBranch::new("agent", 5_000);
+        branch.add_static_tagged(
+            "n1",
+            "Both",
+            "system",
+            "Relevant to both",
+            vec!["rust".into(), "go".into()],
+        );
+
+        let partitions = branch.partition_by_tags(&[vec!["rust".into()], vec!["go".into()]]);
+
+        // Node with both tags appears in both partitions.
+        assert_eq!(partitions[0].nodes.len(), 1);
+        assert_eq!(partitions[1].nodes.len(), 1);
+    }
+
+    #[test]
+    fn test_token_estimate_from_content_length() {
+        let mut branch = MainBranch::new("agent", 10_000);
+        branch.add_static("n1", "Test", "system", "a]bc"); // 4 chars → 1 token
+        assert_eq!(branch.nodes[0].tokens_estimate, 1);
+    }
 }

--- a/src/infra/context_store.rs
+++ b/src/infra/context_store.rs
@@ -62,6 +62,7 @@ mod tests {
             },
             label: "Greeting".into(),
             tokens_estimate: 100,
+            tags: Vec::new(),
         });
 
         store.save(&branch, &path).expect("save failed");

--- a/src/infra/dto/context.rs
+++ b/src/infra/dto/context.rs
@@ -24,6 +24,8 @@ pub struct StoredNode {
     pub kind: StoredNodeKind,
     pub label: String,
     pub tokens_estimate: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 /// Storage format for node kinds.
@@ -84,6 +86,7 @@ impl From<StoredNode> for Node {
             kind: dto.kind.into(),
             label: dto.label,
             tokens_estimate: dto.tokens_estimate,
+            tags: dto.tags,
         }
     }
 }
@@ -95,6 +98,7 @@ impl From<&Node> for StoredNode {
             kind: (&n.kind).into(),
             label: n.label.clone(),
             tokens_estimate: n.tokens_estimate,
+            tags: n.tags.clone(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
             let config_path = match &action {
                 deskd::app::cli::A2aAction::AgentCard { config }
                 | deskd::app::cli::A2aAction::Serve { config, .. } => config.clone(),
+                deskd::app::cli::A2aAction::Keygen {} => None,
             };
             let config_path = resolve_workspace_config(config_path)?;
             commands::a2a::handle(action, &config_path).await?;


### PR DESCRIPTION
## Summary

Adds asymmetric JWT authentication for A2A protocol, replacing shared secrets with Ed25519 key pairs:

- **`deskd a2a keygen`** — generates Ed25519 key pair (`~/.deskd/a2a_key.pem` + `.pub`)
- **JWT signing** — outgoing requests signed with private key, 60s TTL
- **JWT verification** — incoming requests verified against sender's public key
- **JWKS in Agent Card** — public key published for discovery
- **Config**: `auth: jwt | api_key | none` in workspace.yaml `a2a:` section
- **Backward compatible** — default remains `api_key` mode

### Architecture

```
Sender                              Receiver
  │                                    │
  │ sign JWT with private key          │
  │ Authorization: Bearer <token>  ──► │ extract Bearer token
  │                                    │ verify against JWKS public key
  │                                    │ check expiry (60s TTL)
  │                                    │ ✓ proceed or ✗ 401
```

### Files changed

| File | Change |
|------|--------|
| `src/app/a2a_jwt.rs` | **New** — KeyPair, JWT sign/verify, JWKS, PEM helpers |
| `src/app/a2a_server.rs` | Multi-mode auth (api_key/jwt/none) |
| `src/app/a2a.rs` | JWKS field in AgentAuthentication, auth scheme from config |
| `src/app/commands/a2a.rs` | Keygen command, JWT key loading on serve |
| `src/app/mcp_tools.rs` | `apply_a2a_auth` helper (jwt_key or api_key) |
| `src/config.rs` | `auth` + `private_key` fields on A2aConfig |
| `src/app/cli.rs` | `Keygen` variant in A2aAction |

Closes #366

## Test plan

- [x] Key generation, save/load roundtrip
- [x] JWT sign + verify with correct key
- [x] JWT verification fails with wrong key
- [x] Expired token rejected
- [x] Base64url roundtrip for JWKS
- [x] Server: JWT auth valid/missing/wrong key
- [x] Server: API key auth still works
- [x] `cargo fmt + clippy + test` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)