### PR TITLE
feat: unified config hot-reload with graceful component restart

### DIFF
--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -1,0 +1,324 @@
+/// Unified config hot-reload — watches deskd.yaml and restarts all restartable
+/// components when the config changes.
+///
+/// Restartable components (aborted and respawned on config change):
+///   - Adapters (Telegram, Discord)
+///   - Schedule watcher
+///   - Reminder runner
+///   - Sub-agent workers
+///
+/// Session-persistent components (NOT restarted):
+///   - Bus server (transport layer)
+///   - Main worker (Claude session)
+///   - Bus API handler
+///   - Workflow engine
+///
+/// System prompt changes are still injected via bus message (existing pattern
+/// in config_watcher.rs) rather than restarting the worker.
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use crate::app::{adapters, config_watcher, schedule, worker};
+use crate::config;
+
+/// Holds all restartable component handles for a single agent.
+pub struct AgentComponents {
+    pub adapter_handles: Vec<JoinHandle<()>>,
+    pub schedule_watcher: Option<JoinHandle<()>>,
+    pub config_watcher: Option<JoinHandle<()>>,
+    pub reminder_runner: Option<JoinHandle<()>>,
+    pub sub_agent_handles: Vec<JoinHandle<()>>,
+}
+
+impl AgentComponents {
+    /// Abort all restartable components.
+    pub fn abort_all(&mut self) {
+        for h in self.adapter_handles.drain(..) {
+            h.abort();
+        }
+        if let Some(h) = self.schedule_watcher.take() {
+            h.abort();
+        }
+        if let Some(h) = self.config_watcher.take() {
+            h.abort();
+        }
+        if let Some(h) = self.reminder_runner.take() {
+            h.abort();
+        }
+        for h in self.sub_agent_handles.drain(..) {
+            h.abort();
+        }
+    }
+
+    /// Return a summary string of component counts.
+    pub fn summary(&self) -> String {
+        format!(
+            "adapters={}, schedules={}, sub_agents={}",
+            self.adapter_handles.len(),
+            if self.schedule_watcher.is_some() {
+                1
+            } else {
+                0
+            },
+            self.sub_agent_handles.len(),
+        )
+    }
+}
+
+/// Spawn all restartable components for an agent and return their handles.
+pub async fn spawn_components(
+    def: &config::AgentDef,
+    user_cfg: Option<&config::UserConfig>,
+    admin_telegram_ids: &[i64],
+    bus_socket: &str,
+    agent_name: &str,
+    cfg_path: &str,
+) -> anyhow::Result<AgentComponents> {
+    let mut components = AgentComponents {
+        adapter_handles: Vec::new(),
+        schedule_watcher: None,
+        config_watcher: None,
+        reminder_runner: None,
+        sub_agent_handles: Vec::new(),
+    };
+
+    // Adapters (Telegram, Discord, etc.)
+    for adapter in adapters::build_adapters(def, user_cfg, admin_telegram_ids) {
+        let bus = bus_socket.to_string();
+        let name = agent_name.to_string();
+        let adapter_name = adapter.name().to_string();
+        let handle = tokio::spawn(async move {
+            if let Err(e) = adapter.run(bus, name).await {
+                tracing::error!(adapter = %adapter_name, error = %e, "adapter failed");
+            }
+        });
+        components.adapter_handles.push(handle);
+    }
+
+    // Schedule watcher
+    {
+        let bus = bus_socket.to_string();
+        let name = agent_name.to_string();
+        let config = cfg_path.to_string();
+        let home = def.work_dir.clone();
+        let handle = tokio::spawn(async move {
+            schedule::watch_and_reload(config, bus, name, home).await;
+        });
+        components.schedule_watcher = Some(handle);
+    }
+
+    // Config watcher (system_prompt injection)
+    {
+        let bus = bus_socket.to_string();
+        let name = agent_name.to_string();
+        let config = cfg_path.to_string();
+        let handle = tokio::spawn(async move {
+            config_watcher::watch_system_prompt(config, bus, name).await;
+        });
+        components.config_watcher = Some(handle);
+    }
+
+    // Reminder runner
+    {
+        let bus = bus_socket.to_string();
+        let name = agent_name.to_string();
+        let handle = tokio::spawn(async move {
+            schedule::run_reminders(bus, name).await;
+        });
+        components.reminder_runner = Some(handle);
+    }
+
+    // Sub-agent workers
+    if let Some(ucfg) = user_cfg {
+        for sub in &ucfg.agents {
+            let mcp_json = serde_json::json!({
+                "mcpServers": {
+                    "deskd": {
+                        "command": "deskd",
+                        "args": ["mcp", "--agent", &sub.name]
+                    }
+                }
+            })
+            .to_string();
+
+            let context_cfg = sub.context.clone().or_else(|| ucfg.context.clone());
+
+            let sub_cfg = crate::app::agent::AgentConfig {
+                name: sub.name.clone(),
+                model: sub.model.clone(),
+                system_prompt: sub.system_prompt.clone(),
+                work_dir: def.work_dir.clone(),
+                max_turns: ucfg.max_turns,
+                unix_user: def.unix_user.clone(),
+                budget_usd: def.budget_usd,
+                command: vec![
+                    "claude".into(),
+                    "--output-format".into(),
+                    "stream-json".into(),
+                    "--verbose".into(),
+                    "--dangerously-skip-permissions".into(),
+                    "--model".into(),
+                    sub.model.clone(),
+                    "--max-turns".into(),
+                    ucfg.max_turns.to_string(),
+                    "--mcp-config".into(),
+                    mcp_json,
+                ],
+                config_path: Some(cfg_path.to_string()),
+                container: def.container.clone(),
+                session: sub.session.clone(),
+                runtime: sub.runtime.clone(),
+                context: context_cfg,
+                compact_threshold: sub.compact_threshold,
+            };
+            crate::app::agent::create_or_update_from_config(&sub_cfg).await?;
+
+            let sub_name = sub.name.clone();
+            let bus = bus_socket.to_string();
+            let subs = sub.subscribe.clone();
+            let sub_task_store = crate::app::task::TaskStore::default_for_home();
+            let handle = tokio::spawn(async move {
+                if let Err(e) = worker::run(
+                    &sub_name,
+                    &bus,
+                    Some(bus.clone()),
+                    Some(subs),
+                    &sub_task_store,
+                )
+                .await
+                {
+                    tracing::error!(agent = %sub_name, error = %e, "sub-agent worker exited");
+                }
+            });
+            components.sub_agent_handles.push(handle);
+        }
+    }
+
+    Ok(components)
+}
+
+/// Watch the agent's deskd.yaml for changes and hot-reload all restartable components.
+///
+/// Polls the file mtime every 30 seconds. On change, aborts all restartable
+/// components, reloads config, and respawns them. Bus server, main worker,
+/// bus API, and workflow engine are NOT affected.
+pub async fn watch_and_reload(
+    def: config::AgentDef,
+    initial_components: AgentComponents,
+    admin_telegram_ids: Vec<i64>,
+    bus_socket: String,
+    agent_name: String,
+    cfg_path: String,
+) {
+    let mut components = initial_components;
+    let mut last_modified = file_mtime(&cfg_path);
+
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+
+        let current_mtime = file_mtime(&cfg_path);
+        if current_mtime == last_modified {
+            continue;
+        }
+        last_modified = current_mtime;
+
+        info!(agent = %agent_name, "config file changed, reloading all restartable components");
+
+        // Abort all running restartable components.
+        let old_summary = components.summary();
+        components.abort_all();
+        info!(agent = %agent_name, old = %old_summary, "aborted old components");
+
+        // Reload config.
+        let user_cfg = match config::UserConfig::load(&cfg_path) {
+            Ok(cfg) => Some(cfg),
+            Err(e) => {
+                warn!(
+                    agent = %agent_name,
+                    error = %e,
+                    "failed to reload config, components stopped"
+                );
+                continue;
+            }
+        };
+
+        // Respawn all restartable components.
+        match spawn_components(
+            &def,
+            user_cfg.as_ref(),
+            &admin_telegram_ids,
+            &bus_socket,
+            &agent_name,
+            &cfg_path,
+        )
+        .await
+        {
+            Ok(new_components) => {
+                let summary = new_components.summary();
+                components = new_components;
+                info!(
+                    agent = %agent_name,
+                    summary = %summary,
+                    "config reloaded: {}", summary
+                );
+            }
+            Err(e) => {
+                warn!(
+                    agent = %agent_name,
+                    error = %e,
+                    "failed to respawn components after config reload"
+                );
+            }
+        }
+    }
+}
+
+fn file_mtime(path: &str) -> Option<std::time::SystemTime> {
+    std::fs::metadata(path).ok().and_then(|m| m.modified().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_components_summary() {
+        let components = AgentComponents {
+            adapter_handles: Vec::new(),
+            schedule_watcher: None,
+            config_watcher: None,
+            reminder_runner: None,
+            sub_agent_handles: Vec::new(),
+        };
+        assert_eq!(
+            components.summary(),
+            "adapters=0, schedules=0, sub_agents=0"
+        );
+    }
+
+    #[test]
+    fn test_agent_components_abort_all_empty() {
+        let mut components = AgentComponents {
+            adapter_handles: Vec::new(),
+            schedule_watcher: None,
+            config_watcher: None,
+            reminder_runner: None,
+            sub_agent_handles: Vec::new(),
+        };
+        // Should not panic on empty components.
+        components.abort_all();
+        assert!(components.adapter_handles.is_empty());
+        assert!(components.schedule_watcher.is_none());
+        assert!(components.sub_agent_handles.is_empty());
+    }
+
+    #[test]
+    fn test_file_mtime_missing() {
+        assert!(file_mtime("/tmp/nonexistent-deskd-config-reload-test").is_none());
+    }
+
+    #[test]
+    fn test_file_mtime_existing() {
+        assert!(file_mtime("Cargo.toml").is_some());
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,6 +15,7 @@ pub mod bus;
 pub mod bus_api;
 pub mod cli;
 pub mod commands;
+pub mod config_reload;
 pub mod config_watcher;
 pub mod context;
 pub mod graph;

--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use tracing::info;
 
-use crate::app::{adapters, agent, bus, bus_api, config_watcher, schedule, worker, workflow};
+use crate::app::{agent, bus, bus_api, config_reload, worker, workflow};
 use crate::config;
 
 /// Start per-agent buses and workers for all agents in workspace config.
@@ -57,6 +57,8 @@ pub async fn serve(config_path: String) -> Result<()> {
         let bus_dir = std::path::Path::new(&def.work_dir).join(".deskd");
         config::ensure_dir_owned(&bus_dir, def.unix_user.as_deref())?;
 
+        // ── Session-persistent components (NOT restarted on config change) ──
+
         // Start the agent's isolated bus.
         {
             let bus = bus_socket.clone();
@@ -68,53 +70,6 @@ pub async fn serve(config_path: String) -> Result<()> {
             });
         }
         info!(agent = %name, bus = %bus_socket, "started agent bus");
-
-        // Start configured adapters (Telegram, Discord, etc.).
-        for adapter in
-            adapters::build_adapters(def, user_cfg.as_ref(), &workspace.admin_telegram_ids)
-        {
-            let bus = bus_socket.clone();
-            let agent_name = name.clone();
-            let adapter_name = adapter.name().to_string();
-            tokio::spawn(async move {
-                if let Err(e) = adapter.run(bus, agent_name).await {
-                    tracing::error!(adapter = %adapter_name, error = %e, "adapter failed");
-                }
-            });
-        }
-
-        // Start schedule watcher — handles initial load + hot-reload on config changes.
-        {
-            let bus = bus_socket.clone();
-            let agent_name = name.clone();
-            let config = cfg_path.clone();
-            let home = def.work_dir.clone();
-            tokio::spawn(async move {
-                schedule::watch_and_reload(config, bus, agent_name, home).await;
-            });
-            info!(agent = %name, "started schedule watcher");
-        }
-
-        // Start config watcher — hot-reloads system_prompt on deskd.yaml changes.
-        {
-            let bus = bus_socket.clone();
-            let agent_name = name.clone();
-            let config = cfg_path.clone();
-            tokio::spawn(async move {
-                config_watcher::watch_system_prompt(config, bus, agent_name).await;
-            });
-            info!(agent = %name, "started config watcher");
-        }
-
-        // Start reminder runner — fires one-shot reminders from ~/.deskd/reminders/.
-        {
-            let bus = bus_socket.clone();
-            let agent_name = name.clone();
-            tokio::spawn(async move {
-                schedule::run_reminders(bus, agent_name).await;
-            });
-            info!(agent = %name, "started reminder runner");
-        }
 
         // Start bus API handler for TUI / external clients.
         {
@@ -140,81 +95,23 @@ pub async fn serve(config_path: String) -> Result<()> {
         }
 
         // Start worker on the agent's bus.
-        let bus = bus_socket.clone();
-        let worker_task_store = crate::app::task::TaskStore::default_for_home();
-        tokio::spawn(async move {
-            if let Err(e) =
-                worker::run(&name, &bus, Some(bus.clone()), None, &worker_task_store).await
-            {
-                tracing::error!(agent = %name, error = %e, "worker exited with error");
-            }
-        });
-
-        // Start sub-agent workers defined in the agent's deskd.yaml.
-        if let Some(ref ucfg) = user_cfg {
-            for sub in &ucfg.agents {
-                let mcp_json = serde_json::json!({
-                    "mcpServers": {
-                        "deskd": {
-                            "command": "deskd",
-                            "args": ["mcp", "--agent", &sub.name]
-                        }
-                    }
-                })
-                .to_string();
-
-                // Per-agent context config falls back to global UserConfig.context.
-                let context_cfg = sub.context.clone().or_else(|| ucfg.context.clone());
-
-                let sub_cfg = agent::AgentConfig {
-                    name: sub.name.clone(),
-                    model: sub.model.clone(),
-                    system_prompt: sub.system_prompt.clone(),
-                    work_dir: def.work_dir.clone(),
-                    max_turns: ucfg.max_turns,
-                    unix_user: def.unix_user.clone(),
-                    budget_usd: def.budget_usd,
-                    command: vec![
-                        "claude".into(),
-                        "--output-format".into(),
-                        "stream-json".into(),
-                        "--verbose".into(),
-                        "--dangerously-skip-permissions".into(),
-                        "--model".into(),
-                        sub.model.clone(),
-                        "--max-turns".into(),
-                        ucfg.max_turns.to_string(),
-                        "--mcp-config".into(),
-                        mcp_json,
-                    ],
-                    config_path: Some(cfg_path.clone()),
-                    container: def.container.clone(),
-                    session: sub.session.clone(),
-                    runtime: sub.runtime.clone(),
-                    context: context_cfg,
-                    compact_threshold: sub.compact_threshold,
-                };
-                agent::create_or_update_from_config(&sub_cfg).await?;
-
-                let sub_name = sub.name.clone();
-                let bus = bus_socket.clone();
-                let subs = sub.subscribe.clone();
-                let sub_task_store = crate::app::task::TaskStore::default_for_home();
-                tokio::spawn(async move {
-                    if let Err(e) = worker::run(
-                        &sub_name,
-                        &bus,
-                        Some(bus.clone()),
-                        Some(subs),
-                        &sub_task_store,
-                    )
-                    .await
-                    {
-                        tracing::error!(agent = %sub_name, error = %e, "sub-agent worker exited");
-                    }
-                });
-                info!(agent = %def.name, sub_agent = %sub.name, "started sub-agent worker");
-            }
+        {
+            let bus = bus_socket.clone();
+            let worker_name = name.clone();
+            let worker_task_store = crate::app::task::TaskStore::default_for_home();
+            tokio::spawn(async move {
+                if let Err(e) = worker::run(
+                    &worker_name,
+                    &bus,
+                    Some(bus.clone()),
+                    None,
+                    &worker_task_store,
+                )
+                .await
+                {
+                    tracing::error!(agent = %worker_name, error = %e, "worker exited with error");
+                }
+            });
         }
 
         // Start workflow engine if models are defined.
@@ -267,6 +164,43 @@ pub async fn serve(config_path: String) -> Result<()> {
                 }
             });
             info!(agent = %def.name, models = ucfg.models.len(), "started workflow engine");
+        }
+
+        // ── Restartable components (hot-reloaded on config change) ───────
+
+        // Spawn initial restartable components.
+        let components = config_reload::spawn_components(
+            def,
+            user_cfg.as_ref(),
+            &workspace.admin_telegram_ids,
+            &bus_socket,
+            &name,
+            &cfg_path,
+        )
+        .await?;
+
+        let initial_summary = components.summary();
+        info!(agent = %name, summary = %initial_summary, "started restartable components");
+
+        // Start the unified config reload watcher.
+        {
+            let reload_def = def.clone();
+            let reload_admin_ids = workspace.admin_telegram_ids.clone();
+            let reload_bus = bus_socket.clone();
+            let reload_name = name.clone();
+            let reload_cfg = cfg_path.clone();
+            tokio::spawn(async move {
+                config_reload::watch_and_reload(
+                    reload_def,
+                    components,
+                    reload_admin_ids,
+                    reload_bus,
+                    reload_name,
+                    reload_cfg,
+                )
+                .await;
+            });
+            info!(agent = %name, "started unified config reload watcher");
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds unified config hot-reload that watches `deskd.yaml` mtime every 30s and gracefully restarts all restartable components on change
- New `AgentComponents` struct in `src/app/config_reload.rs` tracks JoinHandles for adapters, schedule watcher, config watcher, reminder runner, and sub-agents
- Session-persistent components (bus server, main worker, bus API, workflow engine) are NOT restarted -- they survive config changes
- Logs a summary on each reload: `config reloaded: adapters=N, schedules=N, sub_agents=N`

Closes #373

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 62 tests)
- [ ] Manual test: modify `deskd.yaml` while `deskd serve` is running, verify components restart and log summary
- [ ] Manual test: verify bus server and main worker stay alive across config reload
- [ ] Manual test: add/remove a Telegram route in config, verify adapter picks up the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)