### PR TITLE
feat(context): add context agent kind — lightweight worker path (#220)

### DIFF
--- a/src/app/agent_registry.rs
+++ b/src/app/agent_registry.rs
@@ -12,7 +12,9 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
 
 use crate::config::{self, ContainerConfig, UserConfig};
-use crate::domain::config_types::{ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode};
+use crate::domain::config_types::{
+    ConfigAgentKind, ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode,
+};
 
 use super::process_builder::{build_command, inject_required_flags};
 
@@ -44,6 +46,9 @@ pub struct AgentConfig {
     /// Agent runtime protocol: claude (default) or acp.
     #[serde(default)]
     pub runtime: ConfigAgentRuntime,
+    /// Worker loop kind: executor (default, full lifecycle) or context (lightweight Q&A).
+    #[serde(default)]
+    pub kind: ConfigAgentKind,
     /// Context system configuration (main branch, compaction).
     #[serde(default)]
     pub context: Option<ConfigContextConfig>,
@@ -260,6 +265,7 @@ pub async fn create_or_recover(
         container: def.container.clone(),
         session: ConfigSessionMode::default(),
         runtime: def.runtime.clone(),
+        kind: ConfigAgentKind::default(),
         context: user_cfg.and_then(|c| c.context.clone()),
         compact_threshold: None,
         auto_compact_threshold_tokens: user_cfg.and_then(|c| c.auto_compact_threshold_tokens),
@@ -682,6 +688,7 @@ pub async fn spawn_ephemeral(
         container: None,
         session: ConfigSessionMode::default(),
         runtime: ConfigAgentRuntime::default(),
+        kind: ConfigAgentKind::default(),
         context: None,
         compact_threshold: None,
         auto_compact_threshold_tokens: None,
@@ -738,6 +745,7 @@ created_at: "2024-01-01T00:00:00Z"
             container: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
@@ -802,6 +810,7 @@ created_at: "2024-01-01T00:00:00Z"
             container: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,

--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -38,6 +38,7 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 container: None,
                 session: crate::domain::config_types::ConfigSessionMode::default(),
                 runtime: crate::domain::config_types::ConfigAgentRuntime::default(),
+                kind: crate::domain::config_types::ConfigAgentKind::default(),
                 context: None,
                 compact_threshold: None,
                 auto_compact_threshold_tokens: None,

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -102,6 +102,13 @@ pub async fn spawn_components(
     // Sub-agent workers
     if let Some(ucfg) = user_cfg {
         for sub in &ucfg.agents {
+            let is_context = matches!(
+                sub.kind,
+                crate::domain::config_types::ConfigAgentKind::Context
+            );
+
+            // Context agents are lightweight Q&A workers — no MCP server, no
+            // tool access. Executor agents get the full deskd MCP plumbing.
             let mcp_json = serde_json::json!({
                 "mcpServers": {
                     "deskd": {
@@ -114,6 +121,22 @@ pub async fn spawn_components(
 
             let context_cfg = sub.context.clone().or_else(|| ucfg.context.clone());
 
+            let mut command: Vec<String> = vec![
+                "claude".into(),
+                "--output-format".into(),
+                "stream-json".into(),
+                "--verbose".into(),
+                "--dangerously-skip-permissions".into(),
+                "--model".into(),
+                sub.model.clone(),
+                "--max-turns".into(),
+                ucfg.max_turns.to_string(),
+            ];
+            if !is_context {
+                command.push("--mcp-config".into());
+                command.push(mcp_json);
+            }
+
             let sub_cfg = crate::app::agent::AgentConfig {
                 name: sub.name.clone(),
                 model: sub.model.clone(),
@@ -122,23 +145,12 @@ pub async fn spawn_components(
                 max_turns: ucfg.max_turns,
                 unix_user: def.unix_user.clone(),
                 budget_usd: def.budget_usd,
-                command: vec![
-                    "claude".into(),
-                    "--output-format".into(),
-                    "stream-json".into(),
-                    "--verbose".into(),
-                    "--dangerously-skip-permissions".into(),
-                    "--model".into(),
-                    sub.model.clone(),
-                    "--max-turns".into(),
-                    ucfg.max_turns.to_string(),
-                    "--mcp-config".into(),
-                    mcp_json,
-                ],
+                command,
                 config_path: Some(cfg_path.to_string()),
                 container: def.container.clone(),
                 session: sub.session.clone(),
                 runtime: sub.runtime.clone(),
+                kind: sub.kind.clone(),
                 context: context_cfg,
                 compact_threshold: sub.compact_threshold,
                 auto_compact_threshold_tokens: sub

--- a/src/app/context_size.rs
+++ b/src/app/context_size.rs
@@ -602,6 +602,7 @@ mod tests {
                 container: None,
                 session: Default::default(),
                 runtime: Default::default(),
+                kind: Default::default(),
                 context: None,
                 compact_threshold: None,
                 auto_compact_threshold_tokens: None,

--- a/src/app/process_builder.rs
+++ b/src/app/process_builder.rs
@@ -247,7 +247,7 @@ pub fn split_command(command: &[String]) -> (&str, &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::config_types::{ConfigAgentRuntime, ConfigSessionMode};
+    use crate::domain::config_types::{ConfigAgentKind, ConfigAgentRuntime, ConfigSessionMode};
     use std::collections::HashMap;
 
     #[test]
@@ -388,6 +388,7 @@ mod tests {
             container: Some(container),
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
@@ -439,6 +440,7 @@ mod tests {
             container: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
@@ -463,6 +465,7 @@ mod tests {
             container: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
@@ -498,6 +501,7 @@ mod tests {
             container: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
@@ -522,6 +526,7 @@ mod tests {
             container: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: Some(500_000),
@@ -547,6 +552,7 @@ mod tests {
             container: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
@@ -570,6 +576,7 @@ mod tests {
             container: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: Some(400_000),

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -10,7 +10,7 @@ use crate::app::agent::{self, Executor, TokenUsage};
 use crate::app::message::Message;
 use crate::app::tasklog;
 use crate::app::unified_inbox;
-use crate::domain::agent::AgentRuntime;
+use crate::domain::agent::{AgentKind, AgentRuntime};
 use crate::domain::config_types::ConfigSessionMode;
 use crate::domain::events::DomainEvent;
 
@@ -191,19 +191,29 @@ pub async fn run(
     // Start persistent agent process (reused across tasks).
     let effective_bus = bus_socket.as_deref().unwrap_or(socket_path).to_string();
     let agent_runtime: AgentRuntime = initial_state.config.runtime.clone().into();
+    let agent_kind: AgentKind = initial_state.config.kind.clone().into();
     let mut process = start_executor(name, &effective_bus, &agent_runtime).await?;
 
     // Build task limits from agent config — enforced in real-time during tasks.
+    // Context agents get a tight max_turns cap for fast Q&A (no tool loops).
+    let configured_max_turns = if initial_state.config.max_turns > 0 {
+        Some(initial_state.config.max_turns)
+    } else {
+        None
+    };
+    let max_turns = match agent_kind {
+        AgentKind::Context => Some(match configured_max_turns {
+            Some(t) => t.min(3),
+            None => 3,
+        }),
+        AgentKind::Executor => configured_max_turns,
+    };
     let limits = agent::TaskLimits {
-        max_turns: if initial_state.config.max_turns > 0 {
-            Some(initial_state.config.max_turns)
-        } else {
-            None
-        },
+        max_turns,
         budget_usd: Some(budget_usd),
     };
 
-    info!(agent = %name, runtime = ?agent_runtime, "agent process ready, waiting for tasks");
+    info!(agent = %name, runtime = ?agent_runtime, kind = ?agent_kind, "agent process ready, waiting for tasks");
 
     // Startup recovery: handle orphaned active tasks assigned to this agent.
     recover_orphaned_tasks(name, task_store);
@@ -291,6 +301,24 @@ pub async fn run(
                 continue;
             }
         };
+
+        // ── Context agent: lightweight Q&A path ─────────────────────────
+        // Context agents only respond to direct questions (target == agent:{name}).
+        // Fan-out subscriptions (queue:tasks, telegram.in:*) are dropped early
+        // so the agent stays focused. Combined with the clamped max_turns set
+        // above, this gives short-loop answers for context lookups.
+        if agent_kind == AgentKind::Context {
+            let direct_target = format!("agent:{}", name);
+            if msg.target != direct_target {
+                debug!(
+                    agent = %name,
+                    source = %msg.source,
+                    target = %msg.target,
+                    "context: skipping non-direct message"
+                );
+                continue;
+            }
+        }
 
         // ── Memory agent: inject bus events as context ──────────────────
         // For memory agents, messages that are NOT direct questions

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,6 @@
-use crate::domain::config_types::{ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode};
+use crate::domain::config_types::{
+    ConfigAgentKind, ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode,
+};
 use crate::infra::dto::ConfigModelDef;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -511,6 +513,11 @@ pub struct SubAgentDef {
     /// Agent runtime protocol: claude (default) or acp.
     #[serde(default)]
     pub runtime: ConfigAgentRuntime,
+    /// Worker loop kind: executor (default, full lifecycle) or context (lightweight Q&A).
+    /// Context agents have no tool access, no task queue, no inbox — they answer
+    /// questions from their loaded context with minimal overhead.
+    #[serde(default)]
+    pub kind: ConfigAgentKind,
     /// Per-agent context configuration (overrides global UserConfig.context).
     #[serde(default)]
     pub context: Option<ConfigContextConfig>,
@@ -1477,6 +1484,7 @@ agents:
             env: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             compact_strategy: None,
@@ -1500,6 +1508,7 @@ agents:
             env: None,
             session: ConfigSessionMode::default(),
             runtime: ConfigAgentRuntime::default(),
+            kind: ConfigAgentKind::default(),
             context: None,
             compact_threshold: None,
             compact_strategy: None,

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -25,6 +25,21 @@ pub enum AgentRuntime {
     Memory,
 }
 
+/// Worker loop kind: full executor or lightweight context agent.
+///
+/// Executor agents go through the full task lifecycle: queue, inbox,
+/// progress tracking, tool use. Context agents are lightweight Q&A
+/// responders — they answer questions from their loaded context with
+/// no tool access, no task queue, no inbox.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum AgentKind {
+    /// Full task lifecycle with tools, inbox, queue, progress (default).
+    #[default]
+    Executor,
+    /// Lightweight Q&A from loaded context — no tools, no queue, no inbox.
+    Context,
+}
+
 /// Domain-level representation of an agent with capabilities and status.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Agent {
@@ -178,5 +193,15 @@ mod tests {
         let rt = AgentRuntime::Memory;
         assert_ne!(rt, AgentRuntime::Claude);
         assert_ne!(rt, AgentRuntime::Acp);
+    }
+
+    #[test]
+    fn default_agent_kind_is_executor() {
+        assert_eq!(AgentKind::default(), AgentKind::Executor);
+    }
+
+    #[test]
+    fn agent_kind_variants_distinct() {
+        assert_ne!(AgentKind::Executor, AgentKind::Context);
     }
 }

--- a/src/domain/config_types.rs
+++ b/src/domain/config_types.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::agent::{AgentRuntime, SessionMode};
+use super::agent::{AgentKind, AgentRuntime, SessionMode};
 use super::context::ContextConfig;
 
 // ─── SessionMode / AgentRuntime ─────────────────────────────────────────────
@@ -68,6 +68,35 @@ impl From<&AgentRuntime> for ConfigAgentRuntime {
     }
 }
 
+// ─── AgentKind ──────────────────────────────────────────────────────────────
+
+/// Config-level agent kind (serde for YAML parsing).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigAgentKind {
+    #[default]
+    Executor,
+    Context,
+}
+
+impl From<ConfigAgentKind> for AgentKind {
+    fn from(dto: ConfigAgentKind) -> Self {
+        match dto {
+            ConfigAgentKind::Executor => AgentKind::Executor,
+            ConfigAgentKind::Context => AgentKind::Context,
+        }
+    }
+}
+
+impl From<&AgentKind> for ConfigAgentKind {
+    fn from(k: &AgentKind) -> Self {
+        match k {
+            AgentKind::Executor => ConfigAgentKind::Executor,
+            AgentKind::Context => ConfigAgentKind::Context,
+        }
+    }
+}
+
 // ─── ContextConfig ─────────────────────────────────────────────────────────
 
 /// Config-level context configuration (serde for YAML parsing).
@@ -119,5 +148,27 @@ mod tests {
         let yaml = "memory";
         let rt: ConfigAgentRuntime = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(rt, ConfigAgentRuntime::Memory);
+    }
+
+    #[test]
+    fn config_agent_kind_default_is_executor() {
+        assert_eq!(ConfigAgentKind::default(), ConfigAgentKind::Executor);
+    }
+
+    #[test]
+    fn config_agent_kind_roundtrip() {
+        let dto = ConfigAgentKind::Context;
+        let domain: AgentKind = dto.into();
+        assert_eq!(domain, AgentKind::Context);
+        let back: ConfigAgentKind = (&domain).into();
+        assert_eq!(back, ConfigAgentKind::Context);
+    }
+
+    #[test]
+    fn config_agent_kind_serde() {
+        let executor: ConfigAgentKind = serde_yaml::from_str("executor").unwrap();
+        assert_eq!(executor, ConfigAgentKind::Executor);
+        let context: ConfigAgentKind = serde_yaml::from_str("context").unwrap();
+        assert_eq!(context, ConfigAgentKind::Context);
     }
 }

--- a/src/infra/dto/config.rs
+++ b/src/infra/dto/config.rs
@@ -11,7 +11,9 @@ use crate::domain::statemachine::{ModelDef, TransitionDef};
 use crate::domain::task::TaskCriteria;
 
 // Re-export config value types from domain.
-pub use crate::domain::config_types::{ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode};
+pub use crate::domain::config_types::{
+    ConfigAgentKind, ConfigAgentRuntime, ConfigContextConfig, ConfigSessionMode,
+};
 
 // ─── ModelDef / TransitionDef ───────────────────────────────────────────────
 

--- a/tests/agent_lifecycle.rs
+++ b/tests/agent_lifecycle.rs
@@ -70,6 +70,7 @@ fn make_config(name: &str) -> deskd::app::agent::AgentConfig {
         container: None,
         session: deskd::infra::dto::ConfigSessionMode::Ephemeral,
         runtime: deskd::infra::dto::ConfigAgentRuntime::Claude,
+        kind: deskd::infra::dto::ConfigAgentKind::Executor,
         context: None,
         compact_threshold: None,
         auto_compact_threshold_tokens: None,

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -86,6 +86,7 @@ fn test_agent_config(name: &str) -> deskd::app::agent::AgentConfig {
         container: None,
         session: deskd::infra::dto::ConfigSessionMode::Persistent,
         runtime: deskd::infra::dto::ConfigAgentRuntime::Claude,
+        kind: deskd::infra::dto::ConfigAgentKind::Executor,
         context: None,
         compact_threshold: None,
         auto_compact_threshold_tokens: None,


### PR DESCRIPTION
## Summary

Adds a `kind: context` option to sub-agents for lightweight Q&A workers without MCP tool access. Defaults to `executor` for backward compat — existing agents are unaffected.

## Changes

- New `AgentKind` enum (`Executor` / `Context`) in `domain`
- `ConfigAgentKind` DTO with `#[serde(rename_all = "lowercase")]` + From impls
- `SubAgentDef.kind` field with `#[serde(default)]` (executor)
- Propagated through `AgentConfig` → worker dispatch
- Context agents skip `--mcp-config` when spawning Claude (no tool access)
- Worker selects lightweight branch for `kind: context`

## Acceptance Criteria

- [x] `SubAgentDef.kind`: `executor` (default) or `context`
- [x] Context agents use lightweight worker loop
- [x] Context agents have no MCP tool access
- [x] Existing executor agents unaffected (defaults preserved)
- [x] Tests pass: `cargo test`
- [x] Quality gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)