### PR TITLE
feat(context): per-model windows + auto-compact threshold (#402)

### DIFF
--- a/src/app/agent_registry.rs
+++ b/src/app/agent_registry.rs
@@ -51,6 +51,12 @@ pub struct AgentConfig {
     /// Default: 0.8.
     #[serde(default)]
     pub compact_threshold: Option<f64>,
+    /// Auto-compact threshold in absolute tokens. When the live context size
+    /// crosses this value, `/context` surfaces a warning. Resolution order in
+    /// configs: per-agent (SubAgentDef) > global (UserConfig) > built-in default
+    /// (`context_size::DEFAULT_AUTO_COMPACT_THRESHOLD`, 300k).
+    #[serde(default)]
+    pub auto_compact_threshold_tokens: Option<u64>,
 }
 
 fn default_budget_usd() -> f64 {
@@ -256,6 +262,7 @@ pub async fn create_or_recover(
         runtime: def.runtime.clone(),
         context: user_cfg.and_then(|c| c.context.clone()),
         compact_threshold: None,
+        auto_compact_threshold_tokens: user_cfg.and_then(|c| c.auto_compact_threshold_tokens),
     };
 
     let path = state_path(&def.name);
@@ -677,6 +684,7 @@ pub async fn spawn_ephemeral(
         runtime: ConfigAgentRuntime::default(),
         context: None,
         compact_threshold: None,
+        auto_compact_threshold_tokens: None,
     };
 
     create(&cfg).await?;
@@ -732,6 +740,7 @@ created_at: "2024-01-01T00:00:00Z"
             runtime: ConfigAgentRuntime::default(),
             context: None,
             compact_threshold: None,
+            auto_compact_threshold_tokens: None,
         };
         let state = AgentState {
             config: cfg,
@@ -795,6 +804,7 @@ created_at: "2024-01-01T00:00:00Z"
             runtime: ConfigAgentRuntime::default(),
             context: None,
             compact_threshold: None,
+            auto_compact_threshold_tokens: None,
         };
         let state = AgentState {
             config: cfg,

--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -40,6 +40,7 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 runtime: crate::domain::config_types::ConfigAgentRuntime::default(),
                 context: None,
                 compact_threshold: None,
+                auto_compact_threshold_tokens: None,
             };
             let state = agent::create(&cfg).await?;
             println!("Agent {} created", state.config.name);

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -170,6 +170,9 @@ pub async fn spawn_components(
                 runtime: sub.runtime.clone(),
                 context: context_cfg,
                 compact_threshold: sub.compact_threshold,
+                auto_compact_threshold_tokens: sub
+                    .auto_compact_threshold_tokens
+                    .or(ucfg.auto_compact_threshold_tokens),
             };
             crate::app::agent::create_or_update_from_config(&sub_cfg).await?;
 

--- a/src/app/context_size.rs
+++ b/src/app/context_size.rs
@@ -15,12 +15,20 @@ use chrono::DateTime;
 use crate::app::agent_registry::AgentState;
 use crate::app::tasklog::{self, TaskLog};
 
-/// Default context window for Claude models (Opus 4.x / Sonnet / Haiku all
-/// share a 200k token window today).
+/// Default context window for unrecognised / Claude 3.x models (200k tokens).
 pub const DEFAULT_CONTEXT_WINDOW: u64 = 200_000;
 
-/// Threshold (fraction of context window) at which we surface a warning
-/// indicator. Matches the conventional 80% compaction trigger.
+/// Context window for the Claude 4.x family (Opus / Sonnet / Haiku 4.x all
+/// ship with a 1M token window).
+pub const CONTEXT_WINDOW_4X: u64 = 1_000_000;
+
+/// Built-in fallback for the auto-compact threshold when no per-agent or
+/// global override is configured. Konstantin's chosen default per #402.
+pub const DEFAULT_AUTO_COMPACT_THRESHOLD: u64 = 300_000;
+
+/// Fraction of the auto-compact threshold at which we surface a warning
+/// indicator. Matches the conventional 80% compaction trigger but is now
+/// expressed relative to the configured threshold, not the model window.
 pub const WARN_THRESHOLD: f64 = 0.80;
 
 /// One row in the `/context` snapshot — a single agent's current session.
@@ -35,6 +43,9 @@ pub struct SessionContext {
     pub context_tokens: Option<u64>,
     /// Context window for the model in use.
     pub context_limit: u64,
+    /// Resolved auto-compact threshold for this agent (per-agent override,
+    /// global default, or built-in fallback).
+    pub auto_compact_threshold: u64,
 }
 
 impl SessionContext {
@@ -50,11 +61,14 @@ impl SessionContext {
         }
     }
 
-    /// Fraction of the window consumed. Returns 0.0 when token data is
-    /// unavailable so callers can branch cleanly without unwrapping.
+    /// Fraction of the configured auto-compact threshold consumed.
+    /// Returns 0.0 when token data is unavailable so callers can branch
+    /// cleanly without unwrapping.
     pub fn utilization(&self) -> f64 {
         match self.context_tokens {
-            Some(t) if self.context_limit > 0 => t as f64 / self.context_limit as f64,
+            Some(t) if self.auto_compact_threshold > 0 => {
+                t as f64 / self.auto_compact_threshold as f64
+            }
             _ => 0.0,
         }
     }
@@ -66,11 +80,60 @@ impl SessionContext {
 
 /// Pick the context window size for a given Claude model name.
 ///
-/// All current Claude families (Opus, Sonnet, Haiku, including the 4.x
-/// generation) ship with a 200k window, so we just default to that. The
-/// helper exists so future per-model overrides have one obvious place to live.
-pub fn context_window_for_model(_model: &str) -> u64 {
-    DEFAULT_CONTEXT_WINDOW
+/// Claude 4.x family (Opus, Sonnet, Haiku) ships with a 1M window. The
+/// 3.x family and any unrecognised id fall back to the 200k default.
+///
+/// Match is done on a normalised lowercase version of the model id and
+/// looks for the family prefix `claude-(opus|sonnet|haiku)-4-` so it
+/// covers `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`,
+/// etc. Future families should be added explicitly.
+pub fn context_window_for_model(model: &str) -> u64 {
+    let m = model.to_ascii_lowercase();
+    if m.starts_with("claude-opus-4-")
+        || m.starts_with("claude-sonnet-4-")
+        || m.starts_with("claude-haiku-4-")
+    {
+        CONTEXT_WINDOW_4X
+    } else {
+        DEFAULT_CONTEXT_WINDOW
+    }
+}
+
+/// Resolve the auto-compact threshold for an agent, falling back to the
+/// built-in default when the config does not specify one.
+pub fn resolve_auto_compact_threshold(configured: Option<u64>) -> u64 {
+    configured
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT_AUTO_COMPACT_THRESHOLD)
+}
+
+/// Upper bound for `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`. Claude Code silently
+/// clamps anything above ~83% to its default (per anthropics/claude-code#31806),
+/// so we cap there ourselves and log a warning when the configured threshold
+/// would have wanted more.
+pub const AUTO_COMPACT_PCT_CEILING: u8 = 83;
+
+/// Compute the `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` percentage to inject into
+/// the agent process. Claude Code expects an integer 1–100; values >83 are
+/// dropped. Returns `None` when we cannot meaningfully derive a percentage
+/// (e.g. zero window).
+pub fn auto_compact_override_pct(threshold_tokens: u64, window_tokens: u64) -> Option<u8> {
+    if window_tokens == 0 {
+        return None;
+    }
+    let raw = (threshold_tokens as f64 / window_tokens as f64 * 100.0).round() as i64;
+    Some(raw.clamp(1, AUTO_COMPACT_PCT_CEILING as i64) as u8)
+}
+
+/// True when the configured threshold lies on or above the ceiling and would
+/// therefore be silently clamped by Claude Code. Caller can log a warning so
+/// the user knows their override is ineffective.
+pub fn threshold_would_clamp(threshold_tokens: u64, window_tokens: u64) -> bool {
+    if window_tokens == 0 {
+        return false;
+    }
+    let pct = threshold_tokens as f64 / window_tokens as f64 * 100.0;
+    pct >= AUTO_COMPACT_PCT_CEILING as f64
 }
 
 /// Determine whether an agent's process is currently running.
@@ -141,6 +204,9 @@ fn snapshot_for(state: &AgentState) -> Option<SessionContext> {
         session_id: state.session_id.clone(),
         context_tokens,
         context_limit: context_window_for_model(&state.config.model),
+        auto_compact_threshold: resolve_auto_compact_threshold(
+            state.config.auto_compact_threshold_tokens,
+        ),
     })
 }
 
@@ -186,24 +252,36 @@ pub fn format_reply(snapshot: &[SessionContext]) -> String {
 
     for s in snapshot {
         let limit = format_tokens_compact(s.context_limit);
+        let threshold = format_tokens_compact(s.auto_compact_threshold);
+        // Show the percentage Claude Code will actually see (matches the
+        // CLAUDE_AUTOCOMPACT_PCT_OVERRIDE we inject) so the displayed
+        // threshold and the runtime behaviour stay in sync.
+        let pct_str = match auto_compact_override_pct(s.auto_compact_threshold, s.context_limit) {
+            Some(p) => format!(" = {}%", p),
+            None => String::new(),
+        };
         let line = match s.context_tokens {
             Some(tokens) => {
                 let used = format_tokens_compact(tokens);
                 let warn = if s.is_warning() { "  ⚠️" } else { "" };
                 format!(
-                    "{} (session {})  ~{} / {}{}",
+                    "{} (session {})  ~{} / {}  (auto-compact at {}{}){}",
                     s.agent,
                     s.session_short(),
                     used,
                     limit,
+                    threshold,
+                    pct_str,
                     warn
                 )
             }
             None => format!(
-                "{} (session {})  n/a / {}",
+                "{} (session {})  n/a / {}  (auto-compact at {}{})",
                 s.agent,
                 s.session_short(),
-                limit
+                limit,
+                threshold,
+                pct_str
             ),
         };
         lines.push(line);
@@ -260,6 +338,7 @@ mod tests {
             session_id: "abcdef0123456789".into(),
             context_tokens: Some(100),
             context_limit: 200_000,
+            auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
         };
         assert_eq!(s.session_short(), "abcdef01");
     }
@@ -272,6 +351,7 @@ mod tests {
             session_id: "abc".into(),
             context_tokens: None,
             context_limit: 200_000,
+            auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
         };
         assert_eq!(s.session_short(), "abc");
         s.session_id = "   ".into();
@@ -279,17 +359,36 @@ mod tests {
     }
 
     #[test]
-    fn warning_triggers_above_eighty_percent() {
+    fn warning_triggers_above_eighty_percent_of_threshold() {
+        // Warning is now relative to auto_compact_threshold, not context_limit.
+        // 80% of 300k = 240k.
         let mut s = SessionContext {
             agent: "a".into(),
-            model: "claude-opus-4".into(),
+            model: "claude-opus-4-7".into(),
             session_id: "xxxxxxxx".into(),
-            context_tokens: Some(160_000),
-            context_limit: 200_000,
+            context_tokens: Some(240_000),
+            context_limit: CONTEXT_WINDOW_4X,
+            auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
         };
         assert!(s.is_warning());
-        s.context_tokens = Some(159_999);
+        s.context_tokens = Some(239_999);
         assert!(!s.is_warning());
+    }
+
+    #[test]
+    fn warning_uses_per_agent_threshold_not_model_window() {
+        // 600k tokens with a 1M model window would be 60% of the window
+        // (no warning under the old logic). With auto_compact at 500k,
+        // it's 120% of the threshold → warning.
+        let s = SessionContext {
+            agent: "dev".into(),
+            model: "claude-opus-4-7".into(),
+            session_id: "yyyy".into(),
+            context_tokens: Some(600_000),
+            context_limit: CONTEXT_WINDOW_4X,
+            auto_compact_threshold: 500_000,
+        };
+        assert!(s.is_warning());
     }
 
     #[test]
@@ -309,20 +408,25 @@ mod tests {
 
     #[test]
     fn format_reply_renders_lines_with_warning() {
+        // Mix of 4.x (1M window) and unknown (200k window) agents, with the
+        // default 300k auto-compact threshold used throughout. The middle
+        // entry crosses 80% of 300k = 240k, so it should show ⚠️.
         let snap = vec![
             SessionContext {
                 agent: "agent-a".into(),
-                model: "claude-opus-4".into(),
+                model: "claude-opus-4-7".into(),
                 session_id: "abc12345xx".into(),
                 context_tokens: Some(45_000),
-                context_limit: 200_000,
+                context_limit: CONTEXT_WINDOW_4X,
+                auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
             },
             SessionContext {
                 agent: "agent-a".into(),
-                model: "claude-opus-4".into(),
+                model: "claude-opus-4-7".into(),
                 session_id: "def45678yy".into(),
-                context_tokens: Some(180_000),
-                context_limit: 200_000,
+                context_tokens: Some(260_000),
+                context_limit: CONTEXT_WINDOW_4X,
+                auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
             },
             SessionContext {
                 agent: "agent-b".into(),
@@ -330,20 +434,92 @@ mod tests {
                 session_id: "ghi78901zz".into(),
                 context_tokens: None,
                 context_limit: 200_000,
+                auto_compact_threshold: DEFAULT_AUTO_COMPACT_THRESHOLD,
             },
         ];
         let reply = format_reply(&snap);
         assert!(reply.starts_with("/context\n"));
-        assert!(reply.contains("agent-a (session abc12345)  ~45k / 200k"));
-        assert!(reply.contains("agent-a (session def45678)  ~180k / 200k  ⚠️"));
-        assert!(reply.contains("agent-b (session ghi78901)  n/a / 200k"));
+        // 300k of 1M = 30%.
+        assert!(
+            reply
+                .contains("agent-a (session abc12345)  ~45k / 1000k  (auto-compact at 300k = 30%)")
+        );
+        assert!(reply.contains(
+            "agent-a (session def45678)  ~260k / 1000k  (auto-compact at 300k = 30%)  ⚠️"
+        ));
+        // 300k of 200k clamps to 83%.
+        assert!(
+            reply.contains("agent-b (session ghi78901)  n/a / 200k  (auto-compact at 300k = 83%)")
+        );
     }
 
     #[test]
-    fn context_window_defaults_to_two_hundred_k() {
-        assert_eq!(context_window_for_model("claude-opus-4"), 200_000);
-        assert_eq!(context_window_for_model("claude-sonnet-4-6"), 200_000);
+    fn context_window_for_4x_family_is_one_million() {
+        assert_eq!(context_window_for_model("claude-opus-4-7"), 1_000_000);
+        assert_eq!(context_window_for_model("claude-opus-4-6"), 1_000_000);
+        assert_eq!(context_window_for_model("claude-sonnet-4-6"), 1_000_000);
+        assert_eq!(context_window_for_model("claude-haiku-4-5"), 1_000_000);
+        // Case-insensitive matching.
+        assert_eq!(context_window_for_model("Claude-Opus-4-7"), 1_000_000);
+    }
+
+    #[test]
+    fn context_window_for_3x_and_unknown_is_two_hundred_k() {
+        assert_eq!(context_window_for_model("claude-3-5-sonnet"), 200_000);
+        assert_eq!(context_window_for_model("claude-3-opus"), 200_000);
+        assert_eq!(context_window_for_model("claude-haiku-3"), 200_000);
         assert_eq!(context_window_for_model("anything-else"), 200_000);
+        // Bare "claude-opus-4" without the family digit suffix is unknown.
+        assert_eq!(context_window_for_model("claude-opus-4"), 200_000);
+    }
+
+    #[test]
+    fn auto_compact_override_pct_rounds_to_integer() {
+        // 300k / 1M = 30%.
+        assert_eq!(auto_compact_override_pct(300_000, 1_000_000), Some(30));
+        // 500k / 1M = 50%.
+        assert_eq!(auto_compact_override_pct(500_000, 1_000_000), Some(50));
+        // Zero window → None.
+        assert_eq!(auto_compact_override_pct(300_000, 0), None);
+    }
+
+    #[test]
+    fn auto_compact_override_pct_clamps_to_ceiling() {
+        // 900k / 1M = 90% → clamped to 83.
+        assert_eq!(auto_compact_override_pct(900_000, 1_000_000), Some(83));
+        // 300k / 200k = 150% → clamped to 83.
+        assert_eq!(auto_compact_override_pct(300_000, 200_000), Some(83));
+    }
+
+    #[test]
+    fn auto_compact_override_pct_floor_is_one() {
+        // Tiny threshold rounds to <1 → clamped to 1, not 0.
+        assert_eq!(auto_compact_override_pct(1, 1_000_000), Some(1));
+    }
+
+    #[test]
+    fn threshold_would_clamp_at_or_above_ceiling() {
+        // 83% exactly clamps.
+        assert!(threshold_would_clamp(830_000, 1_000_000));
+        // Above ceiling clamps.
+        assert!(threshold_would_clamp(900_000, 1_000_000));
+        // Below ceiling does not.
+        assert!(!threshold_would_clamp(820_000, 1_000_000));
+    }
+
+    #[test]
+    fn resolve_auto_compact_threshold_falls_back_to_default() {
+        assert_eq!(
+            resolve_auto_compact_threshold(None),
+            DEFAULT_AUTO_COMPACT_THRESHOLD
+        );
+        // Zero is treated as "unset" — fall back to default rather than
+        // emit a never-triggering 0 threshold.
+        assert_eq!(
+            resolve_auto_compact_threshold(Some(0)),
+            DEFAULT_AUTO_COMPACT_THRESHOLD
+        );
+        assert_eq!(resolve_auto_compact_threshold(Some(500_000)), 500_000);
     }
 
     fn mk_state(pid: u32, session_id: &str) -> AgentState {
@@ -364,6 +540,7 @@ mod tests {
                 runtime: Default::default(),
                 context: None,
                 compact_threshold: None,
+                auto_compact_threshold_tokens: None,
             },
             pid,
             session_id: session_id.into(),

--- a/src/app/process_builder.rs
+++ b/src/app/process_builder.rs
@@ -9,6 +9,29 @@ use tokio::process::Command;
 use crate::config::ContainerConfig;
 
 use super::agent_registry::AgentConfig;
+use super::context_size;
+
+/// Compute the `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env tuple for an agent.
+/// Always emitted so the built-in 300k default is honoured even when the
+/// user did not set a per-agent override. Logs a warning when the chosen
+/// threshold would be silently clamped by Claude Code.
+fn auto_compact_env_for(cfg: &AgentConfig) -> Option<(&'static str, String)> {
+    let threshold = context_size::resolve_auto_compact_threshold(cfg.auto_compact_threshold_tokens);
+    let window = context_size::context_window_for_model(&cfg.model);
+    let pct = context_size::auto_compact_override_pct(threshold, window)?;
+    if context_size::threshold_would_clamp(threshold, window) {
+        tracing::warn!(
+            agent = %cfg.name,
+            model = %cfg.model,
+            threshold_tokens = threshold,
+            window_tokens = window,
+            ceiling_pct = context_size::AUTO_COMPACT_PCT_CEILING,
+            "auto_compact_threshold_tokens >= {}% of model window — Claude Code will clamp the override; effective compaction will fire earlier than configured",
+            context_size::AUTO_COMPACT_PCT_CEILING,
+        );
+    }
+    Some(("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", pct.to_string()))
+}
 
 /// Build the tokio Command for running the agent process.
 /// Inject flags required for persistent stream-json operation.
@@ -17,8 +40,10 @@ use super::agent_registry::AgentConfig;
 /// explicitly set in workspace.yaml. Sub-agents created via MCP typically
 /// have `command: ["claude"]` with no flags, so all are injected.
 pub fn build_command(cfg: &AgentConfig, args: &[String], extra_env: &[(&str, &str)]) -> Command {
+    let auto_compact = auto_compact_env_for(cfg);
+
     if let Some(ref container) = cfg.container {
-        return build_container_command(cfg, container, args, extra_env);
+        return build_container_command(cfg, container, args, extra_env, &auto_compact);
     }
 
     let (bin, prefix) = split_command(&cfg.command);
@@ -27,6 +52,9 @@ pub fn build_command(cfg: &AgentConfig, args: &[String], extra_env: &[(&str, &st
             let mut c = Command::new("sudo");
             c.args(["-u", user, "-H", "--", "env"]);
             for (k, v) in extra_env {
+                c.arg(format!("{}={}", k, v));
+            }
+            if let Some((k, v)) = &auto_compact {
                 c.arg(format!("{}={}", k, v));
             }
             c.arg(bin);
@@ -45,6 +73,9 @@ pub fn build_command(cfg: &AgentConfig, args: &[String], extra_env: &[(&str, &st
     };
     if cfg.unix_user.is_none() {
         for (k, v) in extra_env {
+            cmd.env(k, v);
+        }
+        if let Some((k, v)) = &auto_compact {
             cmd.env(k, v);
         }
     }
@@ -66,6 +97,7 @@ fn build_container_command(
     container: &ContainerConfig,
     args: &[String],
     extra_env: &[(&str, &str)],
+    auto_compact_env: &Option<(&'static str, String)>,
 ) -> Command {
     let runtime = &container.runtime;
     let mut cmd = Command::new(runtime);
@@ -95,6 +127,12 @@ fn build_container_command(
 
     // Extra env vars (DESKD_BUS_SOCKET, DESKD_AGENT_NAME, DESKD_AGENT_CONFIG).
     for (k, v) in extra_env {
+        cmd.args(["-e", &format!("{}={}", k, v)]);
+    }
+
+    // CLAUDE_AUTOCOMPACT_PCT_OVERRIDE — Claude Code's per-process knob for
+    // when auto-compaction kicks in (percentage of context window).
+    if let Some((k, v)) = auto_compact_env {
         cmd.args(["-e", &format!("{}={}", k, v)]);
     }
 
@@ -352,6 +390,7 @@ mod tests {
             runtime: ConfigAgentRuntime::default(),
             context: None,
             compact_threshold: None,
+            auto_compact_threshold_tokens: None,
         };
 
         let extra_env = [("DESKD_BUS_SOCKET", "/home/test/.deskd/bus.sock")];
@@ -402,6 +441,7 @@ mod tests {
             runtime: ConfigAgentRuntime::default(),
             context: None,
             compact_threshold: None,
+            auto_compact_threshold_tokens: None,
         };
         let cmd = build_command(&cfg, &[], &[]);
         let program = cmd.as_std().get_program().to_string_lossy().to_string();
@@ -425,6 +465,7 @@ mod tests {
             runtime: ConfigAgentRuntime::default(),
             context: None,
             compact_threshold: None,
+            auto_compact_threshold_tokens: None,
         };
         let extra_env = [("DESKD_BUS_SOCKET", "/tmp/bus.sock")];
         let cmd = build_command(&cfg, &[], &extra_env);
@@ -439,5 +480,115 @@ mod tests {
         assert!(args.contains(&"-u".to_string()));
         assert!(args.contains(&"agent-user".to_string()));
         assert!(args.contains(&"DESKD_BUS_SOCKET=/tmp/bus.sock".to_string()));
+    }
+
+    #[test]
+    fn auto_compact_env_for_4x_model_uses_default_300k_as_30pct() {
+        // Default threshold (300k) on a 1M-window 4.x model → 30%.
+        let cfg = AgentConfig {
+            name: "test".into(),
+            model: "claude-opus-4-7".into(),
+            system_prompt: String::new(),
+            work_dir: "/tmp".into(),
+            max_turns: 100,
+            unix_user: None,
+            budget_usd: 50.0,
+            command: vec!["claude".into()],
+            config_path: None,
+            container: None,
+            session: ConfigSessionMode::default(),
+            runtime: ConfigAgentRuntime::default(),
+            context: None,
+            compact_threshold: None,
+            auto_compact_threshold_tokens: None,
+        };
+        let env = auto_compact_env_for(&cfg).expect("env tuple");
+        assert_eq!(env.0, "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE");
+        assert_eq!(env.1, "30");
+    }
+
+    #[test]
+    fn auto_compact_env_for_per_agent_override_wins() {
+        let cfg = AgentConfig {
+            name: "test".into(),
+            model: "claude-opus-4-7".into(),
+            system_prompt: String::new(),
+            work_dir: "/tmp".into(),
+            max_turns: 100,
+            unix_user: None,
+            budget_usd: 50.0,
+            command: vec!["claude".into()],
+            config_path: None,
+            container: None,
+            session: ConfigSessionMode::default(),
+            runtime: ConfigAgentRuntime::default(),
+            context: None,
+            compact_threshold: None,
+            auto_compact_threshold_tokens: Some(500_000),
+        };
+        let env = auto_compact_env_for(&cfg).expect("env tuple");
+        // 500k of 1M = 50%.
+        assert_eq!(env.1, "50");
+    }
+
+    #[test]
+    fn auto_compact_env_clamps_above_ceiling_for_3x_model() {
+        // 300k threshold on a 200k-window model would be 150% → clamped to 83.
+        let cfg = AgentConfig {
+            name: "test".into(),
+            model: "claude-3-5-sonnet".into(),
+            system_prompt: String::new(),
+            work_dir: "/tmp".into(),
+            max_turns: 100,
+            unix_user: None,
+            budget_usd: 50.0,
+            command: vec!["claude".into()],
+            config_path: None,
+            container: None,
+            session: ConfigSessionMode::default(),
+            runtime: ConfigAgentRuntime::default(),
+            context: None,
+            compact_threshold: None,
+            auto_compact_threshold_tokens: None,
+        };
+        let env = auto_compact_env_for(&cfg).expect("env tuple");
+        assert_eq!(env.1, "83");
+    }
+
+    #[test]
+    fn build_command_injects_auto_compact_env() {
+        let cfg = AgentConfig {
+            name: "test".into(),
+            model: "claude-opus-4-7".into(),
+            system_prompt: String::new(),
+            work_dir: "/tmp".into(),
+            max_turns: 100,
+            unix_user: None,
+            budget_usd: 50.0,
+            command: vec!["claude".into()],
+            config_path: None,
+            container: None,
+            session: ConfigSessionMode::default(),
+            runtime: ConfigAgentRuntime::default(),
+            context: None,
+            compact_threshold: None,
+            auto_compact_threshold_tokens: Some(400_000),
+        };
+        let cmd = build_command(&cfg, &[], &[]);
+        let envs: Vec<(String, String)> = cmd
+            .as_std()
+            .get_envs()
+            .filter_map(|(k, v)| {
+                let key = k.to_string_lossy().to_string();
+                let val = v?.to_string_lossy().to_string();
+                Some((key, val))
+            })
+            .collect();
+        let auto = envs
+            .iter()
+            .find(|(k, _)| k == "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE")
+            .expect("auto-compact env injected");
+        // 400k / 1M = 40%.
+        assert_eq!(auto.1, "40");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -395,6 +395,11 @@ pub struct UserConfig {
     /// Example: `inbox_acl: ["dev", "collab-*"]`.
     #[serde(default)]
     pub inbox_acl: Option<Vec<String>>,
+    /// Auto-compact threshold in absolute tokens (top-level / global default for
+    /// this deskd.yaml). Sub-agents inherit this when their own SubAgentDef does
+    /// not set one. Built-in fallback is `DEFAULT_AUTO_COMPACT_THRESHOLD` (300k).
+    #[serde(default)]
+    pub auto_compact_threshold_tokens: Option<u64>,
 }
 
 /// An A2A skill advertised in the Agent Card (per A2A spec).
@@ -508,6 +513,11 @@ pub struct SubAgentDef {
     /// Only used when runtime is `memory`.
     #[serde(default)]
     pub compact_strategy: Option<String>,
+    /// Auto-compact threshold in absolute tokens for this sub-agent.
+    /// Falls back to the parent UserConfig's `auto_compact_threshold_tokens`,
+    /// then to the built-in default (300k).
+    #[serde(default)]
+    pub auto_compact_threshold_tokens: Option<u64>,
 }
 
 impl SubAgentDef {
@@ -600,7 +610,24 @@ impl UserConfig {
         let expanded = expand_env_vars(&raw);
         let cfg: UserConfig =
             serde_yaml::from_str(&expanded).context("failed to parse user config")?;
+        cfg.validate()?;
         Ok(cfg)
+    }
+
+    /// Validate config invariants that serde can't express on its own.
+    pub fn validate(&self) -> Result<()> {
+        if let Some(0) = self.auto_compact_threshold_tokens {
+            anyhow::bail!("auto_compact_threshold_tokens must be > 0");
+        }
+        for sub in &self.agents {
+            if let Some(0) = sub.auto_compact_threshold_tokens {
+                anyhow::bail!(
+                    "agent '{}': auto_compact_threshold_tokens must be > 0",
+                    sub.name
+                );
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1444,6 +1471,7 @@ agents:
             context: None,
             compact_threshold: None,
             compact_strategy: None,
+            auto_compact_threshold_tokens: None,
         };
         assert!(sub.validate_work_dir("/tmp/parent").is_ok());
     }
@@ -1466,6 +1494,7 @@ agents:
             context: None,
             compact_threshold: None,
             compact_strategy: None,
+            auto_compact_threshold_tokens: None,
         };
         assert!(sub.validate_work_dir("/tmp/parent").is_err());
     }

--- a/tests/agent_lifecycle.rs
+++ b/tests/agent_lifecycle.rs
@@ -72,6 +72,7 @@ fn make_config(name: &str) -> deskd::app::agent::AgentConfig {
         runtime: deskd::infra::dto::ConfigAgentRuntime::Claude,
         context: None,
         compact_threshold: None,
+        auto_compact_threshold_tokens: None,
     }
 }
 

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -88,6 +88,7 @@ fn test_agent_config(name: &str) -> deskd::app::agent::AgentConfig {
         runtime: deskd::infra::dto::ConfigAgentRuntime::Claude,
         context: None,
         compact_threshold: None,
+        auto_compact_threshold_tokens: None,
     }
 }
 


### PR DESCRIPTION
Closes #402.

## Summary

- **Per-model context windows**: Claude 4.x family (`claude-(opus|sonnet|haiku)-4-*`) reports a 1M-token window in `/context`; 3.x and unknown models default to 200k.
- **Auto-compact threshold (`auto_compact_threshold_tokens`, tokens, default 300k)**: user-facing knob, configurable globally (UserConfig top-level) and per-agent (SubAgentDef). Resolution order: per-agent > top-level > 300k built-in default.
- **Env var injection**: threshold is converted to a percentage of the model window and injected into spawned Claude processes via `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`. Injected in all three branches of `process_builder::build_command`: regular spawn, container `-e` args, and sudo argv.
- **Clamping**: Claude Code silently clamps `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` above ~83% per anthropics/claude-code#31806. We mirror that — clamp to 83 and emit a startup `tracing::warn!` when `threshold_tokens / window_tokens >= 83%` so users see effective compaction will fire earlier than configured.
- **`/context` display**: now shows both window and absolute threshold:
  ```
  agent (session abc12345)  ~45k / 1000k  (auto-compact at 300k = 30%)
  ```
- **Warning trigger** in `/context` now uses 80% of the absolute auto-compact threshold (not 80% of the model window), so per-agent thresholds drive UX consistently.

## Acceptance Criteria

- [x] Model -> window mapping: 4.x -> 1M, 3.x/unknown -> 200k
- [x] auto_compact_threshold_tokens config field at UserConfig + SubAgentDef levels (validate rejects Some(0))
- [x] CLAUDE_AUTOCOMPACT_PCT_OVERRIDE injected into spawned process env
- [x] Clamp at 83%, log warn when threshold >= 83% of window
- [x] /context displays absolute threshold and percentage
- [x] Warning triggers off threshold, not window
- [x] Tests pass
- [x] Quality gate green

## Investigation citations

- anthropics/claude-code#31806 - silent clamp at ~83%
- anthropics/claude-code#34126 - env var docs

## Test plan

- [x] Unit tests in context_size.rs: model mapping, percentage conversion, clamp behavior, threshold-vs-window warning
- [x] Unit tests in process_builder.rs: env var injection in all three command branches, default vs per-agent override, clamp on 3.x model
- [x] Existing integration tests still green