### PR TITLE
feat(acp): ACP client runtime (#93)

### DIFF
--- a/src/app/acp.rs
+++ b/src/app/acp.rs
@@ -150,6 +150,57 @@ pub fn extract_session_id(result: &serde_json::Value) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Resolve MCP servers for an ACP session.
+///
+/// Reads the agent's `deskd.yaml` (if `config_path` is set) to extract
+/// `mcp_config` → `mcpServers`. Always injects a default `deskd` entry
+/// that points at `deskd mcp --agent <name>` so ACP agents get the same
+/// bus access Claude agents do.
+///
+/// Returns `None` only if no servers at all could be resolved (agent name
+/// is empty and no config). In practice a non-empty agent name means we
+/// always return at least the default deskd entry.
+pub fn resolve_mcp_servers(
+    agent_name: &str,
+    config_path: Option<&str>,
+) -> Option<HashMap<String, serde_json::Value>> {
+    let mut servers: HashMap<String, serde_json::Value> = HashMap::new();
+
+    // Pull user-defined mcpServers from the agent's deskd.yaml, if any.
+    if let Some(path) = config_path
+        && !path.is_empty()
+        && let Ok(content) = std::fs::read_to_string(path)
+    {
+        // Parse as a loose YAML Value so we don't couple to UserConfig here.
+        if let Ok(yaml) = serde_yaml::from_str::<serde_json::Value>(&content)
+            && let Some(mcp_str) = yaml.get("mcp_config").and_then(|v| v.as_str())
+            && let Ok(mcp_json) = serde_json::from_str::<serde_json::Value>(mcp_str)
+            && let Some(map) = mcp_json.get("mcpServers").and_then(|v| v.as_object())
+        {
+            for (k, v) in map {
+                servers.insert(k.clone(), v.clone());
+            }
+        }
+    }
+
+    // Always inject a default deskd MCP server so ACP agents get bus tools.
+    if !agent_name.is_empty() {
+        servers.entry("deskd".to_string()).or_insert_with(|| {
+            let deskd_bin = std::env::var("DESKD_BIN").unwrap_or_else(|_| "deskd".to_string());
+            serde_json::json!({
+                "command": deskd_bin,
+                "args": ["mcp", "--agent", agent_name]
+            })
+        });
+    }
+
+    if servers.is_empty() {
+        None
+    } else {
+        Some(servers)
+    }
+}
+
 // ─── AcpProcess: long-lived ACP agent process ───────────────────────────────
 
 /// Events emitted by the ACP stdout reader task.
@@ -484,7 +535,8 @@ impl AcpProcess {
     /// Create a new session and return its ID.
     async fn do_session_new(&self, cfg: &AgentConfig) -> Result<String> {
         let id = self.next_request_id().await;
-        let req = build_session_new(id, &cfg.work_dir, None);
+        let mcp_servers = resolve_mcp_servers(&self.name, cfg.config_path.as_deref());
+        let req = build_session_new(id, &cfg.work_dir, mcp_servers);
         let resp = self.send_request(&req, None).await?;
 
         if let Some(err) = resp.error {
@@ -884,6 +936,70 @@ mod tests {
         // Tail includes the *last* line number, not the first.
         assert!(tail.contains("line 49"));
         assert!(!tail.contains("line 0:"));
+    }
+
+    #[test]
+    fn test_resolve_mcp_servers_injects_default_deskd() {
+        // No config path => only the default deskd server.
+        let servers = resolve_mcp_servers("kira", None).unwrap();
+        assert!(servers.contains_key("deskd"));
+        assert_eq!(servers["deskd"]["args"][2], "kira");
+    }
+
+    #[test]
+    fn test_resolve_mcp_servers_merges_user_config() {
+        // Write a temp deskd.yaml with an mcp_config field.
+        let dir = std::env::temp_dir().join(format!(
+            "deskd-acp-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("deskd.yaml");
+        let yaml = r#"
+mcp_config: '{"mcpServers":{"filesystem":{"command":"mcp-fs","args":["--root","/tmp"]}}}'
+"#;
+        std::fs::write(&path, yaml).unwrap();
+
+        let servers = resolve_mcp_servers("kira", Some(path.to_str().unwrap())).unwrap();
+        assert!(servers.contains_key("deskd"));
+        assert!(servers.contains_key("filesystem"));
+        assert_eq!(servers["filesystem"]["command"], "mcp-fs");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_resolve_mcp_servers_user_deskd_takes_precedence() {
+        // If the user defines their own `deskd` entry, don't clobber it.
+        let dir = std::env::temp_dir().join(format!(
+            "deskd-acp-test-prec-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("deskd.yaml");
+        let yaml = r#"
+mcp_config: '{"mcpServers":{"deskd":{"command":"/custom/deskd","args":["mcp","--agent","override"]}}}'
+"#;
+        std::fs::write(&path, yaml).unwrap();
+
+        let servers = resolve_mcp_servers("kira", Some(path.to_str().unwrap())).unwrap();
+        assert_eq!(servers["deskd"]["command"], "/custom/deskd");
+        assert_eq!(servers["deskd"]["args"][2], "override");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_resolve_mcp_servers_missing_file_ok() {
+        // Non-existent config path should not crash; default deskd still injected.
+        let servers = resolve_mcp_servers("kira", Some("/nonexistent/path/deskd.yaml")).unwrap();
+        assert!(servers.contains_key("deskd"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1109,6 +1109,56 @@ agents:
     }
 
     #[test]
+    fn test_workspace_agent_acp_runtime() {
+        // Issue #93: top-level AgentDef must accept `runtime: acp`.
+        let yaml = r#"
+agents:
+  - name: dev
+    unix_user: dev
+    work_dir: /home/dev
+    runtime: acp
+    command:
+      - gemini
+      - --acp
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.agents[0].runtime, ConfigAgentRuntime::Acp);
+        assert_eq!(cfg.agents[0].command, vec!["gemini", "--acp"]);
+    }
+
+    #[test]
+    fn test_workspace_agent_runtime_defaults_to_claude() {
+        // When `runtime` is unset, behavior must be identical to today.
+        let yaml = r#"
+agents:
+  - name: classic
+    unix_user: dev
+    work_dir: /home/dev
+"#;
+        let cfg: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.agents[0].runtime, ConfigAgentRuntime::Claude);
+    }
+
+    #[test]
+    fn test_sub_agent_acp_runtime() {
+        // Sub-agents (in deskd.yaml) also accept runtime: acp.
+        let yaml = r#"
+model: claude-sonnet-4-6
+system_prompt: "parent"
+
+agents:
+  - name: acp-child
+    model: ignored
+    system_prompt: "ACP sub-agent"
+    subscribe:
+      - "agent:acp-child"
+    runtime: acp
+"#;
+        let cfg: UserConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.agents[0].runtime, ConfigAgentRuntime::Acp);
+    }
+
+    #[test]
     fn test_sub_agent_memory_defaults() {
         let yaml = r#"
 model: claude-sonnet-4-6


### PR DESCRIPTION
Closes #93.

Adds an ACP (Agent Client Protocol — JSON-RPC 2.0 over stdin/stdout) client runtime to deskd worker so deskd can launch any ACP-compatible agent (Gemini CLI `gemini --acp`, Goose `goose acp`, etc.) alongside the existing Claude stream-json runtime.

## Config surface

```yaml
# workspace.yaml — top-level AgentDef
agents:
  - name: dev
    work_dir: /home/dev
    runtime: acp             # new: default `claude` keeps existing behavior
    command: [gemini, --acp]

# deskd.yaml — SubAgentDef
agents:
  - name: acp-child
    runtime: acp
```

`runtime: claude` (or unset) preserves the current stream-json path exactly — no behavior change for existing agents.

## RPC methods implemented (client side)

| Method | Direction | Purpose |
|---|---|---|
| `initialize` | → agent | Handshake, report capabilities (`fs: false`, `terminal: false`) |
| `session/new` | → agent | Create session with `cwd` + `mcpServers` |
| `session/load` | → agent | Resume existing session; falls back to `session/new` on failure |
| `session/prompt` | → agent | Send task text |
| `session/cancel` | → agent | On `stop()`, best-effort cancel |
| `session/update` | ← agent | Streamed into the existing `ProgressSink` pipeline |
| `session/request_permission` | ← agent | Auto-replies `approved: true` (deskd policy: trust the agent) |

## Notification mapping

- `session/update` → classified via `classify_message`, text extracted from `messages[].content` (string or content-block array), forwarded to the existing deskd progress/typing event pipeline via `ProgressSink`.
- `session/request_permission` → auto-approved on the wire before the caller ever sees it.
- Completion: `status: completed|done|ended` ends the prompt loop.

## Session persistence

ACP `sessionId` stored in the same `AgentState.session_id` slot Claude uses. On restart with `session: persistent`, `session/load` is attempted; `session/new` as fallback.

## MCP servers pass-through (new in this PR)

`resolve_mcp_servers(agent_name, config_path)` reads the agent's `deskd.yaml` → `mcp_config` field, extracts `mcpServers`, and always injects a default `deskd` entry pointing at `deskd mcp --agent <name>` so ACP agents get the same bus tools Claude agents do. User-defined `deskd` entry wins (no override).

## Test coverage

- **JSON-RPC framing** (`src/app/jsonrpc.rs`): request serialization, response parsing (success/error/notification), `classify_message` for the three message kinds.
- **ACP message helpers** (`src/app/acp.rs`): `build_initialize`, `build_session_{new,load,prompt,cancel}`, `build_permission_approval`, `extract_update_text` (string + block array + skip non-assistant + empty), `is_session_complete`, `extract_session_id`, `truncate_stderr`.
- **Process supervision**: `ProcessExited` diagnostics (exit code + stderr tail + lifetime) mirrored from the Claude runtime.
- **New**: `resolve_mcp_servers` — default injection, user config merge, user override precedence, missing-file tolerance.
- **New**: config round-trip — `AgentDef` accepts `runtime: acp`, defaults to `claude` when unset, `SubAgentDef` accepts `runtime: acp`.
- **Existing Claude stream-json tests remain green** (438 unit + 30+ integration).

## Quality gate

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (438 lib + all integration suites pass)