### PR TITLE
[DRAFT] Add Telegram MTProto history skeleton (refs #376)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +273,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -259,6 +285,15 @@ checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -308,6 +343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +392,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -510,6 +565,8 @@ dependencies = [
  "cron",
  "futures",
  "grammers-client",
+ "grammers-mtsender",
+ "grammers-session",
  "jsonwebtoken",
  "openssl",
  "reqwest 0.12.28",
@@ -821,6 +878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "grammers-client"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +962,7 @@ checksum = "e5ad9fe6e7acc0eaf653460233fce428bcdcd0f5648768bd8941145a430b84bb"
 dependencies = [
  "futures-core",
  "grammers-tl-types",
+ "libsql",
  "log",
  "tokio",
 ]
@@ -984,6 +1048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1397,6 +1470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1486,63 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libsql"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
+dependencies = [
+ "async-trait",
+ "bitflags 2.11.0",
+ "bytes",
+ "futures",
+ "libsql-sys",
+ "parking_lot",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "libsql-ffi"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "glob",
+]
+
+[[package]]
+name = "libsql-sys"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
+dependencies = [
+ "bytes",
+ "libsql-ffi",
+ "once_cell",
+ "tracing",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1876,6 +2012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,7 +2104,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.47",
 ]
 
 [[package]]
@@ -2019,7 +2161,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls 0.23.38",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -2039,7 +2181,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
@@ -2168,6 +2310,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,6 +2439,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -2300,6 +2460,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2307,7 +2480,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2869,7 +3042,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3492,6 +3665,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,11 +4034,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.47",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +295,16 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -395,6 +425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +509,7 @@ dependencies = [
  "clap",
  "cron",
  "futures",
+ "grammers-client",
  "jsonwebtoken",
  "openssl",
  "reqwest 0.12.28",
@@ -495,6 +535,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
 ]
 
 [[package]]
@@ -750,8 +801,134 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "glass_pumpkin"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09b0eef9941bda7cc263c23c3977d437a9aa19abb6a58ed0234d145d9c024bc"
+dependencies = [
+ "getrandom 0.4.2",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "grammers-client"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3237b0c5916c97477e0ef16154b1f2e759b252e1a399cd718abd9466fe9de107"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "grammers-crypto",
+ "grammers-mtsender",
+ "grammers-session",
+ "grammers-tl-types",
+ "log",
+ "md5",
+ "mime_guess",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "grammers-crypto"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68fe353d0d566b5b1171ce92c981a0d221db8754bb37524f1159bd5d693164fd"
+dependencies = [
+ "aes",
+ "ctr",
+ "getrandom 0.4.2",
+ "glass_pumpkin",
+ "hmac",
+ "num-bigint",
+ "num-traits",
+ "pbkdf2",
+ "sha1",
+ "sha2",
+]
+
+[[package]]
+name = "grammers-mtproto"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2ade3e0db6feef2a411d0a6a4820005f3a9c17d1bddcfab2603c0dfbb50cf8"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "flate2",
+ "getrandom 0.4.2",
+ "grammers-crypto",
+ "grammers-tl-types",
+ "log",
+ "num-bigint",
+ "sha1",
+]
+
+[[package]]
+name = "grammers-mtsender"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae24e1d8f1de2c777b025c64eedb1578c142cc2786cc8d165f62f54a6e97809"
+dependencies = [
+ "bytes",
+ "grammers-crypto",
+ "grammers-mtproto",
+ "grammers-session",
+ "grammers-tl-types",
+ "locate-locale",
+ "log",
+ "os_info",
+ "tokio",
+]
+
+[[package]]
+name = "grammers-session"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ad9fe6e7acc0eaf653460233fce428bcdcd0f5648768bd8941145a430b84bb"
+dependencies = [
+ "futures-core",
+ "grammers-tl-types",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "grammers-tl-gen"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e27a47ca08e062c08d76d7a01eaf151d70980ce9b9dc66cf46a4902dd8a37c4"
+dependencies = [
+ "grammers-tl-parser",
+]
+
+[[package]]
+name = "grammers-tl-parser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c01be87038dce51855b5037e7d341eb84146db713a1c4953a8415512d26477"
+dependencies = [
+ "crc32fast",
+]
+
+[[package]]
+name = "grammers-tl-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e1f6fa6142fda4f3938d6b5cd1d74848e39a845ff18a1c632200285b4d8a4"
+dependencies = [
+ "grammers-tl-gen",
+ "grammers-tl-parser",
 ]
 
 [[package]]
@@ -799,6 +976,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1134,6 +1320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1421,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "locate-locale"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2835eaaed39a92511442aff277d4dca3d7674ca058df3bc45170661c2ccb4619"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1464,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -1328,6 +1538,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,6 +1600,165 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1447,6 +1828,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1863,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -1736,6 +2142,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rc-box"
@@ -2177,6 +2589,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3067,6 +3490,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ ring = "0.17"
 # feature is enabled so default builds stay lightweight and do not pay
 # the compile cost of the full grammers stack.
 grammers-client = { version = "0.9", optional = true }
+grammers-session = { version = "0.9", optional = true }
+grammers-mtsender = { version = "0.9", optional = true }
 
 [lib]
 name = "deskd"
@@ -52,4 +54,4 @@ default = []
 vendored-openssl = ["openssl"]
 # Enables the MTProto user-account path for Telegram history retrieval
 # (issue #376). Disabled by default; pulls in grammers-client.
-mtproto = ["grammers-client"]
+mtproto = ["grammers-client", "grammers-session", "grammers-mtsender"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 jsonwebtoken = "9"
 ring = "0.17"
+# Optional MTProto client (issue #376). Pulled in only when the `mtproto`
+# feature is enabled so default builds stay lightweight and do not pay
+# the compile cost of the full grammers stack.
+grammers-client = { version = "0.9", optional = true }
 
 [lib]
 name = "deskd"
@@ -46,3 +50,6 @@ path = "src/bin/session2graph.rs"
 [features]
 default = []
 vendored-openssl = ["openssl"]
+# Enables the MTProto user-account path for Telegram history retrieval
+# (issue #376). Disabled by default; pulls in grammers-client.
+mtproto = ["grammers-client"]

--- a/docs/TELEGRAM_MTPROTO.md
+++ b/docs/TELEGRAM_MTPROTO.md
@@ -1,0 +1,109 @@
+# Telegram MTProto history retrieval
+
+Tracking issue: [kgatilin/deskd#376](https://github.com/kgatilin/deskd/issues/376).
+This document describes the design only — phase 1 ships the skeleton,
+phase 2 wires the real `grammers-client` integration.
+
+## Why MTProto
+
+deskd's default Telegram path is the Bot API (teloxide). In groups with
+privacy mode enabled — the default for Bot API users — a bot only sees
+messages that mention or reply to it. It cannot read history, scan other
+participants' messages, or recover context it missed while offline.
+
+That blocks agents like Kira from answering questions such as
+"summarize today's thread" or "what did Konstantin say yesterday?". The
+user-account MTProto API has no such restriction, so we add it as an
+optional, read-only parallel path.
+
+## Feature flag
+
+The grammers dependency is large. It is gated behind an opt-in cargo
+feature:
+
+```
+cargo build                       # default — no mtproto, no grammers
+cargo build --features mtproto    # pulls in grammers-client
+```
+
+Default builds are unaffected. The `telegram_history` MCP tool is still
+advertised in `tools/list` even without the feature so agents get a
+consistent contract; the handler simply errors with a rebuild hint.
+
+## Config example
+
+```yaml
+# deskd.yaml (per-agent user config)
+telegram:
+  routes:
+    - chat_id: -1001234567890
+  mtproto:
+    api_id: 12345
+    api_hash: "deadbeef"
+    session_path: "/var/lib/deskd/tg-session.bin"
+    phone: "+1234567890"
+    allowed_chats:
+      kira: [-1001234567890, -1003733725513]
+      dev:  [-1001234567890]
+```
+
+The same `mtproto` block also exists on workspace-level
+`TelegramConfig` for ops-managed deployments; the running agent reads
+the per-user entry.
+
+## Login flow (intended — phase 2)
+
+MTProto sessions are interactive to create: Telegram SMS-es a code.
+We keep that out of the daemon hot path with a dedicated subcommand:
+
+```
+deskd telegram-login \
+    --api-id 12345 \
+    --api-hash deadbeef \
+    --phone +1234567890 \
+    --session-path /var/lib/deskd/tg-session.bin
+```
+
+It prompts for the code (and the 2FA password if set) on stdin and
+writes the grammers session file. `deskd serve` then loads the session
+non-interactively.
+
+## ACL model
+
+`telegram_history` enforces a per-agent allow-list. The handler checks
+`allowed_chats[agent_name]` for the requested `chat_id`; unknown agents
+and unlisted chats are denied with a clear error. Default is empty —
+deny all. This prevents an agent from snooping on chats it was never
+intended to see, even if it gets the session file path right.
+
+## Security
+
+The session file is equivalent to full account access — anyone with the
+file can log in as you. Treat it like an SSH private key:
+
+  - Mode 0600, owned by the agent's unix user.
+  - Never commit it to git; never ship it in container images.
+  - Prefer a dedicated Telegram account for agent use, not a personal
+    one. Automation on a personal number carries ban risk and exposes
+    private DMs to the agent.
+  - Filesystem-level encryption (LUKS, encrypted home) is recommended
+    for the host storing the session.
+
+## Scope — phase 1 (this PR)
+
+In scope:
+  - `grammers-client` added as an optional dep behind `mtproto` feature.
+  - `MtProtoConfig` on both workspace `TelegramConfig` and per-user
+    `TelegramRoutesConfig`, with an `agent_can_query` ACL helper.
+  - `infra::telegram_mtproto` skeleton with `ChatMessage` serde type
+    and a `MtProtoClient` whose methods are `todo!()` stubs.
+  - `telegram_history` MCP tool surfaced with feature + config + ACL
+    guards.
+  - `deskd telegram-login` subcommand prints a phase-2 notice.
+
+Not in scope (phase 2):
+  - Real grammers `Client::connect` / `messages.getHistory` calls.
+  - Interactive login implementation.
+  - Session-file encryption at rest beyond filesystem ACLs.
+  - Posting via MTProto (Bot API stays the canonical send channel).
+  - Media downloads or real-time message streaming.

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -141,9 +141,9 @@ pub enum Commands {
         socket: Option<String>,
     },
     /// Interactively log in to Telegram via MTProto and persist a session
-    /// file (issue #376). Phase 1 stub — prints a not-implemented notice.
+    /// file (issue #376).
     ///
-    /// Intended phase 2 UX:
+    /// Usage:
     ///   deskd telegram-login \
     ///       --api-id 12345 \
     ///       --api-hash deadbeef \

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -140,6 +140,33 @@ pub enum Commands {
         #[arg(long)]
         socket: Option<String>,
     },
+    /// Interactively log in to Telegram via MTProto and persist a session
+    /// file (issue #376). Phase 1 stub — prints a not-implemented notice.
+    ///
+    /// Intended phase 2 UX:
+    ///   deskd telegram-login \
+    ///       --api-id 12345 \
+    ///       --api-hash deadbeef \
+    ///       --phone +1234567890 \
+    ///       --session-path /var/lib/deskd/tg-session.bin
+    ///
+    /// Prompts for the SMS code (and 2FA password if enabled) on stdin,
+    /// then writes the grammers session file. Kept out of `deskd serve`
+    /// so no interactive input is ever required in the daemon path.
+    TelegramLogin {
+        /// Telegram API ID from https://my.telegram.org.
+        #[arg(long)]
+        api_id: Option<i32>,
+        /// Telegram API hash from https://my.telegram.org.
+        #[arg(long)]
+        api_hash: Option<String>,
+        /// Phone number in international format (e.g. +1234567890).
+        #[arg(long)]
+        phone: Option<String>,
+        /// Where to persist the grammers session file.
+        #[arg(long)]
+        session_path: Option<String>,
+    },
     /// Schedule a one-shot reminder for an agent.
     ///
     /// Writes a RemindDef JSON to ~/.deskd/reminders/<uuid>.json.

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -19,7 +19,7 @@ use crate::app::mcp_protocol::{
     write_response,
 };
 use crate::app::mcp_tools::{self, InternalBus, build_send_message_description};
-use crate::config::UserConfig;
+use crate::config::{MtProtoConfig, ServeState, UserConfig, WorkspaceConfig};
 use crate::ports::bus_wire::BusMessage;
 
 // ─── Main entry point ────────────────────────────────────────────────────────
@@ -34,6 +34,11 @@ pub async fn run(agent_name: &str) -> Result<()> {
     let user_config = config_path
         .as_deref()
         .and_then(|p| UserConfig::load(p).ok());
+
+    // Load mtproto config from workspace config (via serve state).
+    // The mtproto config lives on the workspace-level TelegramConfig,
+    // not on the per-user TelegramRoutesConfig.
+    let mtproto_config: Option<MtProtoConfig> = load_mtproto_config(agent_name);
 
     // Lazy-initialized internal bus for sub-agent orchestration.
     let internal_bus: Arc<Mutex<Option<InternalBus>>> = Arc::new(Mutex::new(None));
@@ -107,6 +112,7 @@ pub async fn run(agent_name: &str) -> Result<()> {
                     agent_name,
                     &bus_socket,
                     user_config.as_ref(),
+                    mtproto_config.as_ref(),
                     &internal_bus,
                     &task_store,
                     &sm_store,
@@ -162,11 +168,13 @@ pub async fn run(agent_name: &str) -> Result<()> {
 
 // ─── Request routing ─────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_request(
     req: &Request,
     agent_name: &str,
     bus_socket: &str,
     user_config: Option<&UserConfig>,
+    mtproto_config: Option<&MtProtoConfig>,
     internal_bus: &Arc<Mutex<Option<InternalBus>>>,
     task_store: &dyn crate::ports::store::TaskRepository,
     sm_store: &dyn crate::ports::store::StateMachineRepository,
@@ -182,6 +190,7 @@ async fn handle_request(
                 agent_name,
                 bus_socket,
                 user_config,
+                mtproto_config,
                 internal_bus,
                 task_store,
                 sm_store,
@@ -610,7 +619,7 @@ fn handle_tools_list(
     // or the config/ACL does not permit the call.
     tools.push(json!({
         "name": "telegram_history",
-        "description": "Fetch recent messages from a Telegram chat via MTProto (issue #376). Requires the `mtproto` build feature and a per-agent ACL entry under telegram.mtproto.allowed_chats in deskd.yaml. Phase 1 returns a contract-only error; phase 2 wires grammers-client.",
+        "description": "Fetch recent messages from a Telegram chat via MTProto (issue #376). Requires the `mtproto` build feature and a per-agent ACL entry under telegram.mtproto.allowed_chats in workspace.yaml. Phase 1 returns a contract-only error; phase 2 wires grammers-client.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -627,11 +636,13 @@ fn handle_tools_list(
 
 // ─── Tool dispatch ───────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_tools_call(
     params: &Value,
     agent_name: &str,
     bus_socket: &str,
     user_config: Option<&UserConfig>,
+    mtproto_config: Option<&MtProtoConfig>,
     internal_bus: &Arc<Mutex<Option<InternalBus>>>,
     task_store: &dyn crate::ports::store::TaskRepository,
     sm_store: &dyn crate::ports::store::StateMachineRepository,
@@ -675,7 +686,29 @@ async fn handle_tools_call(
         "browse_needs" => mcp_tools::call_browse_needs(args).await,
         "propose_for_need" => mcp_tools::call_propose_for_need(args).await,
         "query_agent" => mcp_tools::call_query_agent(args, agent_name, bus_socket).await,
-        "telegram_history" => mcp_tools::call_telegram_history(args, agent_name, user_config).await,
+        "telegram_history" => {
+            mcp_tools::call_telegram_history(args, agent_name, mtproto_config).await
+        }
         other => anyhow::bail!("Unknown tool: {}", other),
     }
+}
+
+// ─── MTProto config loader ──────────────────────────────────────────────────
+
+/// Load the MTProto config from the workspace config for the given agent.
+///
+/// Reads the serve state file to find the workspace config path, then loads
+/// the workspace config and extracts `telegram.mtproto` for the agent.
+/// Returns `None` if any step fails (no serve state, no workspace config,
+/// no telegram section, no mtproto section).
+fn load_mtproto_config(agent_name: &str) -> Option<MtProtoConfig> {
+    let serve_state = ServeState::load()?;
+    let ws = WorkspaceConfig::load(&serve_state.workspace_config).ok()?;
+    ws.agents
+        .iter()
+        .find(|a| a.name == agent_name)?
+        .telegram
+        .as_ref()?
+        .mtproto
+        .clone()
 }

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -619,7 +619,7 @@ fn handle_tools_list(
     // or the config/ACL does not permit the call.
     tools.push(json!({
         "name": "telegram_history",
-        "description": "Fetch recent messages from a Telegram chat via MTProto (issue #376). Requires the `mtproto` build feature and a per-agent ACL entry under telegram.mtproto.allowed_chats in workspace.yaml. Phase 1 returns a contract-only error; phase 2 wires grammers-client.",
+        "description": "Fetch recent messages from a Telegram chat via MTProto (issue #376). Requires the `mtproto` build feature, a session file (created by `deskd telegram-login`), and a per-agent ACL entry under telegram.mtproto.allowed_chats in workspace.yaml.",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -604,6 +604,24 @@ fn handle_tools_list(
         }
     }));
 
+    // telegram_history — MTProto chat-history retrieval (issue #376).
+    // Always advertised so agents can discover the contract; the
+    // handler returns a clean error when the `mtproto` feature is off
+    // or the config/ACL does not permit the call.
+    tools.push(json!({
+        "name": "telegram_history",
+        "description": "Fetch recent messages from a Telegram chat via MTProto (issue #376). Requires the `mtproto` build feature and a per-agent ACL entry under telegram.mtproto.allowed_chats in deskd.yaml. Phase 1 returns a contract-only error; phase 2 wires grammers-client.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "integer", "description": "Telegram chat id (positive for users/groups, negative for channels/supergroups)"},
+                "limit": {"type": "integer", "description": "How many messages to fetch (1..=200, default 50)", "default": 50},
+                "offset_id": {"type": "integer", "description": "Return only messages older than this message id (pagination)"}
+            },
+            "required": ["chat_id"]
+        }
+    }));
+
     Response::ok(id, json!({ "tools": tools }))
 }
 
@@ -657,6 +675,9 @@ async fn handle_tools_call(
         "browse_needs" => mcp_tools::call_browse_needs(args).await,
         "propose_for_need" => mcp_tools::call_propose_for_need(args).await,
         "query_agent" => mcp_tools::call_query_agent(args, agent_name, bus_socket).await,
+        "telegram_history" => {
+            mcp_tools::call_telegram_history(args, agent_name, user_config).await
+        }
         other => anyhow::bail!("Unknown tool: {}", other),
     }
 }

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -675,9 +675,7 @@ async fn handle_tools_call(
         "browse_needs" => mcp_tools::call_browse_needs(args).await,
         "propose_for_need" => mcp_tools::call_propose_for_need(args).await,
         "query_agent" => mcp_tools::call_query_agent(args, agent_name, bus_socket).await,
-        "telegram_history" => {
-            mcp_tools::call_telegram_history(args, agent_name, user_config).await
-        }
+        "telegram_history" => mcp_tools::call_telegram_history(args, agent_name, user_config).await,
         other => anyhow::bail!("Unknown tool: {}", other),
     }
 }

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -1195,7 +1195,10 @@ pub(crate) async fn call_telegram_history(
         .context("telegram_history: missing required integer 'chat_id'")?;
     let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as u32;
     if limit == 0 || limit > 200 {
-        bail!("telegram_history: 'limit' must be in 1..=200 (got {})", limit);
+        bail!(
+            "telegram_history: 'limit' must be in 1..=200 (got {})",
+            limit
+        );
     }
     let _offset_id: Option<i32> = args
         .get("offset_id")
@@ -1212,9 +1215,8 @@ pub(crate) async fn call_telegram_history(
 
     #[cfg(feature = "mtproto")]
     {
-        let cfg = user_config.context(
-            "telegram_history: no user config loaded — set DESKD_AGENT_CONFIG",
-        )?;
+        let cfg = user_config
+            .context("telegram_history: no user config loaded — set DESKD_AGENT_CONFIG")?;
         let mtproto = cfg
             .telegram
             .as_ref()
@@ -1265,10 +1267,9 @@ mod tests {
 
     #[tokio::test]
     async fn telegram_history_rejects_bad_limit() {
-        let err =
-            call_telegram_history(&json!({"chat_id": 1, "limit": 500}), "kira", None)
-                .await
-                .unwrap_err();
+        let err = call_telegram_history(&json!({"chat_id": 1, "limit": 500}), "kira", None)
+            .await
+            .unwrap_err();
         let msg = format!("{:#}", err);
         assert!(msg.contains("limit"), "expected limit error, got: {}", msg);
     }

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -1174,14 +1174,8 @@ pub(crate) async fn call_query_agent(
 
 /// Handle the `telegram_history` MCP tool call.
 ///
-/// Phase 1 (this PR): exposes the tool surface so agents can be
-/// exercised against the contract. The handler validates:
-///   1. The `mtproto` feature was compiled in.
-///   2. `mtproto_config` is provided (from workspace-level config).
-///   3. The calling agent is allowed to query the requested chat_id.
-///
-/// If all checks pass, it still errors with "not yet implemented"
-/// because the actual grammers integration is phase 2.
+/// Validates feature flag, config, and ACL, then connects to Telegram
+/// via grammers-client and fetches chat history.
 pub(crate) async fn call_telegram_history(
     args: &Value,
     agent_name: &str,
@@ -1215,6 +1209,8 @@ pub(crate) async fn call_telegram_history(
 
     #[cfg(feature = "mtproto")]
     {
+        use crate::infra::telegram_mtproto::MtProtoClient;
+
         let mtproto = mtproto_config.ok_or_else(|| {
             anyhow::anyhow!(
                 "telegram_history: mtproto config missing — add telegram.mtproto to workspace.yaml"
@@ -1227,8 +1223,20 @@ pub(crate) async fn call_telegram_history(
                 chat_id
             );
         }
-        // Phase 2 will call MtProtoClient::connect + fetch_history here.
-        bail!("telegram_history: not yet implemented (issue #376 phase 2)");
+
+        let client = MtProtoClient::connect(mtproto)
+            .await
+            .context("telegram_history: failed to connect MTProto client")?;
+        let messages = client
+            .fetch_history(chat_id, limit, _offset_id)
+            .await
+            .context("telegram_history: failed to fetch messages")?;
+
+        Ok(json!({
+            "chat_id": chat_id,
+            "count": messages.len(),
+            "messages": messages,
+        }))
     }
 }
 

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -1170,6 +1170,72 @@ pub(crate) async fn call_query_agent(
     }
 }
 
+// ─── telegram_history (issue #376) ───────────────────────────────────────────
+
+/// Handle the `telegram_history` MCP tool call.
+///
+/// Phase 1 (this PR): exposes the tool surface so agents can be
+/// exercised against the contract. The handler validates:
+///   1. The `mtproto` feature was compiled in.
+///   2. `user_config.telegram.mtproto` is populated.
+///   3. The calling agent is allowed to query the requested chat_id.
+///
+/// If all checks pass, it still errors with "not yet implemented"
+/// because the actual grammers integration is phase 2.
+pub(crate) async fn call_telegram_history(
+    args: &Value,
+    agent_name: &str,
+    user_config: Option<&UserConfig>,
+) -> Result<Value> {
+    // Parse arguments first so the error messages are consistent
+    // regardless of feature flags.
+    let chat_id = args
+        .get("chat_id")
+        .and_then(|v| v.as_i64())
+        .context("telegram_history: missing required integer 'chat_id'")?;
+    let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as u32;
+    if limit == 0 || limit > 200 {
+        bail!("telegram_history: 'limit' must be in 1..=200 (got {})", limit);
+    }
+    let _offset_id: Option<i32> = args
+        .get("offset_id")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
+    #[cfg(not(feature = "mtproto"))]
+    {
+        let _ = (chat_id, agent_name, user_config);
+        bail!(
+            "telegram_history requires the `mtproto` feature — rebuild deskd with `--features mtproto`"
+        );
+    }
+
+    #[cfg(feature = "mtproto")]
+    {
+        let cfg = user_config.context(
+            "telegram_history: no user config loaded — set DESKD_AGENT_CONFIG",
+        )?;
+        let mtproto = cfg
+            .telegram
+            .as_ref()
+            .and_then(|t| t.mtproto.as_ref())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "telegram_history: mtproto config missing — add telegram.mtproto to deskd.yaml"
+                )
+            })?;
+        if !mtproto.agent_can_query(agent_name, chat_id) {
+            bail!(
+                "telegram_history: agent {} not allowed to query chat {}",
+                agent_name,
+                chat_id
+            );
+        }
+        // Phase 2 will call MtProtoClient::connect + fetch_history here.
+        bail!("telegram_history: not yet implemented (issue #376 phase 2)");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1182,5 +1248,42 @@ mod tests {
         assert!(glob_match("agent:dev", "agent:dev"));
         assert!(!glob_match("agent:dev", "agent:researcher"));
         assert!(!glob_match("telegram.out:*", "telegram.in:-1234"));
+    }
+
+    #[tokio::test]
+    async fn telegram_history_rejects_missing_chat_id() {
+        let err = call_telegram_history(&json!({}), "kira", None)
+            .await
+            .unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("chat_id"),
+            "expected chat_id error, got: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
+    async fn telegram_history_rejects_bad_limit() {
+        let err =
+            call_telegram_history(&json!({"chat_id": 1, "limit": 500}), "kira", None)
+                .await
+                .unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("limit"), "expected limit error, got: {}", msg);
+    }
+
+    #[cfg(not(feature = "mtproto"))]
+    #[tokio::test]
+    async fn telegram_history_requires_feature_when_disabled() {
+        let err = call_telegram_history(&json!({"chat_id": 42}), "kira", None)
+            .await
+            .unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("mtproto"),
+            "expected feature-flag hint, got: {}",
+            msg
+        );
     }
 }

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -14,7 +14,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::app::mcp_service;
-use crate::config::UserConfig;
+use crate::config::{MtProtoConfig, UserConfig};
 
 // ─── Embedded bus for sub-agent orchestration ────────────────────────────────
 
@@ -1177,7 +1177,7 @@ pub(crate) async fn call_query_agent(
 /// Phase 1 (this PR): exposes the tool surface so agents can be
 /// exercised against the contract. The handler validates:
 ///   1. The `mtproto` feature was compiled in.
-///   2. `user_config.telegram.mtproto` is populated.
+///   2. `mtproto_config` is provided (from workspace-level config).
 ///   3. The calling agent is allowed to query the requested chat_id.
 ///
 /// If all checks pass, it still errors with "not yet implemented"
@@ -1185,7 +1185,7 @@ pub(crate) async fn call_query_agent(
 pub(crate) async fn call_telegram_history(
     args: &Value,
     agent_name: &str,
-    user_config: Option<&UserConfig>,
+    mtproto_config: Option<&MtProtoConfig>,
 ) -> Result<Value> {
     // Parse arguments first so the error messages are consistent
     // regardless of feature flags.
@@ -1207,7 +1207,7 @@ pub(crate) async fn call_telegram_history(
 
     #[cfg(not(feature = "mtproto"))]
     {
-        let _ = (chat_id, agent_name, user_config);
+        let _ = (chat_id, agent_name, mtproto_config);
         bail!(
             "telegram_history requires the `mtproto` feature — rebuild deskd with `--features mtproto`"
         );
@@ -1215,17 +1215,11 @@ pub(crate) async fn call_telegram_history(
 
     #[cfg(feature = "mtproto")]
     {
-        let cfg = user_config
-            .context("telegram_history: no user config loaded — set DESKD_AGENT_CONFIG")?;
-        let mtproto = cfg
-            .telegram
-            .as_ref()
-            .and_then(|t| t.mtproto.as_ref())
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "telegram_history: mtproto config missing — add telegram.mtproto to deskd.yaml"
-                )
-            })?;
+        let mtproto = mtproto_config.ok_or_else(|| {
+            anyhow::anyhow!(
+                "telegram_history: mtproto config missing — add telegram.mtproto to workspace.yaml"
+            )
+        })?;
         if !mtproto.agent_can_query(agent_name, chat_id) {
             bail!(
                 "telegram_history: agent {} not allowed to query chat {}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -518,7 +518,16 @@ pub struct SubAgentDef {
 /// Telegram channel routing config in the per-user deskd.yaml.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelegramRoutesConfig {
+    #[serde(default)]
     pub routes: Vec<TelegramRoute>,
+    /// Optional MTProto user-account config (issue #376). Kept here in
+    /// addition to `WorkspaceConfig::TelegramConfig.mtproto` so the
+    /// per-agent MCP server — which only sees `UserConfig` — can read
+    /// it without reaching into workspace.yaml. In practice only one
+    /// of the two is populated; the workspace entry is for admin/ops,
+    /// the user entry is what the running agent consumes.
+    #[serde(default)]
+    pub mtproto: Option<MtProtoConfig>,
 }
 
 /// A single Telegram chat route.

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,6 +109,50 @@ pub struct RoomDef {
 pub struct TelegramConfig {
     /// Bot token from @BotFather. Typically set via ${TELEGRAM_BOT_TOKEN}.
     pub token: String,
+    /// Optional MTProto user-account config for history retrieval
+    /// (issue #376). Parallel to the Bot API path — absent by default,
+    /// in which case only teloxide/Bot API is used.
+    #[serde(default)]
+    pub mtproto: Option<MtProtoConfig>,
+}
+
+/// MTProto user-account config. Used by the `telegram_history` MCP tool
+/// to fetch chat history in groups where bot privacy mode hides messages.
+///
+/// See `docs/TELEGRAM_MTPROTO.md` for the design.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MtProtoConfig {
+    /// Telegram API ID from https://my.telegram.org.
+    pub api_id: i32,
+    /// Telegram API hash from https://my.telegram.org.
+    pub api_hash: String,
+    /// Path to the persisted grammers session file. Contains full
+    /// account credentials — filesystem ACL must restrict it to the
+    /// agent's unix user (mode 0600).
+    pub session_path: PathBuf,
+    /// Phone number in international format (e.g. "+1234567890").
+    /// Only consulted by the `deskd telegram-login` command; the serve
+    /// runtime reads the session file directly.
+    #[serde(default)]
+    pub phone: Option<String>,
+    /// Per-agent chat ACL: `agent_name -> [chat_id, ...]`. The
+    /// `telegram_history` tool refuses to query a chat that is not
+    /// listed for the requesting agent. Default empty — deny all.
+    #[serde(default)]
+    pub allowed_chats: HashMap<String, Vec<i64>>,
+}
+
+impl MtProtoConfig {
+    /// Return true if `agent_name` is allowed to query `chat_id`.
+    ///
+    /// Pure function, no I/O — used by the MCP handler before any
+    /// grammers call. Unknown agents are always denied.
+    pub fn agent_can_query(&self, agent_name: &str, chat_id: i64) -> bool {
+        self.allowed_chats
+            .get(agent_name)
+            .map(|chats| chats.contains(&chat_id))
+            .unwrap_or(false)
+    }
 }
 
 /// Discord bot adapter config. Defined per-agent in workspace.yaml.
@@ -667,7 +711,93 @@ agents:
             cfg.agents[0].telegram.as_ref().unwrap().token,
             "bot-token-123"
         );
+        // Back-compat: no mtproto section present.
+        assert!(cfg.agents[0].telegram.as_ref().unwrap().mtproto.is_none());
         assert!(cfg.agents[1].telegram.is_none());
+    }
+
+    #[test]
+    fn test_workspace_config_with_telegram_mtproto() {
+        let yaml = r#"
+agents:
+  - name: kira
+    work_dir: /home/kira
+    unix_user: kira
+    telegram:
+      token: "bot-token-123"
+      mtproto:
+        api_id: 12345
+        api_hash: "deadbeef"
+        session_path: "/var/lib/deskd/tg-session.bin"
+        phone: "+1234567890"
+        allowed_chats:
+          kira: [123, 456]
+          dev: [789]
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let tg = cfg.agents[0].telegram.as_ref().unwrap();
+        let mtp = tg.mtproto.as_ref().expect("mtproto section present");
+        assert_eq!(mtp.api_id, 12345);
+        assert_eq!(mtp.api_hash, "deadbeef");
+        assert_eq!(
+            mtp.session_path,
+            std::path::PathBuf::from("/var/lib/deskd/tg-session.bin")
+        );
+        assert_eq!(mtp.phone.as_deref(), Some("+1234567890"));
+        assert_eq!(mtp.allowed_chats.get("kira").unwrap(), &vec![123i64, 456]);
+        assert_eq!(mtp.allowed_chats.get("dev").unwrap(), &vec![789i64]);
+    }
+
+    #[test]
+    fn test_workspace_config_telegram_without_mtproto() {
+        // Back-compat: existing yaml with only `token` must still parse
+        // and mtproto must default to None.
+        let yaml = r#"
+agents:
+  - name: kira
+    work_dir: /home/kira
+    telegram:
+      token: "bot-token-123"
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let tg = cfg.agents[0].telegram.as_ref().unwrap();
+        assert_eq!(tg.token, "bot-token-123");
+        assert!(tg.mtproto.is_none());
+    }
+
+    #[test]
+    fn test_mtproto_config_acl_allow_and_deny() {
+        let mut allowed = HashMap::new();
+        allowed.insert("kira".to_string(), vec![123i64, 456]);
+        let cfg = MtProtoConfig {
+            api_id: 1,
+            api_hash: "x".into(),
+            session_path: PathBuf::from("/tmp/session.bin"),
+            phone: None,
+            allowed_chats: allowed,
+        };
+        // Allowed: agent+chat pair present.
+        assert!(cfg.agent_can_query("kira", 123));
+        assert!(cfg.agent_can_query("kira", 456));
+        // Denied: chat not in kira's list.
+        assert!(!cfg.agent_can_query("kira", 999));
+        // Denied: agent not in the ACL map at all.
+        assert!(!cfg.agent_can_query("vasya", 123));
+        // Denied: unknown agent + unknown chat.
+        assert!(!cfg.agent_can_query("vasya", 999));
+    }
+
+    #[test]
+    fn test_mtproto_config_acl_empty_denies_all() {
+        let cfg = MtProtoConfig {
+            api_id: 1,
+            api_hash: "x".into(),
+            session_path: PathBuf::from("/tmp/session.bin"),
+            phone: None,
+            allowed_chats: HashMap::new(),
+        };
+        assert!(!cfg.agent_can_query("kira", 123));
+        assert!(!cfg.agent_can_query("anyone", 0));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -520,14 +520,6 @@ pub struct SubAgentDef {
 pub struct TelegramRoutesConfig {
     #[serde(default)]
     pub routes: Vec<TelegramRoute>,
-    /// Optional MTProto user-account config (issue #376). Kept here in
-    /// addition to `WorkspaceConfig::TelegramConfig.mtproto` so the
-    /// per-agent MCP server — which only sees `UserConfig` — can read
-    /// it without reaching into workspace.yaml. In practice only one
-    /// of the two is populated; the workspace entry is for admin/ops,
-    /// the user entry is what the running agent consumes.
-    #[serde(default)]
-    pub mtproto: Option<MtProtoConfig>,
 }
 
 /// A single Telegram chat route.

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -8,4 +8,5 @@ pub mod memory_store;
 pub mod paths;
 pub mod sm_store;
 pub mod task_store;
+pub mod telegram_mtproto;
 pub mod unix_bus;

--- a/src/infra/telegram_mtproto.rs
+++ b/src/infra/telegram_mtproto.rs
@@ -164,30 +164,27 @@ mod imp {
 
     /// Convert a Bot-API-style chat_id to a grammers `PeerId`.
     ///
-    /// Bot API conventions:
-    /// - Positive IDs → user
-    /// - Negative IDs starting with -100 → channel/supergroup
-    /// - Other negative IDs → small group chat
+    /// `PeerId` uses the same Bot-API Dialog ID encoding internally,
+    /// so we construct via the appropriate typed constructor using the
+    /// bare (positive) id extracted from the Bot-API convention:
+    /// - Positive → user
+    /// - -100XXXXXXXXXX → channel/supergroup (bare = strip -100 prefix)
+    /// - Other negative → small group (bare = abs)
     fn bot_api_to_peer_id(chat_id: i64) -> Result<PeerId> {
         if chat_id > 0 {
             PeerId::user(chat_id).context("invalid user id")
         } else if chat_id < -1_000_000_000_000 {
-            let channel_id = -(chat_id + 1_000_000_000_000);
-            PeerId::channel(channel_id).context("invalid channel id")
+            let bare = -(chat_id + 1_000_000_000_000);
+            PeerId::channel(bare).context("invalid channel id")
         } else {
-            let group_id = -chat_id;
-            PeerId::chat(group_id).context("invalid group id")
+            let bare = -chat_id;
+            PeerId::chat(bare).context("invalid group id")
         }
     }
 
-    /// Convert a grammers `PeerId` back to a plain i64.
+    /// Extract the bare (positive) user/chat/channel id from a `PeerId`.
     fn peer_id_to_i64(pid: &PeerId) -> i64 {
-        // PeerId's Debug format is "User(123)" / "Chat(456)" / "Channel(789)".
-        let s = format!("{:?}", pid);
-        s.trim_start_matches(|c: char| c.is_alphabetic() || c == '(')
-            .trim_end_matches(')')
-            .parse::<i64>()
-            .unwrap_or(0)
+        pid.bare_id()
     }
 
     // ─── Interactive login flow ─────────────────────────────────────────────

--- a/src/infra/telegram_mtproto.rs
+++ b/src/infra/telegram_mtproto.rs
@@ -1,20 +1,19 @@
-//! Telegram MTProto client (issue #376) — skeleton.
+//! Telegram MTProto client (issue #376).
 //!
-//! This module provides the API surface that the rest of deskd calls
-//! into when the `mtproto` feature is enabled. The actual grammers
-//! integration (connect, auth flow, `messages.getHistory`) lands in
-//! phase 2; for now every method is a `todo!()` stub so callers can
-//! be wired against a stable contract.
+//! When the `mtproto` feature is enabled this module provides a thin
+//! wrapper around grammers-client that can:
+//!   - connect to Telegram using a persisted session file,
+//!   - interactively log in (SMS code + optional 2FA),
+//!   - fetch chat history via `messages.getHistory`.
 //!
-//! Without the `mtproto` feature, the module compiles to an empty
-//! stub — no grammers types leak into the default build.
+//! Without the `mtproto` feature the module only exports the shared
+//! `ChatMessage` type (pure serde, no grammers dep).
 
 use serde::{Deserialize, Serialize};
 
 /// A single Telegram chat message as returned by `fetch_history`.
 ///
 /// Deliberately narrow: text only, no media, no formatting entities.
-/// Media support is out of scope for phase 1 (see issue #376).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub message_id: i32,
@@ -29,49 +28,271 @@ pub struct ChatMessage {
 mod imp {
     use super::ChatMessage;
     use crate::config::MtProtoConfig;
+    use anyhow::{Context, Result, bail};
+    use grammers_client::Client;
+    use grammers_client::client::SignInError;
+    use grammers_mtsender::{SenderPool, SenderPoolFatHandle};
+    use grammers_session::storages::SqliteSession;
+    use grammers_session::types::PeerId;
+    use std::io::{self, BufRead, Write};
+    use std::sync::Arc;
+    use tracing::{debug, info};
 
-    // Keep the grammers import live under the feature flag so the
-    // dependency actually gets compiled and linked — otherwise cargo
-    // warns about the unused optional dep. The concrete Client wiring
-    // lands in phase 2.
-    #[allow(unused_imports)]
-    use grammers_client as _;
-
-    /// Wrapper around a grammers `Client`. Phase 2 will hold the real
-    /// client handle; for now it is a unit struct so the API surface
-    /// is stable.
+    /// Wrapper around a grammers `Client` + its background I/O task.
     pub struct MtProtoClient {
-        _private: (),
+        client: Client,
+        handle: SenderPoolFatHandle,
+        _pool_task: tokio::task::JoinHandle<()>,
     }
 
     impl MtProtoClient {
-        /// Connect to Telegram's MTProto servers using the session
-        /// file referenced by `cfg`. Phase 2: actual grammers wiring.
-        pub async fn connect(_cfg: &MtProtoConfig) -> anyhow::Result<Self> {
-            todo!("Phase 2: integrate grammers-client (issue #376)")
+        /// Connect to Telegram using the session file from `cfg`.
+        ///
+        /// The session file must already exist (created by `deskd telegram-login`).
+        pub async fn connect(cfg: &MtProtoConfig) -> Result<Self> {
+            let session_path = cfg
+                .session_path
+                .to_str()
+                .context("session_path is not valid UTF-8")?;
+
+            let session = Arc::new(
+                SqliteSession::open(session_path)
+                    .await
+                    .with_context(|| format!("failed to open session file: {}", session_path))?,
+            );
+
+            let SenderPool {
+                runner,
+                handle,
+                updates: _,
+            } = SenderPool::new(Arc::clone(&session), cfg.api_id);
+
+            let pool_task = tokio::spawn(runner.run());
+            let client = Client::new(handle.clone());
+
+            if !client.is_authorized().await? {
+                bail!(
+                    "session file exists but is not authorized — run `deskd telegram-login` again"
+                );
+            }
+
+            info!("MTProto client connected (api_id={})", cfg.api_id);
+            Ok(Self {
+                client,
+                handle,
+                _pool_task: pool_task,
+            })
         }
 
         /// Fetch the most recent `limit` messages from `chat_id`.
-        /// If `offset_id` is set, only messages older than that id are
-        /// returned (pagination). Phase 2: real MTProto call.
+        ///
+        /// For supergroups/channels, `chat_id` is the negative ID as used
+        /// by the Bot API (e.g. -1001234567890). We strip the -100 prefix
+        /// to get the MTProto channel ID.
         pub async fn fetch_history(
             &self,
-            _chat_id: i64,
-            _limit: u32,
-            _offset_id: Option<i32>,
-        ) -> anyhow::Result<Vec<ChatMessage>> {
-            todo!("Phase 2: actual MTProto messages.getHistory (issue #376)")
+            chat_id: i64,
+            limit: u32,
+            offset_id: Option<i32>,
+        ) -> Result<Vec<ChatMessage>> {
+            let peer_ref = self
+                .resolve_peer_ref(chat_id)
+                .await
+                .with_context(|| format!("failed to resolve chat {}", chat_id))?;
+
+            let mut iter = self.client.iter_messages(peer_ref).limit(limit as usize);
+            if let Some(oid) = offset_id {
+                iter = iter.offset_id(oid);
+            }
+
+            let mut messages = Vec::new();
+            while let Some(msg) = iter.next().await? {
+                let sender_id = msg.sender().map(|p| peer_id_to_i64(&p.id()));
+                let sender_username = msg.sender().and_then(|p| p.username().map(String::from));
+                messages.push(ChatMessage {
+                    message_id: msg.id(),
+                    date: msg.date(),
+                    sender_id,
+                    sender_username,
+                    text: msg.text().to_string(),
+                    reply_to_msg_id: msg.reply_to_message_id(),
+                });
+            }
+
+            debug!("fetched {} messages from chat {}", messages.len(), chat_id);
+            Ok(messages)
         }
+
+        /// Resolve a Bot-API-style chat_id to a grammers `PeerRef`.
+        ///
+        /// First tries the session cache (fast). If not cached, iterates
+        /// dialogs to populate the cache and retries.
+        async fn resolve_peer_ref(&self, chat_id: i64) -> Result<grammers_session::types::PeerRef> {
+            let peer_id = bot_api_to_peer_id(chat_id)?;
+
+            // Try session cache first.
+            if let Some(pr) = self.handle.session.peer_ref(peer_id).await {
+                return Ok(pr);
+            }
+
+            // Cache miss — iterate dialogs to populate it.
+            info!(
+                "peer {} not in session cache, iterating dialogs to populate",
+                chat_id
+            );
+            let mut dialogs = self.client.iter_dialogs();
+            while let Some(dialog) = dialogs.next().await? {
+                let p = dialog.peer();
+                if p.id() == peer_id {
+                    // Found it — to_ref() should succeed now that it's cached.
+                    return p.to_ref().await.with_context(|| {
+                        format!(
+                            "peer {} found in dialogs but to_ref() returned None",
+                            chat_id
+                        )
+                    });
+                }
+            }
+
+            bail!(
+                "chat {} not found in account's dialogs — \
+                 the user account must be a member of this chat",
+                chat_id
+            )
+        }
+    }
+
+    /// Convert a Bot-API-style chat_id to a grammers `PeerId`.
+    ///
+    /// Bot API conventions:
+    /// - Positive IDs → user
+    /// - Negative IDs starting with -100 → channel/supergroup
+    /// - Other negative IDs → small group chat
+    fn bot_api_to_peer_id(chat_id: i64) -> Result<PeerId> {
+        if chat_id > 0 {
+            PeerId::user(chat_id).context("invalid user id")
+        } else if chat_id < -1_000_000_000_000 {
+            let channel_id = -(chat_id + 1_000_000_000_000);
+            PeerId::channel(channel_id).context("invalid channel id")
+        } else {
+            let group_id = -chat_id;
+            PeerId::chat(group_id).context("invalid group id")
+        }
+    }
+
+    /// Convert a grammers `PeerId` back to a plain i64.
+    fn peer_id_to_i64(pid: &PeerId) -> i64 {
+        // PeerId's Debug format is "User(123)" / "Chat(456)" / "Channel(789)".
+        let s = format!("{:?}", pid);
+        s.trim_start_matches(|c: char| c.is_alphabetic() || c == '(')
+            .trim_end_matches(')')
+            .parse::<i64>()
+            .unwrap_or(0)
+    }
+
+    // ─── Interactive login flow ─────────────────────────────────────────────
+
+    /// Run the interactive `deskd telegram-login` flow.
+    ///
+    /// Prompts for SMS code and optional 2FA password on stdin, then
+    /// persists the session to `session_path`.
+    pub async fn telegram_login(
+        api_id: i32,
+        api_hash: &str,
+        phone: &str,
+        session_path: &str,
+    ) -> Result<()> {
+        eprintln!("Opening session at: {}", session_path);
+
+        let session = Arc::new(SqliteSession::open(session_path).await?);
+        let SenderPool {
+            runner,
+            handle,
+            updates: _,
+        } = SenderPool::new(Arc::clone(&session), api_id);
+
+        let pool_task = tokio::spawn(runner.run());
+        let client = Client::new(handle.clone());
+
+        if client.is_authorized().await? {
+            eprintln!("Already authorized! Session file is valid.");
+            handle.quit();
+            let _ = pool_task.await;
+            return Ok(());
+        }
+
+        eprintln!("Requesting login code for {}...", phone);
+        let token = client
+            .request_login_code(phone, api_hash)
+            .await
+            .context("failed to request login code")?;
+
+        eprint!("Enter the code you received: ");
+        io::stderr().flush()?;
+        let code = {
+            let stdin = io::stdin();
+            let mut line = String::new();
+            stdin.lock().read_line(&mut line)?;
+            line.trim().to_string()
+        };
+
+        match client.sign_in(&token, &code).await {
+            Ok(user) => {
+                eprintln!(
+                    "Signed in as: {} (id {:?})",
+                    user.first_name().unwrap_or("?"),
+                    user.id()
+                );
+            }
+            Err(SignInError::PasswordRequired(pw_token)) => {
+                let hint = pw_token
+                    .hint()
+                    .map(|h| format!(" (hint: {})", h))
+                    .unwrap_or_default();
+                eprint!("2FA password required{}: ", hint);
+                io::stderr().flush()?;
+                let password = {
+                    let stdin = io::stdin();
+                    let mut line = String::new();
+                    stdin.lock().read_line(&mut line)?;
+                    line.trim().to_string()
+                };
+                let user = client
+                    .check_password(pw_token, password.as_bytes())
+                    .await
+                    .map_err(|e| match e {
+                        SignInError::InvalidPassword(_) => {
+                            anyhow::anyhow!("invalid 2FA password")
+                        }
+                        other => anyhow::anyhow!("sign-in error: {:?}", other),
+                    })?;
+                eprintln!(
+                    "Signed in as: {} (id {:?})",
+                    user.first_name().unwrap_or("?"),
+                    user.id()
+                );
+            }
+            Err(SignInError::InvalidCode) => {
+                bail!("invalid login code — please try again");
+            }
+            Err(SignInError::SignUpRequired) => {
+                bail!("this phone number is not registered with Telegram");
+            }
+            Err(other) => {
+                bail!("sign-in failed: {:?}", other);
+            }
+        }
+
+        eprintln!("Session saved to: {}", session_path);
+
+        handle.quit();
+        let _ = pool_task.await;
+        Ok(())
     }
 }
 
 #[cfg(feature = "mtproto")]
-pub use imp::MtProtoClient;
-
-// When the `mtproto` feature is disabled, the module still exports
-// `ChatMessage` (pure serde types, no grammers dep) so callers can
-// reference the shape in error messages and tests. No MtProtoClient
-// is exported — any code that needs it must be gated on the feature.
+pub use imp::{MtProtoClient, telegram_login};
 
 #[cfg(test)]
 mod tests {

--- a/src/infra/telegram_mtproto.rs
+++ b/src/infra/telegram_mtproto.rs
@@ -1,0 +1,97 @@
+//! Telegram MTProto client (issue #376) — skeleton.
+//!
+//! This module provides the API surface that the rest of deskd calls
+//! into when the `mtproto` feature is enabled. The actual grammers
+//! integration (connect, auth flow, `messages.getHistory`) lands in
+//! phase 2; for now every method is a `todo!()` stub so callers can
+//! be wired against a stable contract.
+//!
+//! Without the `mtproto` feature, the module compiles to an empty
+//! stub — no grammers types leak into the default build.
+
+use serde::{Deserialize, Serialize};
+
+/// A single Telegram chat message as returned by `fetch_history`.
+///
+/// Deliberately narrow: text only, no media, no formatting entities.
+/// Media support is out of scope for phase 1 (see issue #376).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub message_id: i32,
+    pub date: chrono::DateTime<chrono::Utc>,
+    pub sender_id: Option<i64>,
+    pub sender_username: Option<String>,
+    pub text: String,
+    pub reply_to_msg_id: Option<i32>,
+}
+
+#[cfg(feature = "mtproto")]
+mod imp {
+    use super::ChatMessage;
+    use crate::config::MtProtoConfig;
+
+    // Keep the grammers import live under the feature flag so the
+    // dependency actually gets compiled and linked — otherwise cargo
+    // warns about the unused optional dep. The concrete Client wiring
+    // lands in phase 2.
+    #[allow(unused_imports)]
+    use grammers_client as _;
+
+    /// Wrapper around a grammers `Client`. Phase 2 will hold the real
+    /// client handle; for now it is a unit struct so the API surface
+    /// is stable.
+    pub struct MtProtoClient {
+        _private: (),
+    }
+
+    impl MtProtoClient {
+        /// Connect to Telegram's MTProto servers using the session
+        /// file referenced by `cfg`. Phase 2: actual grammers wiring.
+        pub async fn connect(_cfg: &MtProtoConfig) -> anyhow::Result<Self> {
+            todo!("Phase 2: integrate grammers-client (issue #376)")
+        }
+
+        /// Fetch the most recent `limit` messages from `chat_id`.
+        /// If `offset_id` is set, only messages older than that id are
+        /// returned (pagination). Phase 2: real MTProto call.
+        pub async fn fetch_history(
+            &self,
+            _chat_id: i64,
+            _limit: u32,
+            _offset_id: Option<i32>,
+        ) -> anyhow::Result<Vec<ChatMessage>> {
+            todo!("Phase 2: actual MTProto messages.getHistory (issue #376)")
+        }
+    }
+}
+
+#[cfg(feature = "mtproto")]
+pub use imp::MtProtoClient;
+
+// When the `mtproto` feature is disabled, the module still exports
+// `ChatMessage` (pure serde types, no grammers dep) so callers can
+// reference the shape in error messages and tests. No MtProtoClient
+// is exported — any code that needs it must be gated on the feature.
+
+#[cfg(test)]
+mod tests {
+    use super::ChatMessage;
+    use chrono::Utc;
+
+    #[test]
+    fn chat_message_roundtrips_through_json() {
+        let msg = ChatMessage {
+            message_id: 42,
+            date: Utc::now(),
+            sender_id: Some(111),
+            sender_username: Some("kira".into()),
+            text: "hello".into(),
+            reply_to_msg_id: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let back: ChatMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.message_id, 42);
+        assert_eq!(back.text, "hello");
+        assert_eq!(back.sender_username.as_deref(), Some("kira"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::Upgrade { install_dir } => {
             commands::upgrade::handle(install_dir).await?;
         }
+        Commands::TelegramLogin { .. } => {
+            eprintln!(
+                "deskd telegram-login: Phase 2 — not yet implemented. See issue #376 \
+                 (https://github.com/kgatilin/deskd/issues/376)."
+            );
+        }
         Commands::Usage {
             period,
             agent,

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,11 +108,48 @@ async fn main() -> anyhow::Result<()> {
         Commands::Upgrade { install_dir } => {
             commands::upgrade::handle(install_dir).await?;
         }
-        Commands::TelegramLogin { .. } => {
-            eprintln!(
-                "deskd telegram-login: Phase 2 — not yet implemented. See issue #376 \
-                 (https://github.com/kgatilin/deskd/issues/376)."
-            );
+        Commands::TelegramLogin {
+            api_id,
+            api_hash,
+            phone,
+            session_path,
+        } => {
+            #[cfg(feature = "mtproto")]
+            {
+                let api_id = api_id.ok_or_else(|| {
+                    anyhow::anyhow!("--api-id is required (from https://my.telegram.org)")
+                })?;
+                let api_hash = api_hash.ok_or_else(|| {
+                    anyhow::anyhow!("--api-hash is required (from https://my.telegram.org)")
+                })?;
+                let phone = phone.ok_or_else(|| {
+                    anyhow::anyhow!("--phone is required (international format, e.g. +1234567890)")
+                })?;
+                let session_path = session_path.unwrap_or_else(|| {
+                    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+                    format!("{}/.deskd/telegram.session", home)
+                });
+                // Ensure parent directory exists.
+                if let Some(parent) = std::path::Path::new(&session_path).parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                deskd::infra::telegram_mtproto::telegram_login(
+                    api_id,
+                    &api_hash,
+                    &phone,
+                    &session_path,
+                )
+                .await?;
+            }
+            #[cfg(not(feature = "mtproto"))]
+            {
+                let _ = (api_id, api_hash, phone, session_path);
+                eprintln!(
+                    "deskd telegram-login requires the `mtproto` feature — \
+                     rebuild with `cargo build --features mtproto`"
+                );
+                std::process::exit(1);
+            }
         }
         Commands::Usage {
             period,


### PR DESCRIPTION
## Summary

Full MTProto integration via grammers-client 0.9 for Telegram chat history retrieval.

- **MtProtoClient**: connect via SQLite session, fetch_history via messages.getHistory with session-cache peer resolution + dialog fallback
- **telegram-login CLI**: interactive SMS code + 2FA password flow, session file persistence
- **telegram_history MCP tool**: real connect + fetch instead of stub, with feature flag + ACL enforcement
- **Dependencies**: grammers-client, grammers-session, grammers-mtsender (all optional under `mtproto` feature)

Closes #378

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (both default and `--features mtproto`)
- [x] `cargo test` passes (both default and `--features mtproto`)
- [ ] Manual: `deskd telegram-login` with real credentials
- [ ] Manual: `telegram_history` MCP tool call against a real chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)