### PR TITLE
fix(telegram): graceful reload via CancellationToken + selective config diff (#405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "serenity",
  "teloxide",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -2650,6 +2651,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }

--- a/src/app/adapters/mod.rs
+++ b/src/app/adapters/mod.rs
@@ -4,6 +4,7 @@ pub mod telegram;
 use crate::config::{AgentDef, UserConfig};
 use std::future::Future;
 use std::pin::Pin;
+use tokio_util::sync::CancellationToken;
 
 pub type BoxFuture = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>>;
 
@@ -17,24 +18,31 @@ pub trait Adapter: Send + 'static {
 }
 
 /// Build all configured adapters for an agent from workspace + user config.
+/// Returns each adapter paired with its `CancellationToken` so callers can
+/// cancel individual adapters cooperatively before aborting their task handles.
 pub fn build_adapters(
     def: &AgentDef,
     user_cfg: Option<&UserConfig>,
     admin_telegram_ids: &[i64],
-) -> Vec<Box<dyn Adapter>> {
-    let mut adapters: Vec<Box<dyn Adapter>> = Vec::new();
+) -> Vec<(Box<dyn Adapter>, CancellationToken)> {
+    let mut adapters: Vec<(Box<dyn Adapter>, CancellationToken)> = Vec::new();
 
     if let Some(tg) = &def.telegram {
         let routes = user_cfg
             .and_then(|c| c.telegram.as_ref())
             .map(|t| t.routes.clone())
             .unwrap_or_default();
-        adapters.push(Box::new(telegram::TelegramAdapter::new(
-            tg.token.clone(),
-            routes,
-            admin_telegram_ids.to_vec(),
-            def.name.clone(),
-        )));
+        let cancel = CancellationToken::new();
+        adapters.push((
+            Box::new(telegram::TelegramAdapter::new(
+                tg.token.clone(),
+                routes,
+                admin_telegram_ids.to_vec(),
+                def.name.clone(),
+                cancel.clone(),
+            )),
+            cancel,
+        ));
     }
 
     if let Some(dc) = &def.discord {
@@ -42,10 +50,13 @@ pub fn build_adapters(
             .and_then(|c| c.discord.as_ref())
             .map(|d| d.routes.clone())
             .unwrap_or_default();
-        adapters.push(Box::new(discord::DiscordAdapter::new(
-            dc.token.clone(),
-            routes,
-        )));
+        // Discord adapter does not yet support cooperative cancellation;
+        // provide a token that is never triggered so the API is uniform.
+        let cancel = CancellationToken::new();
+        adapters.push((
+            Box::new(discord::DiscordAdapter::new(dc.token.clone(), routes)),
+            cancel,
+        ));
     }
 
     adapters

--- a/src/app/adapters/telegram.rs
+++ b/src/app/adapters/telegram.rs
@@ -17,6 +17,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
 use tokio::time::Duration;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -90,6 +91,7 @@ pub struct TelegramAdapter {
     routes: Vec<TelegramRoute>,
     admin_telegram_ids: Vec<i64>,
     agent_name: String,
+    cancel: CancellationToken,
 }
 
 impl TelegramAdapter {
@@ -98,12 +100,14 @@ impl TelegramAdapter {
         routes: Vec<TelegramRoute>,
         admin_telegram_ids: Vec<i64>,
         agent_name: String,
+        cancel: CancellationToken,
     ) -> Self {
         Self {
             token,
             routes,
             admin_telegram_ids,
             agent_name,
+            cancel,
         }
     }
 }
@@ -141,6 +145,7 @@ impl super::Adapter for TelegramAdapter {
             chat_names,
             chat_route_to,
             self.admin_telegram_ids,
+            self.cancel,
         ))
     }
 }
@@ -170,6 +175,7 @@ pub async fn run(
     chat_names: std::collections::HashMap<i64, String>,
     chat_route_to: std::collections::HashMap<i64, String>,
     admin_telegram_ids: Vec<i64>,
+    cancel: CancellationToken,
 ) -> Result<()> {
     info!(agent = %agent_name, "starting Telegram adapter");
 
@@ -192,8 +198,9 @@ pub async fn run(
         let outbound_tx = outbound_tx.clone();
         let socket = socket_path.clone();
         let name = adapter_name.clone();
+        let cancel = cancel.clone();
         tokio::spawn(async move {
-            if let Err(e) = bus_loop(&socket, &name, outbound_tx).await {
+            if let Err(e) = bus_loop(&socket, &name, outbound_tx, cancel).await {
                 tracing::error!(error = %e, "telegram bus loop failed");
             }
         })
@@ -202,8 +209,9 @@ pub async fn run(
     // Task 2: send outbound messages to Telegram, manage typing indicators
     let sender_task = {
         let bot = bot.clone();
+        let cancel = cancel.clone();
         tokio::spawn(async move {
-            outbound_sender(bot, outbound_rx).await;
+            outbound_sender(bot, outbound_rx, cancel).await;
         })
     };
 
@@ -212,6 +220,7 @@ pub async fn run(
         let socket = socket_path.clone();
         let name = agent_name.clone();
         let mention_only: std::collections::HashSet<i64> = mention_only_chats.into_iter().collect();
+        let cancel = cancel.clone();
         tokio::spawn(async move {
             if let Err(e) = polling_loop(
                 bot,
@@ -223,6 +232,7 @@ pub async fn run(
                 chat_names,
                 chat_route_to,
                 admin_telegram_ids,
+                cancel,
             )
             .await
             {
@@ -235,6 +245,7 @@ pub async fn run(
         _ = bus_task => warn!(agent = %agent_name, "telegram bus task exited"),
         _ = sender_task => warn!(agent = %agent_name, "telegram sender task exited"),
         _ = polling_task => warn!(agent = %agent_name, "telegram polling task exited"),
+        _ = cancel.cancelled() => info!(agent = %agent_name, "telegram adapter cancelled"),
     }
 
     Ok(())
@@ -245,6 +256,7 @@ async fn bus_loop(
     socket_path: &str,
     adapter_name: &str,
     outbound_tx: mpsc::UnboundedSender<OutboundCmd>,
+    cancel: CancellationToken,
 ) -> Result<()> {
     let mut stream = UnixStream::connect(socket_path).await.with_context(|| {
         format!(
@@ -268,7 +280,17 @@ async fn bus_loop(
     let (reader, _writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
 
-    while let Some(line) = lines.next_line().await? {
+    loop {
+        let line = tokio::select! {
+            result = lines.next_line() => match result? {
+                Some(l) => l,
+                None => break,
+            },
+            _ = cancel.cancelled() => {
+                info!(adapter = %adapter_name, "telegram bus loop cancelled");
+                break;
+            }
+        };
         if line.is_empty() {
             continue;
         }
@@ -397,11 +419,22 @@ fn spawn_typing(bot: Bot, chat_id: i64) -> tokio::task::JoinHandle<()> {
 
 /// Send messages from the outbound channel to Telegram.
 /// Manages per-chat typing indicators, progress messages, and converts Markdown to HTML.
-async fn outbound_sender(bot: Bot, mut rx: mpsc::UnboundedReceiver<OutboundCmd>) {
+async fn outbound_sender(
+    bot: Bot,
+    mut rx: mpsc::UnboundedReceiver<OutboundCmd>,
+    cancel: CancellationToken,
+) {
     let mut typing_tasks: HashMap<i64, tokio::task::JoinHandle<()>> = HashMap::new();
     let mut progress_ids: HashMap<i64, teloxide::types::MessageId> = HashMap::new();
 
-    while let Some(cmd) = rx.recv().await {
+    loop {
+        let cmd = tokio::select! {
+            result = rx.recv() => match result {
+                Some(c) => c,
+                None => break,
+            },
+            _ = cancel.cancelled() => break,
+        };
         match cmd {
             OutboundCmd::Text { chat_id, text } => {
                 // Abort current typing loop while sending so Telegram doesn't show
@@ -489,7 +522,221 @@ async fn download_photo_base64(bot: &Bot, file_id: &str) -> Result<String> {
     Ok(base64::engine::general_purpose::STANDARD.encode(&buf))
 }
 
+/// Process a single incoming Telegram message and publish it to the bus.
+#[allow(clippy::too_many_arguments)]
+async fn handle_message(
+    bot: &Bot,
+    msg: Message,
+    socket_path: &str,
+    agent_name: &str,
+    bot_username: &str,
+    allowed_chats: &std::collections::HashSet<i64>,
+    mention_only_chats: &std::collections::HashSet<i64>,
+    chat_names: &std::collections::HashMap<i64, String>,
+    chat_route_to: &std::collections::HashMap<i64, String>,
+    admin_ids: &std::collections::HashSet<i64>,
+) -> Result<()> {
+    // Skip messages from the bot itself to prevent reply loops.
+    if msg
+        .from
+        .as_ref()
+        .map(|u| u.username.as_deref() == Some(bot_username))
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+    // Skip messages from other bots.
+    if msg.from.as_ref().map(|u| u.is_bot).unwrap_or(false) {
+        return Ok(());
+    }
+
+    // Determine the task text and optional image data from the message.
+    // Photos are base64-encoded in memory and passed alongside the caption.
+    // Pure text messages are passed through unchanged.
+    let mut image_base64: Option<String> = None;
+    let task_text: Option<String> = if let Some(photos) = msg.photo() {
+        // Take the largest photo (Telegram sends sizes smallest → largest).
+        if let Some(largest) = photos.last() {
+            let file_id = largest.file.id.clone();
+            match download_photo_base64(bot, &file_id).await {
+                Ok(b64) => {
+                    image_base64 = Some(b64);
+                    let caption = msg.caption().unwrap_or("[photo attached]");
+                    Some(caption.to_string())
+                }
+                Err(e) => {
+                    warn!(file_id = %file_id, error = %e, "failed to download Telegram photo");
+                    // Fall back to caption-only so the message isn't silently dropped.
+                    let caption = msg
+                        .caption()
+                        .unwrap_or("[photo attached — download failed]");
+                    Some(caption.to_string())
+                }
+            }
+        } else {
+            None
+        }
+    } else {
+        msg.text().map(|t| t.to_string())
+    };
+
+    if let Some(text) = task_text {
+        let chat_id = msg.chat.id.0;
+
+        // ── /channel_info — runs BEFORE whitelist ──────────────
+        // This command must work in ANY chat (including unconfigured
+        // ones) so users can discover the chat_id to add to routes.
+        let cmd = text.trim();
+        let cmd_base = cmd.split('@').next().unwrap_or(cmd);
+        if cmd_base == "/channel_info" {
+            let chat_type = match &msg.chat.kind {
+                teloxide::types::ChatKind::Public(p) => match &p.kind {
+                    teloxide::types::PublicChatKind::Supergroup(_) => "supergroup",
+                    teloxide::types::PublicChatKind::Group(_) => "group",
+                    teloxide::types::PublicChatKind::Channel(_) => "channel",
+                },
+                teloxide::types::ChatKind::Private(_) => "private",
+            };
+            let name = chat_names
+                .get(&chat_id)
+                .map(|s| format!("\"{}\" (from route config)", s))
+                .unwrap_or_else(|| "(not configured)".to_string());
+            let is_mention_only = mention_only_chats.contains(&chat_id);
+            let route_to_label = chat_route_to
+                .get(&chat_id)
+                .map(|s| s.as_str())
+                .unwrap_or("default");
+            let route_to_detail = if route_to_label == "default" {
+                format!("default (telegram.in:{})", chat_id)
+            } else {
+                route_to_label.to_string()
+            };
+            let reply = format!(
+                "📋 Channel Info\n─────────────\nChat ID: {}\nChat type: {}\nName: {}\nMention only: {}\nRoute to: {}\nAgent: {}",
+                chat_id,
+                chat_type,
+                name,
+                if is_mention_only { "yes" } else { "no" },
+                route_to_detail,
+                agent_name
+            );
+            let _ = bot.send_message(msg.chat.id, reply).await;
+            return Ok(());
+        }
+
+        // Whitelist check — only process chats explicitly configured in routes.
+        if !allowed_chats.is_empty() && !allowed_chats.contains(&chat_id) {
+            debug!(agent = %agent_name, chat_id = chat_id, "ignoring message — chat not in whitelist");
+            return Ok(());
+        }
+
+        // ── Slash command interception ──────────────────────────────
+        // Handle /status and /restart locally without forwarding to
+        // the agent.  This runs AFTER the whitelist check so that
+        // only authorised chats can invoke these commands.
+        if cmd_base == "/status" {
+            let reply = format_status_reply(agent_name);
+            let _ = bot.send_message(msg.chat.id, reply).await;
+            return Ok(());
+        }
+        if cmd_base == "/restart" {
+            let sender_id = msg.from.as_ref().map(|u| u.id.0 as i64).unwrap_or(0);
+            if !admin_ids.contains(&sender_id) {
+                let _ = bot
+                    .send_message(msg.chat.id, "Permission denied. Admin access required.")
+                    .await;
+                return Ok(());
+            }
+            let reply = handle_restart_command(agent_name, socket_path).await;
+            let _ = bot.send_message(msg.chat.id, reply).await;
+            return Ok(());
+        }
+        if cmd_base == "/context" {
+            let reply = handle_context_command().await;
+            let _ = bot.send_message(msg.chat.id, reply).await;
+            return Ok(());
+        }
+
+        // Write ALL messages from allowed chats to unified inbox,
+        // regardless of mention_only filtering.
+        let sender_username = msg.from.as_ref().and_then(|u| u.username.clone());
+        let inbox_name = format!("telegram/{}", chat_id);
+        let inbox_msg = unified_inbox::InboxMessage {
+            ts: chrono::Utc::now(),
+            source: "telegram".to_string(),
+            from: sender_username,
+            text: text.clone(),
+            metadata: serde_json::json!({
+                "chat_id": chat_id,
+                "chat_name": chat_names.get(&chat_id),
+                "message_id": msg.id.0,
+            }),
+        };
+        if let Err(e) = unified_inbox::write_message(&inbox_name, &inbox_msg) {
+            warn!(chat_id = chat_id, error = %e, "failed to write to unified inbox");
+        }
+
+        // If this chat requires a mention, skip unless @bot_username appears in text.
+        if mention_only_chats.contains(&chat_id) {
+            let mention = format!("@{}", bot_username);
+            if !text.contains(&mention) {
+                debug!(agent = %agent_name, chat_id = chat_id, "skipping message — not a mention");
+                return Ok(());
+            }
+        }
+
+        // Use route_to override if configured, otherwise default to telegram.in:<chat_id>.
+        let target = if let Some(rt) = chat_route_to.get(&chat_id) {
+            rt.clone()
+        } else {
+            format!("telegram.in:{}", chat_id)
+        };
+        // reply_to always goes back to Telegram so agent responses reach the chat.
+        let reply_to = format!("telegram.out:{}", chat_id);
+        let chat_name = chat_names.get(&chat_id).cloned();
+
+        debug!(agent = %agent_name, chat_id = chat_id, "received Telegram message");
+
+        // Extract sender metadata from the Telegram message.
+        let sender_info = msg.from.as_ref().map(|u| SenderInfo {
+            id: u.id.0,
+            username: u.username.clone(),
+            first_name: u.first_name.clone(),
+            is_bot: u.is_bot,
+        });
+        let message_id = msg.id.0;
+        let reply_to_message_id = msg.reply_to_message().map(|r| r.id.0);
+        let reply_to_text = msg
+            .reply_to_message()
+            .and_then(|r| r.text().or_else(|| r.caption()).map(|s| s.to_string()));
+
+        if let Err(e) = publish_to_bus(
+            socket_path,
+            agent_name,
+            &text,
+            &target,
+            &reply_to,
+            chat_id,
+            chat_name,
+            image_base64.as_deref(),
+            sender_info.as_ref(),
+            message_id,
+            reply_to_message_id,
+            reply_to_text.as_deref(),
+        )
+        .await
+        {
+            warn!(chat_id = chat_id, error = %e, "failed to publish message to bus");
+            let _ = bot
+                .send_message(msg.chat.id, "Internal error, please try again.")
+                .await;
+        }
+    }
+    Ok(())
+}
+
 /// Poll Telegram for incoming messages and publish them to the bus as `telegram.in:<chat_id>`.
+/// Uses a manual `get_updates` loop instead of `teloxide::repl` so we can cooperatively cancel.
 #[allow(clippy::too_many_arguments)]
 async fn polling_loop(
     bot: Bot,
@@ -501,199 +748,59 @@ async fn polling_loop(
     chat_names: std::collections::HashMap<i64, String>,
     chat_route_to: std::collections::HashMap<i64, String>,
     admin_telegram_ids: Vec<i64>,
+    cancel: CancellationToken,
 ) -> Result<()> {
     let admin_ids: std::collections::HashSet<i64> = admin_telegram_ids.into_iter().collect();
-    teloxide::repl(bot, move |bot: Bot, msg: Message| {
-        let socket = socket_path.clone();
-        let agent = agent_name.clone();
-        let bot_user = bot_username.clone();
-        let allowed = allowed_chats.clone();
-        let mention_only = mention_only_chats.clone();
-        let names = chat_names.clone();
-        let route_to_map = chat_route_to.clone();
-        let admins = admin_ids.clone();
-        async move {
-            // Skip messages from the bot itself to prevent reply loops.
-            if msg.from.as_ref().map(|u| u.username.as_deref() == Some(&bot_user)).unwrap_or(false) {
-                return Ok(());
-            }
-            // Skip messages from other bots.
-            if msg.from.as_ref().map(|u| u.is_bot).unwrap_or(false) {
-                return Ok(());
-            }
+    let mut next_offset: i32 = 0;
 
-            // Determine the task text and optional image data from the message.
-            // Photos are base64-encoded in memory and passed alongside the caption.
-            // Pure text messages are passed through unchanged.
-            let mut image_base64: Option<String> = None;
-            let task_text: Option<String> = if let Some(photos) = msg.photo() {
-                // Take the largest photo (Telegram sends sizes smallest → largest).
-                if let Some(largest) = photos.last() {
-                    let file_id = largest.file.id.clone();
-                    match download_photo_base64(&bot, &file_id).await {
-                        Ok(b64) => {
-                            image_base64 = Some(b64);
-                            let caption = msg.caption().unwrap_or("[photo attached]");
-                            Some(caption.to_string())
-                        }
-                        Err(e) => {
-                            warn!(file_id = %file_id, error = %e, "failed to download Telegram photo");
-                            // Fall back to caption-only so the message isn't silently dropped.
-                            let caption = msg.caption().unwrap_or("[photo attached — download failed]");
-                            Some(caption.to_string())
+    loop {
+        // Build the get_updates future — 30s long-poll timeout.
+        let updates_fut = bot.get_updates().offset(next_offset).timeout(30).send();
+
+        let updates = tokio::select! {
+            result = updates_fut => match result {
+                Ok(u) => u,
+                Err(e) => {
+                    warn!(agent = %agent_name, error = %e, "get_updates error, retrying in 5s");
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(5)) => {},
+                        _ = cancel.cancelled() => {
+                            info!(agent = %agent_name, "telegram polling loop cancelled during backoff");
+                            break;
                         }
                     }
-                } else {
-                    None
+                    continue;
                 }
-            } else {
-                msg.text().map(|t| t.to_string())
-            };
-
-            if let Some(text) = task_text {
-                let chat_id = msg.chat.id.0;
-
-                // ── /channel_info — runs BEFORE whitelist ──────────────
-                // This command must work in ANY chat (including unconfigured
-                // ones) so users can discover the chat_id to add to routes.
-                let cmd = text.trim();
-                let cmd_base = cmd.split('@').next().unwrap_or(cmd);
-                if cmd_base == "/channel_info" {
-                    let chat_type = match &msg.chat.kind {
-                        teloxide::types::ChatKind::Public(p) => match &p.kind {
-                            teloxide::types::PublicChatKind::Supergroup(_) => "supergroup",
-                            teloxide::types::PublicChatKind::Group(_) => "group",
-                            teloxide::types::PublicChatKind::Channel(_) => "channel",
-                        },
-                        teloxide::types::ChatKind::Private(_) => "private",
-                    };
-                    let name = names
-                        .get(&chat_id)
-                        .map(|s| format!("\"{}\" (from route config)", s))
-                        .unwrap_or_else(|| "(not configured)".to_string());
-                    let is_mention_only = mention_only.contains(&chat_id);
-                    let route_to_label = route_to_map
-                        .get(&chat_id)
-                        .map(|s| s.as_str())
-                        .unwrap_or("default");
-                    let route_to_detail = if route_to_label == "default" {
-                        format!("default (telegram.in:{})", chat_id)
-                    } else {
-                        route_to_label.to_string()
-                    };
-                    let reply = format!(
-                        "📋 Channel Info\n─────────────\nChat ID: {}\nChat type: {}\nName: {}\nMention only: {}\nRoute to: {}\nAgent: {}",
-                        chat_id,
-                        chat_type,
-                        name,
-                        if is_mention_only { "yes" } else { "no" },
-                        route_to_detail,
-                        agent
-                    );
-                    let _ = bot.send_message(msg.chat.id, reply).await;
-                    return Ok(());
-                }
-
-                // Whitelist check — only process chats explicitly configured in routes.
-                if !allowed.is_empty() && !allowed.contains(&chat_id) {
-                    debug!(agent = %agent, chat_id = chat_id, "ignoring message — chat not in whitelist");
-                    return Ok(());
-                }
-
-                // ── Slash command interception ──────────────────────────────
-                // Handle /status and /restart locally without forwarding to
-                // the agent.  This runs AFTER the whitelist check so that
-                // only authorised chats can invoke these commands.
-                if cmd_base == "/status" {
-                    let reply = format_status_reply(&agent);
-                    let _ = bot.send_message(msg.chat.id, reply).await;
-                    return Ok(());
-                }
-                if cmd_base == "/restart" {
-                    let sender_id = msg.from.as_ref().map(|u| u.id.0 as i64).unwrap_or(0);
-                    if !admins.contains(&sender_id) {
-                        let _ = bot
-                            .send_message(msg.chat.id, "Permission denied. Admin access required.")
-                            .await;
-                        return Ok(());
-                    }
-                    let reply = handle_restart_command(&agent, &socket).await;
-                    let _ = bot.send_message(msg.chat.id, reply).await;
-                    return Ok(());
-                }
-                if cmd_base == "/context" {
-                    let reply = handle_context_command().await;
-                    let _ = bot.send_message(msg.chat.id, reply).await;
-                    return Ok(());
-                }
-
-                // Write ALL messages from allowed chats to unified inbox,
-                // regardless of mention_only filtering.
-                let sender_username = msg.from.as_ref().and_then(|u| u.username.clone());
-                let inbox_name = format!("telegram/{}", chat_id);
-                let inbox_msg = unified_inbox::InboxMessage {
-                    ts: chrono::Utc::now(),
-                    source: "telegram".to_string(),
-                    from: sender_username,
-                    text: text.clone(),
-                    metadata: serde_json::json!({
-                        "chat_id": chat_id,
-                        "chat_name": names.get(&chat_id),
-                        "message_id": msg.id.0,
-                    }),
-                };
-                if let Err(e) = unified_inbox::write_message(&inbox_name, &inbox_msg) {
-                    warn!(chat_id = chat_id, error = %e, "failed to write to unified inbox");
-                }
-
-                // If this chat requires a mention, skip unless @bot_user appears in text.
-                if mention_only.contains(&chat_id) {
-                    let mention = format!("@{}", bot_user);
-                    if !text.contains(&mention) {
-                        debug!(agent = %agent, chat_id = chat_id, "skipping message — not a mention");
-                        return Ok(());
-                    }
-                }
-
-                // Use route_to override if configured, otherwise default to telegram.in:<chat_id>.
-                let target = if let Some(rt) = route_to_map.get(&chat_id) {
-                    rt.clone()
-                } else {
-                    format!("telegram.in:{}", chat_id)
-                };
-                // reply_to always goes back to Telegram so agent responses reach the chat.
-                let reply_to = format!("telegram.out:{}", chat_id);
-                let chat_name = names.get(&chat_id).cloned();
-
-                debug!(agent = %agent, chat_id = chat_id, "received Telegram message");
-
-                // Extract sender metadata from the Telegram message.
-                let sender_info = msg.from.as_ref().map(|u| SenderInfo {
-                    id: u.id.0,
-                    username: u.username.clone(),
-                    first_name: u.first_name.clone(),
-                    is_bot: u.is_bot,
-                });
-                let message_id = msg.id.0;
-                let reply_to_message_id = msg.reply_to_message().map(|r| r.id.0);
-                let reply_to_text = msg
-                    .reply_to_message()
-                    .and_then(|r| r.text().or_else(|| r.caption()).map(|s| s.to_string()));
-
-                if let Err(e) =
-                    publish_to_bus(&socket, &agent, &text, &target, &reply_to, chat_id, chat_name, image_base64.as_deref(), sender_info.as_ref(), message_id, reply_to_message_id, reply_to_text.as_deref())
-                        .await
-                {
-                    warn!(chat_id = chat_id, error = %e, "failed to publish message to bus");
-                    let _ = bot
-                        .send_message(msg.chat.id, "Internal error, please try again.")
-                        .await;
-                }
+            },
+            _ = cancel.cancelled() => {
+                info!(agent = %agent_name, "telegram polling loop cancelled");
+                break;
             }
-            Ok(())
+        };
+
+        for update in updates {
+            // Advance offset past this update so it won't be re-delivered.
+            next_offset = update.id.0 as i32 + 1;
+
+            if let teloxide::types::UpdateKind::Message(msg) = update.kind
+                && let Err(e) = handle_message(
+                    &bot,
+                    msg,
+                    &socket_path,
+                    &agent_name,
+                    &bot_username,
+                    &allowed_chats,
+                    &mention_only_chats,
+                    &chat_names,
+                    &chat_route_to,
+                    &admin_ids,
+                )
+                .await
+            {
+                warn!(agent = %agent_name, error = %e, "handle_message error");
+            }
         }
-    })
-    .await;
+    }
 
     Ok(())
 }

--- a/src/app/agent_components.rs
+++ b/src/app/agent_components.rs
@@ -1,0 +1,173 @@
+//! Per-agent restartable component bundle used by `config_reload`.
+//!
+//! Holds the join handles + cancellation tokens for adapters, schedule
+//! watcher, config watcher, reminder runner, and sub-agent workers, plus
+//! the abort routines that drive cooperative shutdown when `deskd.yaml`
+//! changes.
+
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Holds all restartable component handles and cancellation tokens for a single agent.
+pub struct AgentComponents {
+    pub adapter_handles: Vec<JoinHandle<()>>,
+    /// Cancellation tokens — one per adapter, in the same order as `adapter_handles`.
+    pub adapter_cancel_tokens: Vec<CancellationToken>,
+    pub schedule_watcher: Option<JoinHandle<()>>,
+    pub config_watcher: Option<JoinHandle<()>>,
+    pub reminder_runner: Option<JoinHandle<()>>,
+    pub sub_agent_handles: Vec<JoinHandle<()>>,
+}
+
+impl AgentComponents {
+    /// Gracefully cancel then abort all restartable components.
+    ///
+    /// 1. Cancel all adapter tokens (cooperative cancellation).
+    /// 2. Wait up to 1 s for adapter tasks to finish.
+    /// 3. Abort any adapters that are still running after the grace period.
+    /// 4. Abort all remaining non-adapter components immediately.
+    pub async fn abort_all(&mut self) {
+        // Step 1: signal cooperative cancellation for all adapters.
+        for token in &self.adapter_cancel_tokens {
+            token.cancel();
+        }
+
+        // Step 2: wait up to 1 s for adapters to drain.
+        // We can't await the JoinHandles directly without consuming them, so we
+        // use a short sleep as the grace window — the tokens already signalled
+        // cancellation; the tasks will exit their select! loops promptly.
+        if !self.adapter_handles.is_empty() {
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+        }
+
+        // Step 3: abort adapter handles (no-op if already finished).
+        for h in self.adapter_handles.drain(..) {
+            h.abort();
+        }
+        self.adapter_cancel_tokens.clear();
+
+        // Step 4: abort remaining components immediately.
+        if let Some(h) = self.schedule_watcher.take() {
+            h.abort();
+        }
+        if let Some(h) = self.config_watcher.take() {
+            h.abort();
+        }
+        if let Some(h) = self.reminder_runner.take() {
+            h.abort();
+        }
+        for h in self.sub_agent_handles.drain(..) {
+            h.abort();
+        }
+    }
+
+    /// Abort only adapter components (used for adapter-only config changes).
+    pub async fn abort_adapters(&mut self) {
+        for token in &self.adapter_cancel_tokens {
+            token.cancel();
+        }
+        if !self.adapter_handles.is_empty() {
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+        }
+        for h in self.adapter_handles.drain(..) {
+            h.abort();
+        }
+        self.adapter_cancel_tokens.clear();
+    }
+
+    /// Abort only schedule/reminder components (used for schedule-only config changes).
+    pub fn abort_schedules(&mut self) {
+        if let Some(h) = self.schedule_watcher.take() {
+            h.abort();
+        }
+        if let Some(h) = self.reminder_runner.take() {
+            h.abort();
+        }
+    }
+
+    /// Abort only sub-agent worker components.
+    pub fn abort_sub_agents(&mut self) {
+        for h in self.sub_agent_handles.drain(..) {
+            h.abort();
+        }
+    }
+
+    /// Return a summary string of component counts.
+    pub fn summary(&self) -> String {
+        format!(
+            "adapters={}, schedules={}, sub_agents={}",
+            self.adapter_handles.len(),
+            if self.schedule_watcher.is_some() {
+                1
+            } else {
+                0
+            },
+            self.sub_agent_handles.len(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_components_summary() {
+        let components = AgentComponents {
+            adapter_handles: Vec::new(),
+            adapter_cancel_tokens: Vec::new(),
+            schedule_watcher: None,
+            config_watcher: None,
+            reminder_runner: None,
+            sub_agent_handles: Vec::new(),
+        };
+        assert_eq!(
+            components.summary(),
+            "adapters=0, schedules=0, sub_agents=0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_agent_components_abort_all_empty() {
+        let mut components = AgentComponents {
+            adapter_handles: Vec::new(),
+            adapter_cancel_tokens: Vec::new(),
+            schedule_watcher: None,
+            config_watcher: None,
+            reminder_runner: None,
+            sub_agent_handles: Vec::new(),
+        };
+        // Should not panic on empty components.
+        components.abort_all().await;
+        assert!(components.adapter_handles.is_empty());
+        assert!(components.adapter_cancel_tokens.is_empty());
+        assert!(components.schedule_watcher.is_none());
+        assert!(components.sub_agent_handles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_adapter_cancel_token_fires_on_abort_adapters() {
+        let token = CancellationToken::new();
+        let child = token.clone();
+
+        // Spawn a task that waits for cancellation.
+        let handle = tokio::spawn(async move {
+            child.cancelled().await;
+        });
+
+        let mut components = AgentComponents {
+            adapter_handles: vec![handle],
+            adapter_cancel_tokens: vec![token],
+            schedule_watcher: None,
+            config_watcher: None,
+            reminder_runner: None,
+            sub_agent_handles: Vec::new(),
+        };
+
+        components.abort_adapters().await;
+        assert!(components.adapter_handles.is_empty());
+        assert!(components.adapter_cancel_tokens.is_empty());
+    }
+}

--- a/src/app/config_changeset.rs
+++ b/src/app/config_changeset.rs
@@ -1,0 +1,128 @@
+//! Config diff classifier — figures out which restartable components need to
+//! be restarted when `deskd.yaml` changes.
+//!
+//! Used by `config_reload::watch_and_reload` to drive selective restarts so
+//! that, e.g., a `system_prompt`-only edit does not disrupt the Telegram
+//! adapter.
+
+use crate::config;
+
+/// What changed between two `UserConfig` snapshots.
+#[derive(Debug, Default, PartialEq)]
+pub struct ConfigChangeset {
+    /// Telegram routes, token, or admin_ids changed → adapter restart needed.
+    pub adapters_changed: bool,
+    /// Schedules changed → schedule_watcher restart needed.
+    pub schedules_changed: bool,
+    /// Sub-agent definitions changed → sub-agent worker restart needed.
+    pub sub_agents_changed: bool,
+    /// Only system_prompt changed (and nothing else requiring a restart).
+    pub system_prompt_only: bool,
+}
+
+/// Compare two `UserConfig` snapshots and classify what changed.
+/// Returns a `ConfigChangeset` that callers use to decide which components
+/// need to be restarted.
+pub fn classify_config_change(
+    old: &config::UserConfig,
+    new: &config::UserConfig,
+) -> ConfigChangeset {
+    let adapters_changed = old.telegram != new.telegram || old.discord != new.discord;
+    let schedules_changed = old.schedules != new.schedules;
+    let sub_agents_changed = old.agents != new.agents;
+    let system_prompt_changed = old.system_prompt != new.system_prompt;
+
+    // Classify as system-prompt-only when ONLY the system prompt differs and
+    // nothing that requires restarting any component has changed.
+    let system_prompt_only =
+        system_prompt_changed && !adapters_changed && !schedules_changed && !sub_agents_changed;
+
+    ConfigChangeset {
+        adapters_changed,
+        schedules_changed,
+        sub_agents_changed,
+        system_prompt_only,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ScheduleAction, ScheduleDef, TelegramRoute, TelegramRoutesConfig};
+
+    fn base_config() -> config::UserConfig {
+        config::UserConfig {
+            system_prompt: "You are a helpful assistant.".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_classify_no_change() {
+        let cfg = base_config();
+        let cs = classify_config_change(&cfg, &cfg);
+        assert_eq!(cs, ConfigChangeset::default());
+        assert!(!cs.system_prompt_only);
+    }
+
+    #[test]
+    fn test_classify_system_prompt_only() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.system_prompt = "New prompt.".into();
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.system_prompt_only);
+        assert!(!cs.adapters_changed);
+        assert!(!cs.schedules_changed);
+        assert!(!cs.sub_agents_changed);
+    }
+
+    #[test]
+    fn test_classify_telegram_routes_changed() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.telegram = Some(TelegramRoutesConfig {
+            routes: vec![TelegramRoute {
+                chat_id: 12345,
+                mention_only: false,
+                name: None,
+                route_to: None,
+            }],
+        });
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.adapters_changed);
+        assert!(!cs.system_prompt_only);
+        assert!(!cs.schedules_changed);
+    }
+
+    #[test]
+    fn test_classify_schedules_changed() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.schedules = vec![ScheduleDef {
+            cron: "0 9 * * *".into(),
+            target: "agent:dev".into(),
+            action: ScheduleAction::Raw,
+            config: None,
+            timezone: None,
+        }];
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.schedules_changed);
+        assert!(!cs.adapters_changed);
+        assert!(!cs.system_prompt_only);
+    }
+
+    #[test]
+    fn test_classify_system_prompt_and_adapters_not_prompt_only() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.system_prompt = "Updated.".into();
+        new.telegram = Some(TelegramRoutesConfig { routes: vec![] });
+        let cs = classify_config_change(&old, &new);
+        assert!(
+            !cs.system_prompt_only,
+            "both changed — should not be prompt-only"
+        );
+        assert!(cs.adapters_changed);
+    }
+}

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -1,7 +1,7 @@
-/// Unified config hot-reload — watches deskd.yaml and restarts all restartable
+/// Unified config hot-reload — watches deskd.yaml and restarts restartable
 /// components when the config changes.
 ///
-/// Restartable components (aborted and respawned on config change):
+/// Restartable components (cancelled/aborted and respawned on config change):
 ///   - Adapters (Telegram, Discord)
 ///   - Schedule watcher
 ///   - Reminder runner
@@ -15,15 +15,74 @@
 ///
 /// System prompt changes are still injected via bus message (existing pattern
 /// in config_watcher.rs) rather than restarting the worker.
+///
+/// # Graceful adapter shutdown (Part A)
+///
+/// Adapters that support cooperative cancellation (currently Telegram) are
+/// cancelled via their `CancellationToken` first, giving them up to 1 second
+/// to drain in-flight messages before the task handle is aborted.
+///
+/// # Selective reload (Part B)
+///
+/// `classify_config_change` inspects what actually changed and returns a
+/// `ConfigChangeset` so only the affected components are restarted, avoiding
+/// unnecessary adapter disruption on system-prompt-only or schedule-only edits.
+use std::time::Duration;
+
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::app::{adapters, config_watcher, schedule, worker};
 use crate::config;
 
-/// Holds all restartable component handles for a single agent.
+// ─── Part B: config diff classifier ─────────────────────────────────────────
+
+/// What changed between two `UserConfig` snapshots.
+#[derive(Debug, Default, PartialEq)]
+pub struct ConfigChangeset {
+    /// Telegram routes, token, or admin_ids changed → adapter restart needed.
+    pub adapters_changed: bool,
+    /// Schedules changed → schedule_watcher restart needed.
+    pub schedules_changed: bool,
+    /// Sub-agent definitions changed → sub-agent worker restart needed.
+    pub sub_agents_changed: bool,
+    /// Only system_prompt changed (and nothing else requiring a restart).
+    pub system_prompt_only: bool,
+}
+
+/// Compare two `UserConfig` snapshots and classify what changed.
+/// Returns a `ConfigChangeset` that callers use to decide which components
+/// need to be restarted.
+pub fn classify_config_change(
+    old: &config::UserConfig,
+    new: &config::UserConfig,
+) -> ConfigChangeset {
+    let adapters_changed = old.telegram != new.telegram || old.discord != new.discord;
+    let schedules_changed = old.schedules != new.schedules;
+    let sub_agents_changed = old.agents != new.agents;
+    let system_prompt_changed = old.system_prompt != new.system_prompt;
+
+    // Classify as system-prompt-only when ONLY the system prompt differs and
+    // nothing that requires restarting any component has changed.
+    let system_prompt_only =
+        system_prompt_changed && !adapters_changed && !schedules_changed && !sub_agents_changed;
+
+    ConfigChangeset {
+        adapters_changed,
+        schedules_changed,
+        sub_agents_changed,
+        system_prompt_only,
+    }
+}
+
+// ─── Part A: AgentComponents with cooperative cancellation ──────────────────
+
+/// Holds all restartable component handles and cancellation tokens for a single agent.
 pub struct AgentComponents {
     pub adapter_handles: Vec<JoinHandle<()>>,
+    /// Cancellation tokens — one per adapter, in the same order as `adapter_handles`.
+    pub adapter_cancel_tokens: Vec<CancellationToken>,
     pub schedule_watcher: Option<JoinHandle<()>>,
     pub config_watcher: Option<JoinHandle<()>>,
     pub reminder_runner: Option<JoinHandle<()>>,
@@ -31,11 +90,33 @@ pub struct AgentComponents {
 }
 
 impl AgentComponents {
-    /// Abort all restartable components.
-    pub fn abort_all(&mut self) {
+    /// Gracefully cancel then abort all restartable components.
+    ///
+    /// 1. Cancel all adapter tokens (cooperative cancellation).
+    /// 2. Wait up to 1 s for adapter tasks to finish.
+    /// 3. Abort any adapters that are still running after the grace period.
+    /// 4. Abort all remaining non-adapter components immediately.
+    pub async fn abort_all(&mut self) {
+        // Step 1: signal cooperative cancellation for all adapters.
+        for token in &self.adapter_cancel_tokens {
+            token.cancel();
+        }
+
+        // Step 2: wait up to 1 s for adapters to drain.
+        // We can't await the JoinHandles directly without consuming them, so we
+        // use a short sleep as the grace window — the tokens already signalled
+        // cancellation; the tasks will exit their select! loops promptly.
+        if !self.adapter_handles.is_empty() {
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+        }
+
+        // Step 3: abort adapter handles (no-op if already finished).
         for h in self.adapter_handles.drain(..) {
             h.abort();
         }
+        self.adapter_cancel_tokens.clear();
+
+        // Step 4: abort remaining components immediately.
         if let Some(h) = self.schedule_watcher.take() {
             h.abort();
         }
@@ -45,6 +126,37 @@ impl AgentComponents {
         if let Some(h) = self.reminder_runner.take() {
             h.abort();
         }
+        for h in self.sub_agent_handles.drain(..) {
+            h.abort();
+        }
+    }
+
+    /// Abort only adapter components (used for adapter-only config changes).
+    pub async fn abort_adapters(&mut self) {
+        for token in &self.adapter_cancel_tokens {
+            token.cancel();
+        }
+        if !self.adapter_handles.is_empty() {
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+        }
+        for h in self.adapter_handles.drain(..) {
+            h.abort();
+        }
+        self.adapter_cancel_tokens.clear();
+    }
+
+    /// Abort only schedule/reminder components (used for schedule-only config changes).
+    pub fn abort_schedules(&mut self) {
+        if let Some(h) = self.schedule_watcher.take() {
+            h.abort();
+        }
+        if let Some(h) = self.reminder_runner.take() {
+            h.abort();
+        }
+    }
+
+    /// Abort only sub-agent worker components.
+    pub fn abort_sub_agents(&mut self) {
         for h in self.sub_agent_handles.drain(..) {
             h.abort();
         }
@@ -76,6 +188,7 @@ pub async fn spawn_components(
 ) -> anyhow::Result<AgentComponents> {
     let mut components = AgentComponents {
         adapter_handles: Vec::new(),
+        adapter_cancel_tokens: Vec::new(),
         schedule_watcher: None,
         config_watcher: None,
         reminder_runner: None,
@@ -83,7 +196,7 @@ pub async fn spawn_components(
     };
 
     // Adapters (Telegram, Discord, etc.)
-    for adapter in adapters::build_adapters(def, user_cfg, admin_telegram_ids) {
+    for (adapter, cancel_token) in adapters::build_adapters(def, user_cfg, admin_telegram_ids) {
         let bus = bus_socket.to_string();
         let name = agent_name.to_string();
         let adapter_name = adapter.name().to_string();
@@ -93,6 +206,7 @@ pub async fn spawn_components(
             }
         });
         components.adapter_handles.push(handle);
+        components.adapter_cancel_tokens.push(cancel_token);
     }
 
     // Schedule watcher
@@ -200,11 +314,67 @@ pub async fn spawn_components(
     Ok(components)
 }
 
-/// Watch the agent's deskd.yaml for changes and hot-reload all restartable components.
+/// Spawn only adapter components and append them to existing `components`.
+async fn spawn_adapters(
+    def: &config::AgentDef,
+    user_cfg: Option<&config::UserConfig>,
+    admin_telegram_ids: &[i64],
+    bus_socket: &str,
+    agent_name: &str,
+    components: &mut AgentComponents,
+) {
+    for (adapter, cancel_token) in adapters::build_adapters(def, user_cfg, admin_telegram_ids) {
+        let bus = bus_socket.to_string();
+        let name = agent_name.to_string();
+        let adapter_name = adapter.name().to_string();
+        let handle = tokio::spawn(async move {
+            if let Err(e) = adapter.run(bus, name).await {
+                tracing::error!(adapter = %adapter_name, error = %e, "adapter failed");
+            }
+        });
+        components.adapter_handles.push(handle);
+        components.adapter_cancel_tokens.push(cancel_token);
+    }
+}
+
+/// Spawn only schedule/reminder components and store them in `components`.
+fn spawn_schedules(
+    def: &config::AgentDef,
+    bus_socket: &str,
+    agent_name: &str,
+    cfg_path: &str,
+    components: &mut AgentComponents,
+) {
+    {
+        let bus = bus_socket.to_string();
+        let name = agent_name.to_string();
+        let config = cfg_path.to_string();
+        let home = def.work_dir.clone();
+        let handle = tokio::spawn(async move {
+            schedule::watch_and_reload(config, bus, name, home).await;
+        });
+        components.schedule_watcher = Some(handle);
+    }
+    {
+        let bus = bus_socket.to_string();
+        let name = agent_name.to_string();
+        let handle = tokio::spawn(async move {
+            schedule::run_reminders(bus, name).await;
+        });
+        components.reminder_runner = Some(handle);
+    }
+}
+
+/// Watch the agent's deskd.yaml for changes and hot-reload components selectively.
 ///
-/// Polls the file mtime every 30 seconds. On change, aborts all restartable
-/// components, reloads config, and respawns them. Bus server, main worker,
-/// bus API, and workflow engine are NOT affected.
+/// Polls the file mtime every 30 seconds. On change, uses `classify_config_change`
+/// to determine which components need restarting:
+///   - `system_prompt_only` → nothing restarted (system_prompt injected via bus by config_watcher)
+///   - `adapters_changed` → cooperative cancel + respawn adapters only
+///   - `schedules_changed` → abort + respawn schedule_watcher only
+///   - otherwise → full abort_all + respawn
+///
+/// Bus server, main worker, bus API, and workflow engine are never affected.
 pub async fn watch_and_reload(
     def: config::AgentDef,
     initial_components: AgentComponents,
@@ -215,6 +385,8 @@ pub async fn watch_and_reload(
 ) {
     let mut components = initial_components;
     let mut last_modified = file_mtime(&cfg_path);
+    // Track the last known config for diffing.
+    let mut last_user_cfg = config::UserConfig::load(&cfg_path).ok();
 
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
@@ -225,30 +397,91 @@ pub async fn watch_and_reload(
         }
         last_modified = current_mtime;
 
-        info!(agent = %agent_name, "config file changed, reloading all restartable components");
-
-        // Abort all running restartable components.
-        let old_summary = components.summary();
-        components.abort_all();
-        info!(agent = %agent_name, old = %old_summary, "aborted old components");
+        info!(agent = %agent_name, "config file changed, analysing diff");
 
         // Reload config.
-        let user_cfg = match config::UserConfig::load(&cfg_path) {
-            Ok(cfg) => Some(cfg),
+        let new_user_cfg = match config::UserConfig::load(&cfg_path) {
+            Ok(cfg) => cfg,
             Err(e) => {
                 warn!(
                     agent = %agent_name,
                     error = %e,
-                    "failed to reload config, components stopped"
+                    "failed to reload config, components unchanged"
                 );
                 continue;
             }
         };
 
-        // Respawn all restartable components.
+        // Classify what changed.
+        let changeset = if let Some(ref old_cfg) = last_user_cfg {
+            classify_config_change(old_cfg, &new_user_cfg)
+        } else {
+            // No previous config — treat everything as changed.
+            ConfigChangeset {
+                adapters_changed: true,
+                schedules_changed: true,
+                sub_agents_changed: true,
+                system_prompt_only: false,
+            }
+        };
+        last_user_cfg = Some(new_user_cfg.clone());
+
+        if changeset.system_prompt_only {
+            // system_prompt_only: config_watcher.rs injects the new prompt via bus.
+            // No adapter or schedule disruption needed.
+            info!(agent = %agent_name, "system_prompt changed only — no component restart needed");
+            continue;
+        }
+
+        if !changeset.adapters_changed
+            && !changeset.schedules_changed
+            && !changeset.sub_agents_changed
+        {
+            // Only non-restartable fields changed (e.g. mcp_config, context config).
+            info!(agent = %agent_name, "config change requires no component restart");
+            continue;
+        }
+
+        // Selective restart.
+        if changeset.adapters_changed
+            && !changeset.schedules_changed
+            && !changeset.sub_agents_changed
+        {
+            info!(agent = %agent_name, "adapter config changed — restarting adapters only");
+            components.abort_adapters().await;
+            spawn_adapters(
+                &def,
+                Some(&new_user_cfg),
+                &admin_telegram_ids,
+                &bus_socket,
+                &agent_name,
+                &mut components,
+            )
+            .await;
+            info!(agent = %agent_name, adapters = components.adapter_handles.len(), "adapters restarted");
+            continue;
+        }
+
+        if changeset.schedules_changed
+            && !changeset.adapters_changed
+            && !changeset.sub_agents_changed
+        {
+            info!(agent = %agent_name, "schedule config changed — restarting schedules only");
+            components.abort_schedules();
+            spawn_schedules(&def, &bus_socket, &agent_name, &cfg_path, &mut components);
+            info!(agent = %agent_name, "schedules restarted");
+            continue;
+        }
+
+        // Full restart for combined or sub-agent changes.
+        info!(agent = %agent_name, "config change requires full component restart");
+        let old_summary = components.summary();
+        components.abort_all().await;
+        info!(agent = %agent_name, old = %old_summary, "aborted old components");
+
         match spawn_components(
             &def,
-            user_cfg.as_ref(),
+            Some(&new_user_cfg),
             &admin_telegram_ids,
             &bus_socket,
             &agent_name,
@@ -283,11 +516,93 @@ fn file_mtime(path: &str) -> Option<std::time::SystemTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{ScheduleAction, ScheduleDef, TelegramRoute, TelegramRoutesConfig};
+
+    fn base_config() -> config::UserConfig {
+        config::UserConfig {
+            system_prompt: "You are a helpful assistant.".into(),
+            ..Default::default()
+        }
+    }
+
+    // ── classify_config_change ────────────────────────────────────────────────
+
+    #[test]
+    fn test_classify_no_change() {
+        let cfg = base_config();
+        let cs = classify_config_change(&cfg, &cfg);
+        assert_eq!(cs, ConfigChangeset::default());
+        assert!(!cs.system_prompt_only);
+    }
+
+    #[test]
+    fn test_classify_system_prompt_only() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.system_prompt = "New prompt.".into();
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.system_prompt_only);
+        assert!(!cs.adapters_changed);
+        assert!(!cs.schedules_changed);
+        assert!(!cs.sub_agents_changed);
+    }
+
+    #[test]
+    fn test_classify_telegram_routes_changed() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.telegram = Some(TelegramRoutesConfig {
+            routes: vec![TelegramRoute {
+                chat_id: 12345,
+                mention_only: false,
+                name: None,
+                route_to: None,
+            }],
+        });
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.adapters_changed);
+        assert!(!cs.system_prompt_only);
+        assert!(!cs.schedules_changed);
+    }
+
+    #[test]
+    fn test_classify_schedules_changed() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.schedules = vec![ScheduleDef {
+            cron: "0 9 * * *".into(),
+            target: "agent:dev".into(),
+            action: ScheduleAction::Raw,
+            config: None,
+            timezone: None,
+        }];
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.schedules_changed);
+        assert!(!cs.adapters_changed);
+        assert!(!cs.system_prompt_only);
+    }
+
+    #[test]
+    fn test_classify_system_prompt_and_adapters_not_prompt_only() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.system_prompt = "Updated.".into();
+        new.telegram = Some(TelegramRoutesConfig { routes: vec![] });
+        let cs = classify_config_change(&old, &new);
+        assert!(
+            !cs.system_prompt_only,
+            "both changed — should not be prompt-only"
+        );
+        assert!(cs.adapters_changed);
+    }
+
+    // ── AgentComponents helpers ──────────────────────────────────────────────
 
     #[test]
     fn test_agent_components_summary() {
         let components = AgentComponents {
             adapter_handles: Vec::new(),
+            adapter_cancel_tokens: Vec::new(),
             schedule_watcher: None,
             config_watcher: None,
             reminder_runner: None,
@@ -299,20 +614,46 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_agent_components_abort_all_empty() {
+    #[tokio::test]
+    async fn test_agent_components_abort_all_empty() {
         let mut components = AgentComponents {
             adapter_handles: Vec::new(),
+            adapter_cancel_tokens: Vec::new(),
             schedule_watcher: None,
             config_watcher: None,
             reminder_runner: None,
             sub_agent_handles: Vec::new(),
         };
         // Should not panic on empty components.
-        components.abort_all();
+        components.abort_all().await;
         assert!(components.adapter_handles.is_empty());
+        assert!(components.adapter_cancel_tokens.is_empty());
         assert!(components.schedule_watcher.is_none());
         assert!(components.sub_agent_handles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_adapter_cancel_token_fires_on_abort_adapters() {
+        let token = CancellationToken::new();
+        let child = token.clone();
+
+        // Spawn a task that waits for cancellation.
+        let handle = tokio::spawn(async move {
+            child.cancelled().await;
+        });
+
+        let mut components = AgentComponents {
+            adapter_handles: vec![handle],
+            adapter_cancel_tokens: vec![token],
+            schedule_watcher: None,
+            config_watcher: None,
+            reminder_runner: None,
+            sub_agent_handles: Vec::new(),
+        };
+
+        components.abort_adapters().await;
+        assert!(components.adapter_handles.is_empty());
+        assert!(components.adapter_cancel_tokens.is_empty());
     }
 
     #[test]

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -27,116 +27,12 @@
 /// `classify_config_change` inspects what actually changed and returns a
 /// `ConfigChangeset` so only the affected components are restarted, avoiding
 /// unnecessary adapter disruption on system-prompt-only or schedule-only edits.
-use std::time::Duration;
-
-use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::app::agent_components::AgentComponents;
 use crate::app::config_changeset::{ConfigChangeset, classify_config_change};
 use crate::app::{adapters, config_watcher, schedule, worker};
 use crate::config;
-
-// ─── Part A: AgentComponents with cooperative cancellation ──────────────────
-
-/// Holds all restartable component handles and cancellation tokens for a single agent.
-pub struct AgentComponents {
-    pub adapter_handles: Vec<JoinHandle<()>>,
-    /// Cancellation tokens — one per adapter, in the same order as `adapter_handles`.
-    pub adapter_cancel_tokens: Vec<CancellationToken>,
-    pub schedule_watcher: Option<JoinHandle<()>>,
-    pub config_watcher: Option<JoinHandle<()>>,
-    pub reminder_runner: Option<JoinHandle<()>>,
-    pub sub_agent_handles: Vec<JoinHandle<()>>,
-}
-
-impl AgentComponents {
-    /// Gracefully cancel then abort all restartable components.
-    ///
-    /// 1. Cancel all adapter tokens (cooperative cancellation).
-    /// 2. Wait up to 1 s for adapter tasks to finish.
-    /// 3. Abort any adapters that are still running after the grace period.
-    /// 4. Abort all remaining non-adapter components immediately.
-    pub async fn abort_all(&mut self) {
-        // Step 1: signal cooperative cancellation for all adapters.
-        for token in &self.adapter_cancel_tokens {
-            token.cancel();
-        }
-
-        // Step 2: wait up to 1 s for adapters to drain.
-        // We can't await the JoinHandles directly without consuming them, so we
-        // use a short sleep as the grace window — the tokens already signalled
-        // cancellation; the tasks will exit their select! loops promptly.
-        if !self.adapter_handles.is_empty() {
-            tokio::time::sleep(Duration::from_millis(1000)).await;
-        }
-
-        // Step 3: abort adapter handles (no-op if already finished).
-        for h in self.adapter_handles.drain(..) {
-            h.abort();
-        }
-        self.adapter_cancel_tokens.clear();
-
-        // Step 4: abort remaining components immediately.
-        if let Some(h) = self.schedule_watcher.take() {
-            h.abort();
-        }
-        if let Some(h) = self.config_watcher.take() {
-            h.abort();
-        }
-        if let Some(h) = self.reminder_runner.take() {
-            h.abort();
-        }
-        for h in self.sub_agent_handles.drain(..) {
-            h.abort();
-        }
-    }
-
-    /// Abort only adapter components (used for adapter-only config changes).
-    pub async fn abort_adapters(&mut self) {
-        for token in &self.adapter_cancel_tokens {
-            token.cancel();
-        }
-        if !self.adapter_handles.is_empty() {
-            tokio::time::sleep(Duration::from_millis(1000)).await;
-        }
-        for h in self.adapter_handles.drain(..) {
-            h.abort();
-        }
-        self.adapter_cancel_tokens.clear();
-    }
-
-    /// Abort only schedule/reminder components (used for schedule-only config changes).
-    pub fn abort_schedules(&mut self) {
-        if let Some(h) = self.schedule_watcher.take() {
-            h.abort();
-        }
-        if let Some(h) = self.reminder_runner.take() {
-            h.abort();
-        }
-    }
-
-    /// Abort only sub-agent worker components.
-    pub fn abort_sub_agents(&mut self) {
-        for h in self.sub_agent_handles.drain(..) {
-            h.abort();
-        }
-    }
-
-    /// Return a summary string of component counts.
-    pub fn summary(&self) -> String {
-        format!(
-            "adapters={}, schedules={}, sub_agents={}",
-            self.adapter_handles.len(),
-            if self.schedule_watcher.is_some() {
-                1
-            } else {
-                0
-            },
-            self.sub_agent_handles.len(),
-        )
-    }
-}
 
 /// Spawn all restartable components for an agent and return their handles.
 pub async fn spawn_components(
@@ -477,64 +373,6 @@ fn file_mtime(path: &str) -> Option<std::time::SystemTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_agent_components_summary() {
-        let components = AgentComponents {
-            adapter_handles: Vec::new(),
-            adapter_cancel_tokens: Vec::new(),
-            schedule_watcher: None,
-            config_watcher: None,
-            reminder_runner: None,
-            sub_agent_handles: Vec::new(),
-        };
-        assert_eq!(
-            components.summary(),
-            "adapters=0, schedules=0, sub_agents=0"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_agent_components_abort_all_empty() {
-        let mut components = AgentComponents {
-            adapter_handles: Vec::new(),
-            adapter_cancel_tokens: Vec::new(),
-            schedule_watcher: None,
-            config_watcher: None,
-            reminder_runner: None,
-            sub_agent_handles: Vec::new(),
-        };
-        // Should not panic on empty components.
-        components.abort_all().await;
-        assert!(components.adapter_handles.is_empty());
-        assert!(components.adapter_cancel_tokens.is_empty());
-        assert!(components.schedule_watcher.is_none());
-        assert!(components.sub_agent_handles.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_adapter_cancel_token_fires_on_abort_adapters() {
-        let token = CancellationToken::new();
-        let child = token.clone();
-
-        // Spawn a task that waits for cancellation.
-        let handle = tokio::spawn(async move {
-            child.cancelled().await;
-        });
-
-        let mut components = AgentComponents {
-            adapter_handles: vec![handle],
-            adapter_cancel_tokens: vec![token],
-            schedule_watcher: None,
-            config_watcher: None,
-            reminder_runner: None,
-            sub_agent_handles: Vec::new(),
-        };
-
-        components.abort_adapters().await;
-        assert!(components.adapter_handles.is_empty());
-        assert!(components.adapter_cancel_tokens.is_empty());
-    }
 
     #[test]
     fn test_file_mtime_missing() {

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -33,48 +33,9 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::app::config_changeset::{ConfigChangeset, classify_config_change};
 use crate::app::{adapters, config_watcher, schedule, worker};
 use crate::config;
-
-// ─── Part B: config diff classifier ─────────────────────────────────────────
-
-/// What changed between two `UserConfig` snapshots.
-#[derive(Debug, Default, PartialEq)]
-pub struct ConfigChangeset {
-    /// Telegram routes, token, or admin_ids changed → adapter restart needed.
-    pub adapters_changed: bool,
-    /// Schedules changed → schedule_watcher restart needed.
-    pub schedules_changed: bool,
-    /// Sub-agent definitions changed → sub-agent worker restart needed.
-    pub sub_agents_changed: bool,
-    /// Only system_prompt changed (and nothing else requiring a restart).
-    pub system_prompt_only: bool,
-}
-
-/// Compare two `UserConfig` snapshots and classify what changed.
-/// Returns a `ConfigChangeset` that callers use to decide which components
-/// need to be restarted.
-pub fn classify_config_change(
-    old: &config::UserConfig,
-    new: &config::UserConfig,
-) -> ConfigChangeset {
-    let adapters_changed = old.telegram != new.telegram || old.discord != new.discord;
-    let schedules_changed = old.schedules != new.schedules;
-    let sub_agents_changed = old.agents != new.agents;
-    let system_prompt_changed = old.system_prompt != new.system_prompt;
-
-    // Classify as system-prompt-only when ONLY the system prompt differs and
-    // nothing that requires restarting any component has changed.
-    let system_prompt_only =
-        system_prompt_changed && !adapters_changed && !schedules_changed && !sub_agents_changed;
-
-    ConfigChangeset {
-        adapters_changed,
-        schedules_changed,
-        sub_agents_changed,
-        system_prompt_only,
-    }
-}
 
 // ─── Part A: AgentComponents with cooperative cancellation ──────────────────
 
@@ -516,87 +477,6 @@ fn file_mtime(path: &str) -> Option<std::time::SystemTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ScheduleAction, ScheduleDef, TelegramRoute, TelegramRoutesConfig};
-
-    fn base_config() -> config::UserConfig {
-        config::UserConfig {
-            system_prompt: "You are a helpful assistant.".into(),
-            ..Default::default()
-        }
-    }
-
-    // ── classify_config_change ────────────────────────────────────────────────
-
-    #[test]
-    fn test_classify_no_change() {
-        let cfg = base_config();
-        let cs = classify_config_change(&cfg, &cfg);
-        assert_eq!(cs, ConfigChangeset::default());
-        assert!(!cs.system_prompt_only);
-    }
-
-    #[test]
-    fn test_classify_system_prompt_only() {
-        let old = base_config();
-        let mut new = old.clone();
-        new.system_prompt = "New prompt.".into();
-        let cs = classify_config_change(&old, &new);
-        assert!(cs.system_prompt_only);
-        assert!(!cs.adapters_changed);
-        assert!(!cs.schedules_changed);
-        assert!(!cs.sub_agents_changed);
-    }
-
-    #[test]
-    fn test_classify_telegram_routes_changed() {
-        let old = base_config();
-        let mut new = old.clone();
-        new.telegram = Some(TelegramRoutesConfig {
-            routes: vec![TelegramRoute {
-                chat_id: 12345,
-                mention_only: false,
-                name: None,
-                route_to: None,
-            }],
-        });
-        let cs = classify_config_change(&old, &new);
-        assert!(cs.adapters_changed);
-        assert!(!cs.system_prompt_only);
-        assert!(!cs.schedules_changed);
-    }
-
-    #[test]
-    fn test_classify_schedules_changed() {
-        let old = base_config();
-        let mut new = old.clone();
-        new.schedules = vec![ScheduleDef {
-            cron: "0 9 * * *".into(),
-            target: "agent:dev".into(),
-            action: ScheduleAction::Raw,
-            config: None,
-            timezone: None,
-        }];
-        let cs = classify_config_change(&old, &new);
-        assert!(cs.schedules_changed);
-        assert!(!cs.adapters_changed);
-        assert!(!cs.system_prompt_only);
-    }
-
-    #[test]
-    fn test_classify_system_prompt_and_adapters_not_prompt_only() {
-        let old = base_config();
-        let mut new = old.clone();
-        new.system_prompt = "Updated.".into();
-        new.telegram = Some(TelegramRoutesConfig { routes: vec![] });
-        let cs = classify_config_change(&old, &new);
-        assert!(
-            !cs.system_prompt_only,
-            "both changed — should not be prompt-only"
-        );
-        assert!(cs.adapters_changed);
-    }
-
-    // ── AgentComponents helpers ──────────────────────────────────────────────
 
     #[test]
     fn test_agent_components_summary() {

--- a/src/app/context_size.rs
+++ b/src/app/context_size.rs
@@ -676,7 +676,7 @@ mod tests {
     #[test]
     fn pick_entry_returns_none_when_no_log_at_all() {
         // Empty session window AND empty full log → genuinely n/a.
-        let result = pick_entry_with_staleness(vec![], || vec![], true);
+        let result = pick_entry_with_staleness(vec![], Vec::new, true);
         assert!(result.is_none());
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,6 +15,7 @@ pub mod bus;
 pub mod bus_api;
 pub mod cli;
 pub mod commands;
+pub mod config_changeset;
 pub mod config_reload;
 pub mod config_watcher;
 pub mod context;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,6 +9,7 @@ pub mod a2a_server;
 pub mod acp;
 pub mod adapters;
 pub mod agent;
+pub mod agent_components;
 pub mod agent_process;
 pub mod agent_registry;
 pub mod bus;

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,13 +119,13 @@ pub struct DiscordConfig {
 }
 
 /// Discord channel routing config in the per-user deskd.yaml.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DiscordRoutesConfig {
     pub routes: Vec<DiscordRoute>,
 }
 
 /// A single Discord channel route.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DiscordRoute {
     /// Discord channel ID (u64).
     pub channel_id: u64,
@@ -347,7 +347,7 @@ impl ServeState {
 /// Per-user agent config (deskd.yaml, lives in the agent's work_dir).
 /// Defines the agent's own model, system prompt, sub-agents, channels,
 /// Telegram routes, and schedules. Managed by the agent's unix user.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct UserConfig {
     /// Claude model for the main agent. Overridden by workspace.yaml `model` if set.
     #[serde(default = "default_model")]
@@ -404,7 +404,7 @@ pub struct UserConfig {
 
 /// An A2A skill advertised in the Agent Card (per A2A spec).
 /// Defined in deskd.yaml under `skills:`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SkillDef {
     /// Unique skill identifier (e.g. "code-review").
     pub id: String,
@@ -420,7 +420,7 @@ pub struct SkillDef {
 
 /// An A2A need — what the agent wants done (custom extension).
 /// Defined in deskd.yaml under `needs:`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NeedDef {
     /// Unique need identifier (e.g. "want-restart-button").
     pub id: String,
@@ -444,7 +444,7 @@ fn default_model() -> String {
 
 /// A named channel for broadcast or task-queue communication.
 /// The name becomes the bus target, e.g. `news:ecosystem` or `queue:reviews`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChannelDef {
     pub name: String,
     pub description: String,
@@ -465,7 +465,7 @@ pub enum ScopeType {
 }
 
 /// A sub-agent running within a parent agent's bus scope.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SubAgentDef {
     pub name: String,
     pub model: String,
@@ -548,14 +548,14 @@ impl SubAgentDef {
 }
 
 /// Telegram channel routing config in the per-user deskd.yaml.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TelegramRoutesConfig {
     #[serde(default)]
     pub routes: Vec<TelegramRoute>,
 }
 
 /// A single Telegram chat route.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TelegramRoute {
     /// Telegram chat_id (positive for users/groups, negative for channels/supergroups).
     pub chat_id: i64,
@@ -571,7 +571,7 @@ pub struct TelegramRoute {
 }
 
 /// A scheduled action that fires on a cron expression and posts a message to the bus.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ScheduleDef {
     /// Cron expression, e.g. `"0 9 * * *"` for 9 AM daily.
     pub cron: String,
@@ -587,7 +587,7 @@ pub struct ScheduleDef {
     pub timezone: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ScheduleAction {
     /// Poll GitHub repos for issues with a label, post new issues to target.

--- a/src/domain/config_types.rs
+++ b/src/domain/config_types.rs
@@ -71,7 +71,7 @@ impl From<&AgentRuntime> for ConfigAgentRuntime {
 // ─── ContextConfig ─────────────────────────────────────────────────────────
 
 /// Config-level context configuration (serde for YAML parsing).
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct ConfigContextConfig {
     pub enabled: bool,
     pub main_budget_tokens: Option<u32>,

--- a/src/infra/dto/config.rs
+++ b/src/infra/dto/config.rs
@@ -16,7 +16,7 @@ pub use crate::domain::config_types::{ConfigAgentRuntime, ConfigContextConfig, C
 // ─── ModelDef / TransitionDef ───────────────────────────────────────────────
 
 /// Config-level state machine model definition (serde for YAML parsing).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ConfigModelDef {
     pub name: String,
     #[serde(default)]
@@ -29,7 +29,7 @@ pub struct ConfigModelDef {
 }
 
 /// Config-level transition definition (serde for YAML parsing).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ConfigTransitionDef {
     pub from: String,
     pub to: String,
@@ -58,7 +58,7 @@ pub struct ConfigTransitionDef {
 }
 
 /// Config-level task criteria (serde for YAML parsing).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct ConfigTaskCriteria {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,


### PR DESCRIPTION
## Summary

Fixes #405 — Telegram adapter no longer drops in-flight messages when `deskd.yaml` is reloaded.

### Part A — Cooperative cancellation (graceful adapter shutdown)

- **Replace `teloxide::repl()`** with a manual `bot.get_updates()` long-poll loop wrapped in `tokio::select!`, so the polling loop exits cleanly when its `CancellationToken` is cancelled.
- **`TelegramAdapter`** stores a `CancellationToken`; all subtasks (`bus_loop`, `outbound_sender`, `polling_loop`) receive clones and race against `cancel.cancelled()`.
- **`build_adapters()`** return type changed from `Vec<Box<dyn Adapter>>` to `Vec<(Box<dyn Adapter>, CancellationToken)>` so callers can store per-adapter tokens.
- **`AgentComponents`** gains `adapter_cancel_tokens: Vec<CancellationToken>`.
- **`abort_all()` and `abort_adapters()`** now: (1) cancel tokens, (2) sleep 1 s grace period, (3) abort task handles — giving adapters time to drain in-flight messages before hard abort.

### Part B — Selective config diff classifier

- **`ConfigChangeset` struct** captures which dimensions changed (adapters, schedules, sub-agents, system-prompt-only).
- **`classify_config_change(old, new)`** compares `PartialEq`-enabled `UserConfig` fields to determine minimum restart scope.
- **`watch_and_reload()`** now does selective restarts instead of blanket `abort_all + respawn`:
  - `system_prompt_only` → **no restart** (config_watcher.rs injects prompt via bus)
  - `adapters_changed` only → `abort_adapters()` + `spawn_adapters()` only
  - `schedules_changed` only → `abort_schedules()` + `spawn_schedules()` only
  - combined or sub-agents → full `abort_all()` + `spawn_components()`

### Other

- Fixed pre-existing `clippy::redundant_closure` in `context_size.rs` tests (unrelated but required for `-D warnings` gate).
- Added `PartialEq` derives to all `UserConfig` nested types required for diffing.

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings/errors
- [ ] `cargo test --all` — 491 unit tests + all integration tests pass, zero failures
- [ ] `test_classify_*` unit tests validate all 4 classifier cases
- [ ] `test_adapter_cancel_token_fires_on_abort_adapters` validates cooperative shutdown lifecycle
- [ ] `test_agent_components_abort_all_empty` validates no-panic on empty component set