### PR TITLE
refactor(config_reload): split out ConfigChangeset classifier

### DIFF
--- a/src/app/config_changeset.rs
+++ b/src/app/config_changeset.rs
@@ -1,0 +1,128 @@
+//! Config diff classifier — figures out which restartable components need to
+//! be restarted when `deskd.yaml` changes.
+//!
+//! Used by `config_reload::watch_and_reload` to drive selective restarts so
+//! that, e.g., a `system_prompt`-only edit does not disrupt the Telegram
+//! adapter.
+
+use crate::config;
+
+/// What changed between two `UserConfig` snapshots.
+#[derive(Debug, Default, PartialEq)]
+pub struct ConfigChangeset {
+    /// Telegram routes, token, or admin_ids changed → adapter restart needed.
+    pub adapters_changed: bool,
+    /// Schedules changed → schedule_watcher restart needed.
+    pub schedules_changed: bool,
+    /// Sub-agent definitions changed → sub-agent worker restart needed.
+    pub sub_agents_changed: bool,
+    /// Only system_prompt changed (and nothing else requiring a restart).
+    pub system_prompt_only: bool,
+}
+
+/// Compare two `UserConfig` snapshots and classify what changed.
+/// Returns a `ConfigChangeset` that callers use to decide which components
+/// need to be restarted.
+pub fn classify_config_change(
+    old: &config::UserConfig,
+    new: &config::UserConfig,
+) -> ConfigChangeset {
+    let adapters_changed = old.telegram != new.telegram || old.discord != new.discord;
+    let schedules_changed = old.schedules != new.schedules;
+    let sub_agents_changed = old.agents != new.agents;
+    let system_prompt_changed = old.system_prompt != new.system_prompt;
+
+    // Classify as system-prompt-only when ONLY the system prompt differs and
+    // nothing that requires restarting any component has changed.
+    let system_prompt_only =
+        system_prompt_changed && !adapters_changed && !schedules_changed && !sub_agents_changed;
+
+    ConfigChangeset {
+        adapters_changed,
+        schedules_changed,
+        sub_agents_changed,
+        system_prompt_only,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ScheduleAction, ScheduleDef, TelegramRoute, TelegramRoutesConfig};
+
+    fn base_config() -> config::UserConfig {
+        config::UserConfig {
+            system_prompt: "You are a helpful assistant.".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_classify_no_change() {
+        let cfg = base_config();
+        let cs = classify_config_change(&cfg, &cfg);
+        assert_eq!(cs, ConfigChangeset::default());
+        assert!(!cs.system_prompt_only);
+    }
+
+    #[test]
+    fn test_classify_system_prompt_only() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.system_prompt = "New prompt.".into();
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.system_prompt_only);
+        assert!(!cs.adapters_changed);
+        assert!(!cs.schedules_changed);
+        assert!(!cs.sub_agents_changed);
+    }
+
+    #[test]
+    fn test_classify_telegram_routes_changed() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.telegram = Some(TelegramRoutesConfig {
+            routes: vec![TelegramRoute {
+                chat_id: 12345,
+                mention_only: false,
+                name: None,
+                route_to: None,
+            }],
+        });
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.adapters_changed);
+        assert!(!cs.system_prompt_only);
+        assert!(!cs.schedules_changed);
+    }
+
+    #[test]
+    fn test_classify_schedules_changed() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.schedules = vec![ScheduleDef {
+            cron: "0 9 * * *".into(),
+            target: "agent:dev".into(),
+            action: ScheduleAction::Raw,
+            config: None,
+            timezone: None,
+        }];
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.schedules_changed);
+        assert!(!cs.adapters_changed);
+        assert!(!cs.system_prompt_only);
+    }
+
+    #[test]
+    fn test_classify_system_prompt_and_adapters_not_prompt_only() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.system_prompt = "Updated.".into();
+        new.telegram = Some(TelegramRoutesConfig { routes: vec![] });
+        let cs = classify_config_change(&old, &new);
+        assert!(
+            !cs.system_prompt_only,
+            "both changed — should not be prompt-only"
+        );
+        assert!(cs.adapters_changed);
+    }
+}

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -33,48 +33,9 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::app::config_changeset::{ConfigChangeset, classify_config_change};
 use crate::app::{adapters, config_watcher, schedule, worker};
 use crate::config;
-
-// ─── Part B: config diff classifier ─────────────────────────────────────────
-
-/// What changed between two `UserConfig` snapshots.
-#[derive(Debug, Default, PartialEq)]
-pub struct ConfigChangeset {
-    /// Telegram routes, token, or admin_ids changed → adapter restart needed.
-    pub adapters_changed: bool,
-    /// Schedules changed → schedule_watcher restart needed.
-    pub schedules_changed: bool,
-    /// Sub-agent definitions changed → sub-agent worker restart needed.
-    pub sub_agents_changed: bool,
-    /// Only system_prompt changed (and nothing else requiring a restart).
-    pub system_prompt_only: bool,
-}
-
-/// Compare two `UserConfig` snapshots and classify what changed.
-/// Returns a `ConfigChangeset` that callers use to decide which components
-/// need to be restarted.
-pub fn classify_config_change(
-    old: &config::UserConfig,
-    new: &config::UserConfig,
-) -> ConfigChangeset {
-    let adapters_changed = old.telegram != new.telegram || old.discord != new.discord;
-    let schedules_changed = old.schedules != new.schedules;
-    let sub_agents_changed = old.agents != new.agents;
-    let system_prompt_changed = old.system_prompt != new.system_prompt;
-
-    // Classify as system-prompt-only when ONLY the system prompt differs and
-    // nothing that requires restarting any component has changed.
-    let system_prompt_only =
-        system_prompt_changed && !adapters_changed && !schedules_changed && !sub_agents_changed;
-
-    ConfigChangeset {
-        adapters_changed,
-        schedules_changed,
-        sub_agents_changed,
-        system_prompt_only,
-    }
-}
 
 // ─── Part A: AgentComponents with cooperative cancellation ──────────────────
 
@@ -516,87 +477,6 @@ fn file_mtime(path: &str) -> Option<std::time::SystemTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ScheduleAction, ScheduleDef, TelegramRoute, TelegramRoutesConfig};
-
-    fn base_config() -> config::UserConfig {
-        config::UserConfig {
-            system_prompt: "You are a helpful assistant.".into(),
-            ..Default::default()
-        }
-    }
-
-    // ── classify_config_change ────────────────────────────────────────────────
-
-    #[test]
-    fn test_classify_no_change() {
-        let cfg = base_config();
-        let cs = classify_config_change(&cfg, &cfg);
-        assert_eq!(cs, ConfigChangeset::default());
-        assert!(!cs.system_prompt_only);
-    }
-
-    #[test]
-    fn test_classify_system_prompt_only() {
-        let old = base_config();
-        let mut new = old.clone();
-        new.system_prompt = "New prompt.".into();
-        let cs = classify_config_change(&old, &new);
-        assert!(cs.system_prompt_only);
-        assert!(!cs.adapters_changed);
-        assert!(!cs.schedules_changed);
-        assert!(!cs.sub_agents_changed);
-    }
-
-    #[test]
-    fn test_classify_telegram_routes_changed() {
-        let old = base_config();
-        let mut new = old.clone();
-        new.telegram = Some(TelegramRoutesConfig {
-            routes: vec![TelegramRoute {
-                chat_id: 12345,
-                mention_only: false,
-                name: None,
-                route_to: None,
-            }],
-        });
-        let cs = classify_config_change(&old, &new);
-        assert!(cs.adapters_changed);
-        assert!(!cs.system_prompt_only);
-        assert!(!cs.schedules_changed);
-    }
-
-    #[test]
-    fn test_classify_schedules_changed() {
-        let old = base_config();
-        let mut new = old.clone();
-        new.schedules = vec![ScheduleDef {
-            cron: "0 9 * * *".into(),
-            target: "agent:dev".into(),
-            action: ScheduleAction::Raw,
-            config: None,
-            timezone: None,
-        }];
-        let cs = classify_config_change(&old, &new);
-        assert!(cs.schedules_changed);
-        assert!(!cs.adapters_changed);
-        assert!(!cs.system_prompt_only);
-    }
-
-    #[test]
-    fn test_classify_system_prompt_and_adapters_not_prompt_only() {
-        let old = base_config();
-        let mut new = old.clone();
-        new.system_prompt = "Updated.".into();
-        new.telegram = Some(TelegramRoutesConfig { routes: vec![] });
-        let cs = classify_config_change(&old, &new);
-        assert!(
-            !cs.system_prompt_only,
-            "both changed — should not be prompt-only"
-        );
-        assert!(cs.adapters_changed);
-    }
-
-    // ── AgentComponents helpers ──────────────────────────────────────────────
 
     #[test]
     fn test_agent_components_summary() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,6 +15,7 @@ pub mod bus;
 pub mod bus_api;
 pub mod cli;
 pub mod commands;
+pub mod config_changeset;
 pub mod config_reload;
 pub mod config_watcher;
 pub mod context;


### PR DESCRIPTION
Per your review on #408 — splits the diff classifier into its own module.

## Changes
- New `src/app/config_changeset.rs` — `ConfigChangeset` struct, `classify_config_change()`, and the 5 classifier unit tests.
- `src/app/config_reload.rs` keeps only the watcher loop and restart orchestration.
- `src/app/mod.rs` registers the new module.

## Result
- `config_reload.rs`: 668 → **548 lines**, **10 production functions** (at the SRP threshold).
- `config_changeset.rs`: 128 lines, 1 production function + 5 tests.
- 48 lines over the 500 heuristic — let me know if you want me to trim further or if the function-count win is enough.

## Verification
- `cargo build` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test config_changeset` → 5 passed
- `cargo test config_reload` → 5 passed

Targets the `fix/405-telegram-graceful-reload` PR branch so it lands with #408.