### PR TITLE
fix(#416): evict persistent sub-agents when *.agent.md files are removed

### DIFF
--- a/src/app/config_changeset.rs
+++ b/src/app/config_changeset.rs
@@ -18,6 +18,9 @@ pub struct ConfigChangeset {
     pub sub_agents_changed: bool,
     /// Only system_prompt changed (and nothing else requiring a restart).
     pub system_prompt_only: bool,
+    /// Names of sub-agents present in `old` but missing from `new` — their
+    /// state files should be evicted via `agent_registry::remove`.
+    pub removed_sub_agents: Vec<String>,
 }
 
 /// Compare two `UserConfig` snapshots and classify what changed.
@@ -37,11 +40,21 @@ pub fn classify_config_change(
     let system_prompt_only =
         system_prompt_changed && !adapters_changed && !schedules_changed && !sub_agents_changed;
 
+    let new_names: std::collections::HashSet<&str> =
+        new.agents.iter().map(|a| a.name.as_str()).collect();
+    let removed_sub_agents: Vec<String> = old
+        .agents
+        .iter()
+        .filter(|a| !new_names.contains(a.name.as_str()))
+        .map(|a| a.name.clone())
+        .collect();
+
     ConfigChangeset {
         adapters_changed,
         schedules_changed,
         sub_agents_changed,
         system_prompt_only,
+        removed_sub_agents,
     }
 }
 
@@ -110,6 +123,51 @@ mod tests {
         assert!(cs.schedules_changed);
         assert!(!cs.adapters_changed);
         assert!(!cs.system_prompt_only);
+    }
+
+    fn make_sub_agent(name: &str) -> crate::config::SubAgentDef {
+        crate::config::SubAgentDef {
+            name: name.into(),
+            model: "haiku".into(),
+            system_prompt: String::new(),
+            subscribe: vec![],
+            publish: None,
+            inbox_read: None,
+            scope: Default::default(),
+            can_message: None,
+            work_dir: None,
+            env: None,
+            session: Default::default(),
+            runtime: Default::default(),
+            kind: Default::default(),
+            context: None,
+            compact_threshold: None,
+            compact_strategy: None,
+            auto_compact_threshold_tokens: None,
+        }
+    }
+
+    #[test]
+    fn test_classify_removed_sub_agents() {
+        let mut old = base_config();
+        old.agents = vec![make_sub_agent("kept"), make_sub_agent("removed")];
+        let mut new = old.clone();
+        new.agents.retain(|a| a.name != "removed");
+
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.sub_agents_changed);
+        assert_eq!(cs.removed_sub_agents, vec!["removed".to_string()]);
+    }
+
+    #[test]
+    fn test_classify_no_removed_when_only_added() {
+        let old = base_config();
+        let mut new = old.clone();
+        new.agents = vec![make_sub_agent("added")];
+
+        let cs = classify_config_change(&old, &new);
+        assert!(cs.sub_agents_changed);
+        assert!(cs.removed_sub_agents.is_empty());
     }
 
     #[test]

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -256,15 +256,20 @@ pub async fn watch_and_reload(
     let mut last_modified = file_mtime(&cfg_path);
     // Track the last known config for diffing.
     let mut last_user_cfg = config::UserConfig::load(&cfg_path).ok();
+    // Track the agents_dir directory mtime so that creating/removing/renaming
+    // *.agent.md files (which doesn't touch deskd.yaml) still triggers reload.
+    let mut last_agents_dir_mtime = agents_dir_mtime(&cfg_path, last_user_cfg.as_ref());
 
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
 
         let current_mtime = file_mtime(&cfg_path);
-        if current_mtime == last_modified {
+        let current_agents_dir_mtime = agents_dir_mtime(&cfg_path, last_user_cfg.as_ref());
+        if current_mtime == last_modified && current_agents_dir_mtime == last_agents_dir_mtime {
             continue;
         }
         last_modified = current_mtime;
+        last_agents_dir_mtime = current_agents_dir_mtime;
 
         info!(agent = %agent_name, "config file changed, analysing diff");
 
@@ -291,6 +296,7 @@ pub async fn watch_and_reload(
                 schedules_changed: true,
                 sub_agents_changed: true,
                 system_prompt_only: false,
+                removed_sub_agents: Vec::new(),
             }
         };
         last_user_cfg = Some(new_user_cfg.clone());
@@ -348,6 +354,21 @@ pub async fn watch_and_reload(
         components.abort_all().await;
         info!(agent = %agent_name, old = %old_summary, "aborted old components");
 
+        // Evict state files for sub-agents that vanished from config (e.g. their
+        // *.agent.md was deleted). Without this they could be respawned on the
+        // next `deskd serve` because state files survive aborts.
+        for removed in &changeset.removed_sub_agents {
+            match crate::app::agent_registry::remove(removed).await {
+                Ok(()) => info!(agent = %agent_name, removed = %removed, "evicted sub-agent state"),
+                Err(e) => warn!(
+                    agent = %agent_name,
+                    removed = %removed,
+                    error = %e,
+                    "failed to evict sub-agent state"
+                ),
+            }
+        }
+
         match spawn_components(
             &def,
             Some(&new_user_cfg),
@@ -382,9 +403,43 @@ fn file_mtime(path: &str) -> Option<std::time::SystemTime> {
     std::fs::metadata(path).ok().and_then(|m| m.modified().ok())
 }
 
+/// Resolve `user_cfg.agents_dir` relative to the deskd.yaml parent and return
+/// the latest mtime among the directory itself and any contained `*.agent.md`
+/// file. Returns `None` when no agents_dir is configured or the directory is
+/// missing — callers compare for equality so two `None`s match.
+fn agents_dir_mtime(
+    cfg_path: &str,
+    user_cfg: Option<&config::UserConfig>,
+) -> Option<std::time::SystemTime> {
+    let dir_rel = user_cfg.and_then(|c| c.agents_dir.as_deref())?;
+    let base = std::path::Path::new(cfg_path).parent()?;
+    let dir = base.join(dir_rel);
+    let mut latest = std::fs::metadata(&dir)
+        .ok()
+        .and_then(|m| m.modified().ok())?;
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "md")
+                && path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with(".agent.md"))
+                && let Ok(meta) = entry.metadata()
+                && let Ok(mtime) = meta.modified()
+                && mtime > latest
+            {
+                latest = mtime;
+            }
+        }
+    }
+    Some(latest)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn test_file_mtime_missing() {
@@ -394,5 +449,60 @@ mod tests {
     #[test]
     fn test_file_mtime_existing() {
         assert!(file_mtime("Cargo.toml").is_some());
+    }
+
+    #[test]
+    fn test_agents_dir_mtime_none_without_dir_field() {
+        let cfg = config::UserConfig::default();
+        // No agents_dir field configured → returns None.
+        assert!(agents_dir_mtime("/tmp/whatever.yaml", Some(&cfg)).is_none());
+    }
+
+    #[test]
+    fn test_agents_dir_mtime_changes_when_agent_file_added_or_removed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg_path = tmp.path().join("deskd.yaml");
+        std::fs::write(&cfg_path, "model: haiku\nagents_dir: agents.d\n").unwrap();
+
+        let agents_dir = tmp.path().join("agents.d");
+        std::fs::create_dir(&agents_dir).unwrap();
+
+        let cfg = config::UserConfig {
+            agents_dir: Some("agents.d".into()),
+            ..Default::default()
+        };
+
+        let before = agents_dir_mtime(cfg_path.to_str().unwrap(), Some(&cfg));
+        assert!(
+            before.is_some(),
+            "empty agents_dir should still report mtime"
+        );
+
+        // Sleep briefly so mtime resolution can register a change.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        let agent_file = agents_dir.join("foo.agent.md");
+        let mut f = std::fs::File::create(&agent_file).unwrap();
+        f.write_all(b"---\nname: foo\nmodel: haiku\n---\nbody\n")
+            .unwrap();
+        f.sync_all().unwrap();
+        drop(f);
+
+        let after_create = agents_dir_mtime(cfg_path.to_str().unwrap(), Some(&cfg));
+        assert!(after_create.is_some());
+        assert_ne!(
+            before, after_create,
+            "creating *.agent.md must change mtime"
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::remove_file(&agent_file).unwrap();
+
+        let after_remove = agents_dir_mtime(cfg_path.to_str().unwrap(), Some(&cfg));
+        assert!(after_remove.is_some());
+        assert_ne!(
+            after_create, after_remove,
+            "removing *.agent.md must change mtime"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #416. Two gaps in the agent-as-file lifecycle:

1. **Trigger gap** — `watch_and_reload` only polled `cfg_path` mtime. Deleting a `*.agent.md` doesn't bump `deskd.yaml`'s mtime, so reload never fired. Now also tracks `agents_dir` mtime + every `*.agent.md` file's mtime.
2. **Cleanup gap** — `ConfigChangeset` now reports `removed_sub_agents` (HashSet diff old vs new). The full-restart path calls `agent_registry::remove` for each, wiping state/log files so a stopped sub-agent can't be resurrected on the next `deskd serve`.

`serve.rs` startup path verified: sub-agents are only spawned from `ucfg.agents` (post `merge_agents_dir`), and `agent_registry::list()` is enumerator-only — no respawn risk.

## Acceptance criteria

- [x] Deleting `*.agent.md` triggers eviction: worker killed (full restart) + state file removed (`agent_registry::remove`) + schedules unregistered (component restart drops them).
- [x] Renaming to `*.disabled` is treated as deletion — `load_agent_dir`'s extension filter ignores it, so it disappears from `ucfg.agents` exactly like a delete.
- [x] No respawn on next cron tick or `deskd serve` restart — state file wiped; `merge_agents_dir` no longer re-adds it.
- [x] Unit tests added (config_changeset + config_reload).
- [x] Quality gate: fmt + clippy + 526 tests pass.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --tests -- -D warnings
- [x] cargo test
- [ ] Manual smoke: drop foo.agent.md, observe spawn; delete file, observe eviction + missing ~/.deskd/agents/foo.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)