### PR TITLE
fix: treat budget_usd <= 0 as unlimited (#387)

### DIFF
--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -194,7 +194,11 @@ pub async fn handle(action: AgentAction) -> Result<()> {
             );
             println!("Total turns:{}", s.total_turns);
             println!("Total cost: ${:.4}", s.total_cost);
-            println!("Budget:     ${:.2}", s.config.budget_usd);
+            if s.config.budget_usd > 0.0 {
+                println!("Budget:     ${:.2}", s.config.budget_usd);
+            } else {
+                println!("Budget:     unlimited");
+            }
             println!(
                 "Session:    {}",
                 if s.session_id.is_empty() {
@@ -393,7 +397,11 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 println!("Model:       {}", s.config.model);
                 println!("Turns:       {}", s.total_turns);
                 println!("Cost:        ${:.4}", s.total_cost);
-                println!("Budget:      ${:.2}", s.config.budget_usd);
+                if s.config.budget_usd > 0.0 {
+                    println!("Budget:      ${:.2}", s.config.budget_usd);
+                } else {
+                    println!("Budget:      unlimited");
+                }
                 println!("Created:     {}", s.created_at);
                 println!("Work dir:    {}", s.config.work_dir);
                 if !s.current_task.is_empty() {

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -892,7 +892,12 @@ fn extract_task_context(msg: &Message, _name: &str) -> Option<TaskContext> {
 }
 
 /// Check if budget is exceeded. Returns Some(error_message) if over budget.
+///
+/// `budget_usd <= 0.0` disables the cap (unlimited budget); see #387.
 fn check_budget(name: &str, budget_usd: f64) -> Option<String> {
+    if !budget_enforced(budget_usd) {
+        return None;
+    }
     let current_state = agent::load_state(name).ok()?;
     if current_state.total_cost >= budget_usd {
         warn!(
@@ -908,6 +913,15 @@ fn check_budget(name: &str, budget_usd: f64) -> Option<String> {
     } else {
         None
     }
+}
+
+/// Returns true when `budget_usd` should be enforced as a hard cap.
+///
+/// A non-positive value (including `0.0`) means "unlimited" — the worker
+/// skips the cost check entirely. NaN is treated as disabled too so that
+/// a malformed config can never block tasks silently.
+fn budget_enforced(budget_usd: f64) -> bool {
+    budget_usd > 0.0
 }
 
 /// Log a skipped task (budget exceeded or empty payload).
@@ -1406,6 +1420,36 @@ fn truncate(s: &str, max: usize) -> &str {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // ─── budget_enforced tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_budget_enforced_positive_value() {
+        assert!(budget_enforced(50.0));
+        assert!(budget_enforced(0.01));
+    }
+
+    #[test]
+    fn test_budget_enforced_zero_is_unlimited() {
+        assert!(!budget_enforced(0.0));
+    }
+
+    #[test]
+    fn test_budget_enforced_negative_is_unlimited() {
+        assert!(!budget_enforced(-1.0));
+    }
+
+    #[test]
+    fn test_budget_enforced_nan_is_unlimited() {
+        assert!(!budget_enforced(f64::NAN));
+    }
+
+    #[test]
+    fn test_check_budget_unlimited_skips_state_lookup() {
+        // A non-existent agent would cause load_state to fail; the early
+        // return on budget_usd == 0.0 must prevent any lookup.
+        assert!(check_budget("definitely-not-an-agent-xyz-387", 0.0).is_none());
+    }
 
     // ─── truncate tests ──────────────────────────────────────────────────────
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,6 +180,8 @@ pub struct AgentDef {
     #[serde(default = "default_command")]
     pub command: Vec<String>,
     /// Budget cap in USD. Worker rejects tasks when exceeded.
+    /// A value of `0` (or any non-positive value) disables the cap and treats
+    /// the agent as having an unlimited budget; see worker::check_budget.
     #[serde(default = "default_budget_usd")]
     pub budget_usd: f64,
     /// Container config. When set, the agent process runs inside a container.


### PR DESCRIPTION
## Summary

`budget_usd: 0` previously rejected every task because `total_cost >= 0` is always true (`worker.rs::check_budget`). This PR makes a non-positive `budget_usd` mean 'unlimited' — the intended sentinel from #387.

## Changes

- `src/app/worker.rs` — extracted a pure `budget_enforced(budget_usd: f64) -> bool` helper. Returns `false` for `0`, negative values, or `NaN` (malformed config must not silently block tasks). `check_budget` short-circuits on that.
- `src/config.rs` — documented the '`0` = unlimited' semantics on the `budget_usd` field.
- `src/app/commands/agent.rs` — `agent stats` and `agent list --detail` now print `Budget: unlimited` when the cap is disabled, instead of `$0.00`.

Behavior for positive budgets is unchanged.

## Acceptance Criteria
- [x] `budget_usd: 0` no longer blocks tasks
- [x] `agent stats` prints `unlimited` when cap is disabled
- [x] Field doc updated
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` passes (459 tests, 0 failures; 5 new tests covering the helper)

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)