### PR TITLE
feat(mcp): agent_logs tool for sub-agent log access

### DIFF
--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -500,6 +500,28 @@ fn handle_tools_list(
             "required": ["name"]
         }
     }));
+    tools.push(json!({
+        "name": "agent_logs",
+        "description": "Read recent log lines captured from a sub-agent's stderr or stream-json stdout. Useful for diagnosing what a worker is doing or why it died. Caller may only read logs of its own sub-agents (or itself).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Agent name"
+                },
+                "source": {
+                    "type": "string",
+                    "description": "'stderr' (default) for plain stderr log, or 'stream' for the Claude stream-json stdout log"
+                },
+                "tail": {
+                    "type": "integer",
+                    "description": "Number of trailing lines to return (1..=1000, default 100)"
+                }
+            },
+            "required": ["name"]
+        }
+    }));
 
     tools.push(json!({
         "name": "usage_stats",
@@ -695,6 +717,7 @@ async fn handle_tools_call(
         "task_cancel" => mcp_tools::call_task_cancel(args, task_store).await,
         "list_agents" => mcp_tools::call_list_agents(agent_name, internal_bus).await,
         "remove_agent" => mcp_tools::call_remove_agent(args, agent_name, internal_bus).await,
+        "agent_logs" => mcp_tools::call_agent_logs(args, agent_name).await,
         "get_scope" => mcp_tools::call_get_scope(agent_name, user_config, internal_bus).await,
         "sm_create" => {
             mcp_tools::call_sm_create(args, agent_name, bus_socket, user_config, sm_store).await

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -888,6 +888,90 @@ pub(crate) async fn call_list_agents(
     }))
 }
 
+/// Read recent log lines captured from a sub-agent's stderr or stream-json
+/// stdout. Access is restricted to sub-agents of the caller (or the caller's
+/// own logs) so an agent cannot peek at a sibling's diagnostics.
+pub(crate) async fn call_agent_logs(args: &Value, caller: &str) -> Result<Value> {
+    let name = args
+        .get("name")
+        .and_then(|v| v.as_str())
+        .context("agent_logs: missing required 'name'")?;
+
+    let tail = args.get("tail").and_then(|v| v.as_u64()).unwrap_or(100) as usize;
+    if tail == 0 || tail > 1000 {
+        bail!("agent_logs: 'tail' must be in 1..=1000 (got {})", tail);
+    }
+
+    let source = args
+        .get("source")
+        .and_then(|v| v.as_str())
+        .unwrap_or("stderr");
+    if source != "stderr" && source != "stream" {
+        bail!(
+            "agent_logs: 'source' must be 'stderr' or 'stream' (got {:?})",
+            source
+        );
+    }
+
+    // Access control: caller may read its own logs or its sub-agents' logs.
+    // Matches the visibility rules of list_agents/remove_agent.
+    if name != caller {
+        let state = crate::app::agent::load_state(name)
+            .with_context(|| format!("agent '{}' not found", name))?;
+        match &state.parent {
+            Some(p) if p == caller => {}
+            _ => bail!(
+                "agent '{}' is not a sub-agent of '{}' — log access denied",
+                name,
+                caller
+            ),
+        }
+    }
+
+    let path = match source {
+        "stream" => crate::app::agent::stream_log_path(name),
+        _ => crate::app::agent::stderr_log_path(name),
+    };
+
+    if !path.exists() {
+        return Ok(json!({
+            "content": [{
+                "type": "text",
+                "text": serde_json::to_string_pretty(&json!({
+                    "name": name,
+                    "source": source,
+                    "path": path.display().to_string(),
+                    "exists": false,
+                    "lines": Vec::<String>::new(),
+                }))?
+            }],
+            "isError": false
+        }));
+    }
+
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("agent_logs: failed to read {}", path.display()))?;
+    let all_lines: Vec<&str> = content.lines().collect();
+    let start = all_lines.len().saturating_sub(tail);
+    let returned: Vec<String> = all_lines[start..].iter().map(|s| s.to_string()).collect();
+
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&json!({
+                "name": name,
+                "source": source,
+                "path": path.display().to_string(),
+                "exists": true,
+                "total_lines": all_lines.len(),
+                "returned_lines": returned.len(),
+                "lines": returned,
+            }))?
+        }],
+        "isError": false
+    }))
+}
+
 pub(crate) async fn call_remove_agent(
     args: &Value,
     caller: &str,
@@ -1540,6 +1624,53 @@ mod tests {
         assert!(glob_match("agent:dev", "agent:dev"));
         assert!(!glob_match("agent:dev", "agent:researcher"));
         assert!(!glob_match("telegram.out:*", "telegram.in:-1234"));
+    }
+
+    #[tokio::test]
+    async fn agent_logs_rejects_missing_name() {
+        let err = call_agent_logs(&json!({}), "caller").await.unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("name"), "expected name error, got: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn agent_logs_rejects_bad_tail() {
+        for bad in [0u64, 5000] {
+            let err = call_agent_logs(&json!({"name": "x", "tail": bad}), "x")
+                .await
+                .unwrap_err();
+            let msg = format!("{:#}", err);
+            assert!(msg.contains("tail"), "expected tail error, got: {}", msg);
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_logs_rejects_bad_source() {
+        let err = call_agent_logs(&json!({"name": "x", "source": "garbage"}), "x")
+            .await
+            .unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("source"),
+            "expected source error, got: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_logs_self_read_nonexistent_returns_exists_false() {
+        // Requesting own logs when the log file does not exist must not error —
+        // it returns `exists: false` so callers can distinguish "no logs yet"
+        // from "access denied" or "bad arg".
+        let unique = format!("__agent_logs_test_{}", Uuid::new_v4());
+        let resp = call_agent_logs(&json!({"name": unique, "tail": 10}), &unique)
+            .await
+            .expect("self-read must not error on missing file");
+        let text = resp["content"][0]["text"].as_str().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["exists"], false);
+        assert_eq!(parsed["source"], "stderr");
+        assert!(parsed["lines"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Implements the `agent_logs` MCP tool (P1 item from kgatilin/deskd#155) so agents can read their sub-agents' logs directly via MCP instead of shelling out to `deskd agent stderr/stream`.

## Tool contract

```
agent_logs(name: str, source?: "stderr"|"stream" = "stderr", tail?: int = 100)
```

Returns JSON with `name`, `source`, `path`, `exists`, `total_lines`, `returned_lines`, `lines[]`.

## Access control

- Caller can read its own logs.
- Caller can read logs of its direct sub-agents (via `AgentState.parent == caller`).
- Anything else → denied, mirroring `validate_remove_agent` in `mcp_service.rs`.

## Safety bounds

- `tail` clamped to `1..=1000` (rejects 0 and >1000).
- `source` must be exactly `stderr` or `stream`.
- Missing log file → returns `exists: false` with empty `lines[]` instead of error, so callers can poll without special-casing cold-start.

## Tests

4 new unit tests in `mcp_tools.rs`:

- `agent_logs_rejects_missing_name`
- `agent_logs_rejects_bad_tail` (0 and 5000)
- `agent_logs_rejects_bad_source`
- `agent_logs_self_read_nonexistent_returns_exists_false`

Quality gate green: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (431 unit + integration tests passing).

## Related

- kgatilin/deskd#155 — parent issue (P1 agent_logs item)
- kgatilin/deskd#391 — companion ACP rich-exit-context landed earlier

🤖 Generated with [Claude Code](https://claude.com/claude-code)