### PR TITLE
feat(usage): token usage analytics (#166)

### DIFF
--- a/src/app/acp.rs
+++ b/src/app/acp.rs
@@ -650,6 +650,7 @@ impl AcpProcess {
             cost_usd: 0.0, // ACP doesn't report cost.
             num_turns: assistant_turns,
             token_usage: TokenUsage::default(),
+            tool_use_count: 0,
         })
     }
 

--- a/src/app/agent_process.rs
+++ b/src/app/agent_process.rs
@@ -20,8 +20,9 @@ use super::process_builder::{build_command, inject_required_flags};
 
 /// Events emitted by the stdout reader task.
 enum StdoutEvent {
-    /// A text block from an `assistant` message, with optional usage data.
-    TextBlock(String, Option<TokenUsage>),
+    /// A text block from an `assistant` message, with optional usage data and
+    /// the number of `tool_use` blocks observed in the same message.
+    TextBlock(String, Option<TokenUsage>, u32),
     /// The `result` event marking end of a turn.
     Result(TurnResult),
     /// Process exited (stdout closed) with diagnostic context.
@@ -456,17 +457,25 @@ impl AgentProcess {
                     match v.get("type").and_then(|t| t.as_str()) {
                         Some("assistant") => {
                             let mut block_text = String::new();
+                            let mut tool_uses: u32 = 0;
                             if let Some(blocks) = v
                                 .get("message")
                                 .and_then(|m| m.get("content"))
                                 .and_then(|c| c.as_array())
                             {
                                 for block in blocks {
-                                    if block.get("type").and_then(|t| t.as_str()) == Some("text")
-                                        && let Some(text) =
-                                            block.get("text").and_then(|t| t.as_str())
-                                    {
-                                        block_text.push_str(text);
+                                    match block.get("type").and_then(|t| t.as_str()) {
+                                        Some("text") => {
+                                            if let Some(text) =
+                                                block.get("text").and_then(|t| t.as_str())
+                                            {
+                                                block_text.push_str(text);
+                                            }
+                                        }
+                                        Some("tool_use") => {
+                                            tool_uses = tool_uses.saturating_add(1);
+                                        }
+                                        _ => {}
                                     }
                                 }
                             }
@@ -474,9 +483,9 @@ impl AgentProcess {
                                 .get("message")
                                 .and_then(|m| m.get("usage"))
                                 .map(TokenUsage::from);
-                            if (!block_text.is_empty() || usage.is_some())
+                            if (!block_text.is_empty() || usage.is_some() || tool_uses > 0)
                                 && event_tx
-                                    .send(StdoutEvent::TextBlock(block_text, usage))
+                                    .send(StdoutEvent::TextBlock(block_text, usage, tool_uses))
                                     .is_err()
                             {
                                 break;
@@ -501,6 +510,7 @@ impl AgentProcess {
                                     cost_usd,
                                     num_turns,
                                     token_usage: TokenUsage::default(),
+                                    tool_use_count: 0,
                                 }))
                                 .is_err()
                             {
@@ -656,13 +666,15 @@ impl AgentProcess {
         let mut response_text = String::new();
         let mut assistant_turns = 0u32;
         let mut accumulated_usage = TokenUsage::default();
+        let mut accumulated_tool_uses: u32 = 0;
 
         loop {
             match event_rx.recv().await {
-                Some(StdoutEvent::TextBlock(text, usage)) => {
+                Some(StdoutEvent::TextBlock(text, usage, tool_uses)) => {
                     if let Some(u) = &usage {
                         accumulated_usage.merge(u);
                     }
+                    accumulated_tool_uses = accumulated_tool_uses.saturating_add(tool_uses);
 
                     if !text.is_empty() {
                         assistant_turns += 1;
@@ -691,7 +703,9 @@ impl AgentProcess {
                     }
                 }
                 Some(StdoutEvent::Result(mut result)) => {
-                    while let Ok(StdoutEvent::TextBlock(trailing, _)) = event_rx.try_recv() {
+                    while let Ok(StdoutEvent::TextBlock(trailing, _, trailing_tools)) =
+                        event_rx.try_recv()
+                    {
                         debug!(
                             agent = %self.name,
                             len = trailing.len(),
@@ -701,10 +715,13 @@ impl AgentProcess {
                             sink(trailing.clone());
                         }
                         response_text.push_str(&trailing);
+                        accumulated_tool_uses =
+                            accumulated_tool_uses.saturating_add(trailing_tools);
                     }
 
                     result.response_text = response_text;
                     result.token_usage = accumulated_usage;
+                    result.tool_use_count = accumulated_tool_uses;
 
                     let mut last_cost = self.last_reported_cost.lock().await;
                     let mut last_turns = self.last_reported_turns.lock().await;

--- a/src/app/commands/usage.rs
+++ b/src/app/commands/usage.rs
@@ -18,6 +18,14 @@ pub struct AgentStats {
     pub cache_creation_input_tokens: u64,
     pub cache_read_input_tokens: u64,
     pub duration_ms: u64,
+    /// Number of Claude invocations.
+    pub sessions: u32,
+    /// Number of tool_use blocks emitted across all tasks.
+    pub tool_calls: u32,
+    /// Average input+output tokens per task.
+    pub avg_tokens_per_task: u64,
+    /// Average cost per task (USD).
+    pub avg_cost_per_task: f64,
 }
 
 /// Aggregate stats across all agents.
@@ -34,6 +42,10 @@ pub struct UsageStats {
     /// Cache hit rate (0.0–1.0): cache_read / (cache_read + cache_creation + non-cache input).
     pub cache_hit_rate: f64,
     pub total_duration_ms: u64,
+    /// Total Claude invocations across all tasks.
+    pub total_sessions: u32,
+    /// Total tool_use blocks across all tasks.
+    pub total_tool_calls: u32,
     pub by_agent: Vec<AgentStats>,
 }
 
@@ -87,75 +99,97 @@ fn discover_agents() -> Vec<String> {
 }
 
 /// Compute aggregate usage stats.
+///
+/// Sub-agent attribution: when a tasklog entry has `parent_agent` set, its
+/// usage is added BOTH to the sub-agent's own bucket and to the parent's
+/// "(via sub-agents)" attribution bucket. The parent's totals therefore
+/// reflect the full cost incurred under its delegation tree.
+///
+/// Top-level totals (`total_*`) are summed from raw entries only — they are
+/// NOT double-counted across sub-agent / parent buckets.
 pub fn compute_stats(period: &str, agent_filter: Option<&str>) -> Result<UsageStats> {
     let since = parse_period(period)?;
 
-    let agents = if let Some(name) = agent_filter {
-        vec![name.to_string()]
-    } else {
-        discover_agents()
-    };
+    // Always scan all agents — even when `agent_filter` is set — because
+    // sub-agent entries contribute to their parent's bucket. The display
+    // buckets are post-filtered below using `agent_filter`.
+    let scan_agents = discover_agents();
 
     let mut by_agent: HashMap<String, AgentStats> = HashMap::new();
 
-    for agent_name in &agents {
+    // Top-level totals (sum once per entry, no double-counting).
+    let mut total_tasks: usize = 0;
+    let mut total_cost_usd: f64 = 0.0;
+    let mut total_turns: u32 = 0;
+    let mut total_input_tokens: u64 = 0;
+    let mut total_output_tokens: u64 = 0;
+    let mut total_cache_creation: u64 = 0;
+    let mut total_cache_read: u64 = 0;
+    let mut total_duration_ms: u64 = 0;
+    let mut total_sessions: u32 = 0;
+    let mut total_tool_calls: u32 = 0;
+
+    for agent_name in &scan_agents {
         let entries = tasklog::read_logs(agent_name, usize::MAX, None, since)?;
         if entries.is_empty() {
             continue;
         }
 
-        let stats = by_agent
-            .entry(agent_name.clone())
-            .or_insert_with(|| AgentStats {
-                agent: agent_name.clone(),
-                tasks: 0,
-                cost_usd: 0.0,
-                turns: 0,
-                input_tokens: 0,
-                output_tokens: 0,
-                cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
-                duration_ms: 0,
-            });
-
         for e in &entries {
-            stats.tasks += 1;
-            stats.cost_usd += e.cost;
-            stats.turns += e.turns;
-            stats.input_tokens += e.input_tokens.unwrap_or(0);
-            stats.output_tokens += e.output_tokens.unwrap_or(0);
-            stats.cache_creation_input_tokens += e.cache_creation_input_tokens.unwrap_or(0);
-            stats.cache_read_input_tokens += e.cache_read_input_tokens.unwrap_or(0);
-            stats.duration_ms += e.duration_ms;
+            // Update top-level totals once per raw entry.
+            total_tasks += 1;
+            total_cost_usd += e.cost;
+            total_turns += e.turns;
+            total_input_tokens += e.input_tokens.unwrap_or(0);
+            total_output_tokens += e.output_tokens.unwrap_or(0);
+            total_cache_creation += e.cache_creation_input_tokens.unwrap_or(0);
+            total_cache_read += e.cache_read_input_tokens.unwrap_or(0);
+            total_duration_ms += e.duration_ms;
+            total_sessions += e.session_count.unwrap_or(0);
+            total_tool_calls += e.tool_use_count.unwrap_or(0);
+
+            // Attribute to the agent that ran the task.
+            attribute_entry(&mut by_agent, agent_name, e);
+
+            // Also attribute to the parent agent (if any).
+            if let Some(parent) = e.parent_agent.as_deref()
+                && parent != agent_name
+            {
+                attribute_entry(&mut by_agent, parent, e);
+            }
         }
     }
 
+    // Compute averages.
+    for stats in by_agent.values_mut() {
+        if stats.tasks > 0 {
+            stats.avg_tokens_per_task =
+                (stats.input_tokens + stats.output_tokens) / stats.tasks as u64;
+            stats.avg_cost_per_task = stats.cost_usd / stats.tasks as f64;
+        }
+    }
+
+    // Apply post-filter on displayed buckets.
+    let mut agent_list: Vec<AgentStats> = if let Some(filter) = agent_filter {
+        by_agent
+            .into_values()
+            .filter(|a| a.agent == filter)
+            .collect()
+    } else {
+        by_agent.into_values().collect()
+    };
+
     // Sort by cost descending.
-    let mut agent_list: Vec<AgentStats> = by_agent.into_values().collect();
     agent_list.sort_by(|a, b| {
         b.cost_usd
             .partial_cmp(&a.cost_usd)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let total_tasks = agent_list.iter().map(|a| a.tasks).sum();
-    let total_cost_usd = agent_list.iter().map(|a| a.cost_usd).sum();
-    let total_turns = agent_list.iter().map(|a| a.turns).sum();
-    let total_input_tokens: u64 = agent_list.iter().map(|a| a.input_tokens).sum();
-    let total_output_tokens = agent_list.iter().map(|a| a.output_tokens).sum();
-    let total_cache_creation_input_tokens: u64 = agent_list
-        .iter()
-        .map(|a| a.cache_creation_input_tokens)
-        .sum();
-    let total_cache_read_input_tokens: u64 =
-        agent_list.iter().map(|a| a.cache_read_input_tokens).sum();
-    let total_duration_ms = agent_list.iter().map(|a| a.duration_ms).sum();
-
     // Cache hit rate: proportion of input tokens served from cache.
-    let total_all_input =
-        total_input_tokens + total_cache_creation_input_tokens + total_cache_read_input_tokens;
+    let total_all_input = total_input_tokens + total_cache_creation + total_cache_read;
     let cache_hit_rate = if total_all_input > 0 {
-        total_cache_read_input_tokens as f64 / total_all_input as f64
+        total_cache_read as f64 / total_all_input as f64
     } else {
         0.0
     };
@@ -167,12 +201,50 @@ pub fn compute_stats(period: &str, agent_filter: Option<&str>) -> Result<UsageSt
         total_turns,
         total_input_tokens,
         total_output_tokens,
-        total_cache_creation_input_tokens,
-        total_cache_read_input_tokens,
+        total_cache_creation_input_tokens: total_cache_creation,
+        total_cache_read_input_tokens: total_cache_read,
         cache_hit_rate,
         total_duration_ms,
+        total_sessions,
+        total_tool_calls,
         by_agent: agent_list,
     })
+}
+
+/// Add a tasklog entry's usage into the named agent's bucket.
+fn attribute_entry(
+    by_agent: &mut HashMap<String, AgentStats>,
+    agent_name: &str,
+    e: &tasklog::TaskLog,
+) {
+    let stats = by_agent
+        .entry(agent_name.to_string())
+        .or_insert_with(|| AgentStats {
+            agent: agent_name.to_string(),
+            tasks: 0,
+            cost_usd: 0.0,
+            turns: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            duration_ms: 0,
+            sessions: 0,
+            tool_calls: 0,
+            avg_tokens_per_task: 0,
+            avg_cost_per_task: 0.0,
+        });
+
+    stats.tasks += 1;
+    stats.cost_usd += e.cost;
+    stats.turns += e.turns;
+    stats.input_tokens += e.input_tokens.unwrap_or(0);
+    stats.output_tokens += e.output_tokens.unwrap_or(0);
+    stats.cache_creation_input_tokens += e.cache_creation_input_tokens.unwrap_or(0);
+    stats.cache_read_input_tokens += e.cache_read_input_tokens.unwrap_or(0);
+    stats.duration_ms += e.duration_ms;
+    stats.sessions += e.session_count.unwrap_or(0);
+    stats.tool_calls += e.tool_use_count.unwrap_or(0);
 }
 
 /// Format token count as human-readable.
@@ -191,18 +263,20 @@ fn format_tokens(n: u64) -> String {
 /// Print usage stats as a table.
 pub fn print_table(stats: &UsageStats) {
     println!("Token Usage ({})", stats.period);
-    println!("{}", "─".repeat(75));
+    println!("{}", "─".repeat(95));
     println!(
-        "{:<20} {:>5}  {:>7}  {:>8}  {:>8}  {:>9}",
-        "Agent", "Tasks", "Cost", "Input", "Output", "Duration"
+        "{:<20} {:>5}  {:>4}  {:>5}  {:>7}  {:>8}  {:>8}  {:>9}",
+        "Agent", "Tasks", "Sess", "Tools", "Cost", "Input", "Output", "Duration"
     );
-    println!("{}", "─".repeat(75));
+    println!("{}", "─".repeat(95));
 
     for a in &stats.by_agent {
         println!(
-            "{:<20} {:>5}  ${:>6.2}  {:>8}  {:>8}  {:>9}",
+            "{:<20} {:>5}  {:>4}  {:>5}  ${:>6.2}  {:>8}  {:>8}  {:>9}",
             a.agent,
             a.tasks,
+            a.sessions,
+            a.tool_calls,
             a.cost_usd,
             format_tokens(a.input_tokens),
             format_tokens(a.output_tokens),
@@ -210,11 +284,13 @@ pub fn print_table(stats: &UsageStats) {
         );
     }
 
-    println!("{}", "─".repeat(75));
+    println!("{}", "─".repeat(95));
     println!(
-        "{:<20} {:>5}  ${:>6.2}  {:>8}  {:>8}  {:>9}",
+        "{:<20} {:>5}  {:>4}  {:>5}  ${:>6.2}  {:>8}  {:>8}  {:>9}",
         "TOTAL",
         stats.total_tasks,
+        stats.total_sessions,
+        stats.total_tool_calls,
         stats.total_cost_usd,
         format_tokens(stats.total_input_tokens),
         format_tokens(stats.total_output_tokens),
@@ -229,6 +305,7 @@ pub fn print_table(stats: &UsageStats) {
             format_tokens(stats.total_output_tokens / stats.total_tasks as u64),
             stats.total_cost_usd / stats.total_tasks as f64,
         );
+        println!("Cache hit rate: {:.1}%", stats.cache_hit_rate * 100.0);
     }
 }
 
@@ -321,6 +398,8 @@ mod tests {
             total_cache_read_input_tokens: 80_000,
             cache_hit_rate: 80_000.0 / (100_000.0 + 5_000.0 + 80_000.0),
             total_duration_ms: 300_000,
+            total_sessions: 10,
+            total_tool_calls: 25,
             by_agent: vec![AgentStats {
                 agent: "test".to_string(),
                 tasks: 10,
@@ -331,6 +410,10 @@ mod tests {
                 cache_creation_input_tokens: 5_000,
                 cache_read_input_tokens: 80_000,
                 duration_ms: 300_000,
+                sessions: 10,
+                tool_calls: 25,
+                avg_tokens_per_task: 12_500,
+                avg_cost_per_task: 0.55,
             }],
         };
         let json = serde_json::to_string(&stats).unwrap();
@@ -339,5 +422,169 @@ mod tests {
         assert!(json.contains("\"total_cache_creation_input_tokens\":5000"));
         assert!(json.contains("\"total_cache_read_input_tokens\":80000"));
         assert!(json.contains("\"cache_hit_rate\":"));
+        assert!(json.contains("\"total_sessions\":10"));
+        assert!(json.contains("\"total_tool_calls\":25"));
+        assert!(json.contains("\"sessions\":10"));
+        assert!(json.contains("\"tool_calls\":25"));
+        assert!(json.contains("\"avg_tokens_per_task\":12500"));
+    }
+
+    /// Verify aggregation uses session_count, tool_use_count, and parent_agent
+    /// from raw entries, attributing usage to both the sub-agent and its parent.
+    #[test]
+    fn test_subagent_attribution_logic() {
+        use super::tasklog::TaskLog;
+
+        let mut by_agent: HashMap<String, AgentStats> = HashMap::new();
+        let entry = TaskLog {
+            ts: "2026-04-24T10:00:00Z".to_string(),
+            source: "telegram".to_string(),
+            turns: 3,
+            cost: 0.10,
+            duration_ms: 5_000,
+            status: "ok".to_string(),
+            task: "test".to_string(),
+            error: None,
+            msg_id: "m1".to_string(),
+            github_repo: None,
+            github_pr: None,
+            input_tokens: Some(1_000),
+            output_tokens: Some(200),
+            cache_creation_input_tokens: Some(50),
+            cache_read_input_tokens: Some(800),
+            session_count: Some(1),
+            tool_use_count: Some(4),
+            parent_agent: Some("kira".to_string()),
+        };
+
+        // Attribute to sub-agent and parent (matches compute_stats inner loop).
+        attribute_entry(&mut by_agent, "kira-helper", &entry);
+        attribute_entry(&mut by_agent, "kira", &entry);
+
+        let helper = by_agent.get("kira-helper").unwrap();
+        let parent = by_agent.get("kira").unwrap();
+
+        assert_eq!(helper.tasks, 1);
+        assert_eq!(parent.tasks, 1);
+        assert_eq!(helper.cost_usd, 0.10);
+        assert_eq!(parent.cost_usd, 0.10);
+        assert_eq!(helper.tool_calls, 4);
+        assert_eq!(parent.tool_calls, 4);
+        assert_eq!(helper.sessions, 1);
+        assert_eq!(parent.sessions, 1);
+        assert_eq!(helper.input_tokens, 1_000);
+        assert_eq!(parent.input_tokens, 1_000);
+    }
+
+    #[test]
+    fn test_compute_stats_attributes_subagent_to_parent() {
+        // Set up isolated HOME with two agents: parent "p1" and sub-agent "p1-sub".
+        let tmp = std::path::PathBuf::from(format!(
+            "/tmp/deskd-test-usage-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let logs = tmp.join(".deskd").join("logs");
+        std::fs::create_dir_all(logs.join("p1")).unwrap();
+        std::fs::create_dir_all(logs.join("p1-sub")).unwrap();
+
+        // Helper to write one entry.
+        let write_entry =
+            |dir: &str, parent: Option<&str>, cost: f64, in_tok: u64, out_tok: u64, tool: u32| {
+                let entry = tasklog::TaskLog {
+                    ts: chrono::Utc::now().to_rfc3339(),
+                    source: "test".to_string(),
+                    turns: 1,
+                    cost,
+                    duration_ms: 1_000,
+                    status: "ok".to_string(),
+                    task: "t".to_string(),
+                    error: None,
+                    msg_id: "m".to_string(),
+                    github_repo: None,
+                    github_pr: None,
+                    input_tokens: Some(in_tok),
+                    output_tokens: Some(out_tok),
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                    session_count: Some(1),
+                    tool_use_count: Some(tool),
+                    parent_agent: parent.map(str::to_string),
+                };
+                let line = serde_json::to_string(&entry).unwrap();
+                let path = logs.join(dir).join("tasks.jsonl");
+                let mut f = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&path)
+                    .unwrap();
+                use std::io::Write;
+                writeln!(f, "{}", line).unwrap();
+            };
+
+        write_entry("p1", None, 1.00, 1_000, 100, 2);
+        write_entry("p1-sub", Some("p1"), 0.50, 500, 50, 3);
+
+        // Override HOME for this test.
+        // SAFETY: tests run sequentially; restore HOME on exit.
+        // (single-threaded test runner not guaranteed, so we do best-effort cleanup).
+        let prev_home = std::env::var("HOME").ok();
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+
+        let stats = compute_stats("all", None).unwrap();
+
+        // Restore HOME first to keep test environment hygienic.
+        unsafe {
+            if let Some(h) = prev_home {
+                std::env::set_var("HOME", h);
+            } else {
+                std::env::remove_var("HOME");
+            }
+        }
+
+        // Top-level totals: only the two raw entries.
+        assert_eq!(stats.total_tasks, 2, "raw entries summed once");
+        assert!((stats.total_cost_usd - 1.50).abs() < 1e-9);
+        assert_eq!(stats.total_tool_calls, 5);
+        assert_eq!(stats.total_sessions, 2);
+
+        // Sub-agent bucket: 1 task, 0.50 cost.
+        let sub = stats
+            .by_agent
+            .iter()
+            .find(|a| a.agent == "p1-sub")
+            .expect("sub-agent bucket present");
+        assert_eq!(sub.tasks, 1);
+        assert!((sub.cost_usd - 0.50).abs() < 1e-9);
+        assert_eq!(sub.tool_calls, 3);
+
+        // Parent bucket: 2 tasks (own + sub-agent's), 1.50 cost.
+        let parent = stats
+            .by_agent
+            .iter()
+            .find(|a| a.agent == "p1")
+            .expect("parent bucket present");
+        assert_eq!(parent.tasks, 2);
+        assert!((parent.cost_usd - 1.50).abs() < 1e-9);
+        assert_eq!(parent.tool_calls, 5);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_tasklog_backward_compat() {
+        // Old-style JSONL line without session_count, tool_use_count, parent_agent
+        // must still parse via serde(default).
+        let old_line = r#"{"ts":"2026-04-01T00:00:00Z","source":"telegram","turns":3,"cost":0.42,"duration_ms":1000,"status":"ok","task":"old task","error":null,"msg_id":"m1"}"#;
+        let entry: tasklog::TaskLog = serde_json::from_str(old_line).unwrap();
+        assert_eq!(entry.turns, 3);
+        assert_eq!(entry.session_count, None);
+        assert_eq!(entry.tool_use_count, None);
+        assert_eq!(entry.parent_agent, None);
     }
 }

--- a/src/app/tasklog.rs
+++ b/src/app/tasklog.rs
@@ -46,6 +46,15 @@ pub struct TaskLog {
     /// Tokens read from cache.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cache_read_input_tokens: Option<u64>,
+    /// Number of Claude invocations (sessions) for this task. Defaults to 1 per task.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub session_count: Option<u32>,
+    /// Number of tool_use blocks emitted by Claude during this task.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tool_use_count: Option<u32>,
+    /// Name of the parent agent if this task ran in a sub-agent. Used for usage attribution.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub parent_agent: Option<String>,
 }
 
 /// Return the path to the task log file for a given agent.
@@ -452,6 +461,9 @@ mod tests {
             output_tokens: None,
             cache_creation_input_tokens: None,
             cache_read_input_tokens: None,
+            session_count: None,
+            tool_use_count: None,
+            parent_agent: None,
         }
     }
 
@@ -505,6 +517,9 @@ mod tests {
                     output_tokens: None,
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
+                    session_count: None,
+                    tool_use_count: None,
+                    parent_agent: None,
                 };
                 let line = serde_json::to_string(&entry).unwrap();
                 writeln!(file, "{}", line).unwrap();

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -371,6 +371,7 @@ pub async fn run(
             None => {
                 debug!(agent = %name, "message has no task payload, skipping");
                 // Log empty message with minimal context.
+                let parent_agent = agent::load_state(name).ok().and_then(|s| s.parent);
                 let empty_log = tasklog::TaskLog {
                     ts: chrono::Utc::now().to_rfc3339(),
                     source: msg.source.clone(),
@@ -391,6 +392,9 @@ pub async fn run(
                     output_tokens: None,
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
+                    session_count: None,
+                    tool_use_count: None,
+                    parent_agent,
                 };
                 if let Err(e) = tasklog::log_task(name, &empty_log) {
                     warn!(agent = %name, error = %e, "failed to write task log");
@@ -926,6 +930,7 @@ fn budget_enforced(budget_usd: f64) -> bool {
 
 /// Log a skipped task (budget exceeded or empty payload).
 fn log_skip(name: &str, msg: &Message, ctx: &TaskContext, status: &str, error: Option<&str>) {
+    let parent_agent = agent::load_state(name).ok().and_then(|s| s.parent);
     let log_entry = tasklog::TaskLog {
         ts: chrono::Utc::now().to_rfc3339(),
         source: msg.source.clone(),
@@ -942,6 +947,9 @@ fn log_skip(name: &str, msg: &Message, ctx: &TaskContext, status: &str, error: O
         output_tokens: None,
         cache_creation_input_tokens: None,
         cache_read_input_tokens: None,
+        session_count: None,
+        tool_use_count: None,
+        parent_agent,
     };
     if let Err(e) = tasklog::log_task(name, &log_entry) {
         warn!(agent = %name, error = %e, "failed to write task log");
@@ -1028,6 +1036,7 @@ async fn handle_task_success(
         ctx.github_pr,
     );
 
+    let parent_agent = agent::load_state(name).ok().and_then(|s| s.parent);
     let log_entry = tasklog::TaskLog {
         ts: chrono::Utc::now().to_rfc3339(),
         source: msg.source.clone(),
@@ -1044,6 +1053,9 @@ async fn handle_task_success(
         output_tokens: Some(turn.token_usage.output_tokens),
         cache_creation_input_tokens: Some(turn.token_usage.cache_creation_input_tokens),
         cache_read_input_tokens: Some(turn.token_usage.cache_read_input_tokens),
+        session_count: Some(1),
+        tool_use_count: Some(turn.tool_use_count),
+        parent_agent,
     };
     if let Err(e) = tasklog::log_task(name, &log_entry) {
         warn!(agent = %name, error = %e, "failed to write task log");
@@ -1121,6 +1133,7 @@ async fn handle_task_failure(
     let err_str = format!("{}", error);
     warn!(agent = %name, error = %err_str, "task failed");
 
+    let parent_agent = agent::load_state(name).ok().and_then(|s| s.parent);
     let log_entry = tasklog::TaskLog {
         ts: chrono::Utc::now().to_rfc3339(),
         source: msg.source.clone(),
@@ -1137,6 +1150,9 @@ async fn handle_task_failure(
         output_tokens: None,
         cache_creation_input_tokens: None,
         cache_read_input_tokens: None,
+        session_count: None,
+        tool_use_count: None,
+        parent_agent,
     };
     if let Err(le) = tasklog::log_task(name, &log_entry) {
         warn!(agent = %name, error = %le, "failed to write task log");

--- a/src/ports/executor.rs
+++ b/src/ports/executor.rs
@@ -42,12 +42,15 @@ pub struct TaskLimits {
 }
 
 /// Result of a single executor turn (task completion).
+#[derive(Debug, Default, Clone)]
 pub struct TurnResult {
     pub response_text: String,
     pub session_id: String,
     pub cost_usd: f64,
     pub num_turns: u32,
     pub token_usage: TokenUsage,
+    /// Number of tool_use blocks emitted by the model during this task.
+    pub tool_use_count: u32,
 }
 
 /// Abstraction over LLM execution backends.

--- a/tests/budget_enforcement.rs
+++ b/tests/budget_enforcement.rs
@@ -168,6 +168,9 @@ async fn test_budget_exceeded_sends_error_and_logs() {
         output_tokens: None,
         cache_creation_input_tokens: None,
         cache_read_input_tokens: None,
+        session_count: None,
+        tool_use_count: None,
+        parent_agent: None,
     };
     deskd::app::tasklog::log_task_to_path(&log_path, &log_entry).unwrap();
 

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -316,6 +316,9 @@ async fn test_tasklog_records_crash_error() {
         output_tokens: Some(200),
         cache_creation_input_tokens: Some(500),
         cache_read_input_tokens: Some(800),
+        session_count: Some(1),
+        tool_use_count: Some(0),
+        parent_agent: None,
     };
 
     let log_file = log_dir.join("crash-test-agent.jsonl");


### PR DESCRIPTION
Closes #166.

Extends the existing `deskd usage` / `usage_stats` analytics with the
remaining signals called out in the issue: session count, tool-use count,
and sub-agent attribution.

## What changed

**TaskLog** (`src/app/tasklog.rs`) gains three optional fields, all
`#[serde(default, skip_serializing_if = \"Option::is_none\")]` so existing
JSONL entries parse unchanged:
- `session_count: Option<u32>` — Claude invocations per task
- `tool_use_count: Option<u32>` — tool_use blocks emitted by the model
- `parent_agent: Option<String>` — parent agent if this ran as a sub-agent

**Stream-json parser** (`src/app/agent_process.rs`) now counts `tool_use`
content blocks in assistant messages and threads the count through
`TurnResult.tool_use_count`.

**Worker** (`src/app/worker.rs`) reads `AgentState.parent` and writes it
into every tasklog entry it produces (success / failure / skip / empty).

**Aggregator** (`src/app/commands/usage.rs`): when an entry has
`parent_agent` set, it is attributed to BOTH the executing agent's bucket
and the parent's bucket, so the parent's totals reflect the full cost
incurred under its delegation tree. Top-level totals remain summed from
raw entries only — no double-counting.

**Display**: table output adds Sess / Tools columns and a cache-hit-rate
footer; JSON output gains `total_sessions`, `total_tool_calls`, per-agent
`sessions`, `tool_calls`, `avg_tokens_per_task`, `avg_cost_per_task`.

## Acceptance criteria

- [x] CLI: `deskd usage [--period today|24h|7d|30d|all] [--agent X] [--format table|json]` — already wired in main.rs, now surfaces the new columns
- [x] MCP: `usage_stats` tool returns the enriched schema
- [x] session_count tracked per task
- [x] tool_use_count tracked per task (from stream-json tool_use blocks)
- [x] Sub-agent attribution: parent bucket aggregates sub-agent usage
- [x] Backward compat: old JSONL entries still parse (test covers)
- [x] Tests pass: 482 tests, 0 failed

## Quality gate

- `cargo fmt --check` — OK
- `cargo test` — 482 passed, 0 failed
- `cargo clippy --lib` — OK (no warnings in modified code)
- `cargo clippy --all-targets` — fails on 3 pre-existing issues in files NOT touched by this PR:
  - `tests/crash_recovery.rs:303` (approximate PI constants) — pre-existing
  - `tests/workflow_transitions.rs` (unused vars, collapsible_if) — pre-existing
  - `src/app/workflow.rs:1629` and `src/app/worker.rs:1798` (cloned_ref_to_slice_refs, useless_vec) — both `git blame`d to commit `3ae00720` from 2026-04-15, unrelated to this PR

I can open a follow-up to fix those clippy warnings separately so this PR stays focused on #166.

## Deferred

None — the full scope of #166 is covered.