### PR TITLE
fix(#424): detect empty completions, WARN + auto-restart

### DIFF
--- a/src/app/agent_registry.rs
+++ b/src/app/agent_registry.rs
@@ -62,6 +62,16 @@ pub struct AgentConfig {
     /// (`context_size::DEFAULT_AUTO_COMPACT_THRESHOLD`, 300k).
     #[serde(default)]
     pub auto_compact_threshold_tokens: Option<u64>,
+    /// Number of consecutive empty completions that triggers an auto-restart
+    /// of the agent worker (#424). `None` falls back to the built-in default
+    /// (3); see [`crate::app::worker::DEFAULT_EMPTY_COMPLETION_THRESHOLD`].
+    #[serde(default)]
+    pub empty_completion_threshold: Option<u32>,
+    /// Minimum seconds between auto-restarts triggered by empty-completion
+    /// detection (#424). `None` falls back to the built-in default (60); see
+    /// [`crate::app::worker::DEFAULT_EMPTY_COMPLETION_RESTART_MIN_SECS`].
+    #[serde(default)]
+    pub empty_completion_restart_min_secs: Option<u64>,
 }
 
 fn default_budget_usd() -> f64 {
@@ -108,6 +118,18 @@ pub struct AgentState {
     /// Turns accumulated in the current session (resets on session_id change).
     #[serde(default)]
     pub session_turns: u32,
+    /// Number of consecutive empty completions observed (#424).
+    /// Reset to 0 on the first non-empty completion. Used for auto-restart
+    /// of suspected-hung claude workers.
+    #[serde(default)]
+    pub consecutive_empty_completions: u32,
+    /// RFC 3339 timestamp of the last auto-restart triggered by empty-completion
+    /// detection (#424). Used to enforce the rate-limit between restarts.
+    #[serde(default)]
+    pub last_empty_restart_at: Option<String>,
+    /// Cumulative number of auto-restarts triggered by empty-completion detection (#424).
+    #[serde(default)]
+    pub total_empty_restarts: u32,
 }
 
 fn default_status() -> String {
@@ -222,6 +244,9 @@ pub async fn create(cfg: &AgentConfig) -> Result<AgentState> {
         session_start: None,
         session_cost: 0.0,
         session_turns: 0,
+        consecutive_empty_completions: 0,
+        last_empty_restart_at: None,
+        total_empty_restarts: 0,
     };
 
     save_state(&state)?;
@@ -257,6 +282,9 @@ pub async fn create_or_update_from_config(cfg: &AgentConfig) -> Result<AgentStat
         session_start: None,
         session_cost: 0.0,
         session_turns: 0,
+        consecutive_empty_completions: 0,
+        last_empty_restart_at: None,
+        total_empty_restarts: 0,
     };
     save_state(&state)?;
     info!(agent = %cfg.name, "sub-agent created");
@@ -299,6 +327,8 @@ pub async fn create_or_recover(
         context: user_cfg.and_then(|c| c.context.clone()),
         compact_threshold: None,
         auto_compact_threshold_tokens: user_cfg.and_then(|c| c.auto_compact_threshold_tokens),
+        empty_completion_threshold: None,
+        empty_completion_restart_min_secs: None,
     };
 
     let path = state_path(&def.name);
@@ -326,6 +356,9 @@ pub async fn create_or_recover(
         session_start: None,
         session_cost: 0.0,
         session_turns: 0,
+        consecutive_empty_completions: 0,
+        last_empty_restart_at: None,
+        total_empty_restarts: 0,
     };
     save_state(&state)?;
     info!(agent = %def.name, "agent created");
@@ -722,6 +755,8 @@ pub async fn spawn_ephemeral(
         context: None,
         compact_threshold: None,
         auto_compact_threshold_tokens: None,
+        empty_completion_threshold: None,
+        empty_completion_restart_min_secs: None,
     };
 
     create(&cfg).await?;
@@ -779,6 +814,8 @@ created_at: "2024-01-01T00:00:00Z"
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let state = AgentState {
             config: cfg,
@@ -796,6 +833,9 @@ created_at: "2024-01-01T00:00:00Z"
             session_start: Some(Utc::now().to_rfc3339()),
             session_cost: 0.0,
             session_turns: 0,
+            consecutive_empty_completions: 0,
+            last_empty_restart_at: None,
+            total_empty_restarts: 0,
         };
         let yaml = serde_yaml::to_string(&state).unwrap();
         let restored: AgentState = serde_yaml::from_str(&yaml).unwrap();
@@ -844,6 +884,8 @@ created_at: "2024-01-01T00:00:00Z"
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let state = AgentState {
             config: cfg,
@@ -861,6 +903,9 @@ created_at: "2024-01-01T00:00:00Z"
             session_start: Some("2026-01-01T00:00:00Z".to_string()),
             session_cost: 0.5,
             session_turns: 3,
+            consecutive_empty_completions: 0,
+            last_empty_restart_at: None,
+            total_empty_restarts: 0,
         };
 
         save_state(&state).unwrap();

--- a/src/app/agent_registry.rs
+++ b/src/app/agent_registry.rs
@@ -862,6 +862,8 @@ created_at: "2024-01-01T00:00:00Z"
 
     #[test]
     fn test_state_save_load_roundtrip() {
+        // Serialize env mutation; setenv is not thread-safe on POSIX.
+        let _env_guard = crate::test_support::env_lock().blocking_lock();
         let tmp =
             std::env::temp_dir().join(format!("deskd-test-agent-state-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&tmp).unwrap();

--- a/src/app/alerts.rs
+++ b/src/app/alerts.rs
@@ -656,7 +656,13 @@ mod tests {
 
         let contents = std::fs::read_to_string(&path).unwrap();
         let lines: Vec<&str> = contents.lines().collect();
-        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected 2 alert lines (Degraded + Recovered), got {}: {:?}",
+            lines.len(),
+            contents,
+        );
         let first: AlertRecord = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(first.kind, AlertKind::Degraded);
         let second: AlertRecord = serde_json::from_str(lines[1]).unwrap();

--- a/src/app/commands/agent.rs
+++ b/src/app/commands/agent.rs
@@ -42,6 +42,8 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 context: None,
                 compact_threshold: None,
                 auto_compact_threshold_tokens: None,
+                empty_completion_threshold: None,
+                empty_completion_restart_min_secs: None,
             };
             let state = agent::create(&cfg).await?;
             println!("Agent {} created", state.config.name);
@@ -205,6 +207,12 @@ pub async fn handle(action: AgentAction) -> Result<()> {
                 }
             );
             println!("Created:    {}", s.created_at);
+            // Empty-completion detection state (#424).
+            println!("Empty cons: {}", s.consecutive_empty_completions);
+            println!("Empty rstr: {}", s.total_empty_restarts);
+            if let Some(ref ts) = s.last_empty_restart_at {
+                println!("Last empty restart: {}", ts);
+            }
         }
         AgentAction::Read {
             name,

--- a/src/app/commands/usage.rs
+++ b/src/app/commands/usage.rs
@@ -478,6 +478,8 @@ mod tests {
 
     #[test]
     fn test_compute_stats_attributes_subagent_to_parent() {
+        // Serialize env mutation; setenv is not thread-safe on POSIX.
+        let _env_guard = crate::test_support::env_lock().blocking_lock();
         // Set up isolated HOME with two agents: parent "p1" and sub-agent "p1-sub".
         let tmp = std::path::PathBuf::from(format!(
             "/tmp/deskd-test-usage-{}",

--- a/src/app/config_changeset.rs
+++ b/src/app/config_changeset.rs
@@ -144,6 +144,8 @@ mod tests {
             compact_threshold: None,
             compact_strategy: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         }
     }
 

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -156,6 +156,8 @@ pub async fn spawn_components(
                 auto_compact_threshold_tokens: sub
                     .auto_compact_threshold_tokens
                     .or(ucfg.auto_compact_threshold_tokens),
+                empty_completion_threshold: sub.empty_completion_threshold,
+                empty_completion_restart_min_secs: sub.empty_completion_restart_min_secs,
             };
             crate::app::agent::create_or_update_from_config(&sub_cfg).await?;
 

--- a/src/app/context_size.rs
+++ b/src/app/context_size.rs
@@ -606,6 +606,8 @@ mod tests {
                 context: None,
                 compact_threshold: None,
                 auto_compact_threshold_tokens: None,
+                empty_completion_threshold: None,
+                empty_completion_restart_min_secs: None,
             },
             pid,
             session_id: session_id.into(),
@@ -621,6 +623,9 @@ mod tests {
             session_start: None,
             session_cost: 0.0,
             session_turns: 0,
+            consecutive_empty_completions: 0,
+            last_empty_restart_at: None,
+            total_empty_restarts: 0,
         }
     }
 

--- a/src/app/mcp_service.rs
+++ b/src/app/mcp_service.rs
@@ -922,6 +922,8 @@ mod restart_tests {
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let state = AgentState {
             config: cfg,
@@ -939,6 +941,9 @@ mod restart_tests {
             session_start: Some("2026-01-01T00:00:00Z".into()),
             session_cost: 0.5,
             session_turns: 3,
+            consecutive_empty_completions: 0,
+            last_empty_restart_at: None,
+            total_empty_restarts: 0,
         };
         crate::app::agent::save_state_in(tmp.path(), &state).unwrap();
         (tmp, name)

--- a/src/app/process_builder.rs
+++ b/src/app/process_builder.rs
@@ -392,6 +392,8 @@ mod tests {
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
 
         let extra_env = [("DESKD_BUS_SOCKET", "/home/test/.deskd/bus.sock")];
@@ -444,6 +446,8 @@ mod tests {
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let cmd = build_command(&cfg, &[], &[]);
         let program = cmd.as_std().get_program().to_string_lossy().to_string();
@@ -469,6 +473,8 @@ mod tests {
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let extra_env = [("DESKD_BUS_SOCKET", "/tmp/bus.sock")];
         let cmd = build_command(&cfg, &[], &extra_env);
@@ -505,6 +511,8 @@ mod tests {
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let env = auto_compact_env_for(&cfg).expect("env tuple");
         assert_eq!(env.0, "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE");
@@ -530,6 +538,8 @@ mod tests {
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: Some(500_000),
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let env = auto_compact_env_for(&cfg).expect("env tuple");
         // 500k of 1M = 50%.
@@ -556,6 +566,8 @@ mod tests {
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let env = auto_compact_env_for(&cfg).expect("env tuple");
         assert_eq!(env.1, "83");
@@ -580,6 +592,8 @@ mod tests {
             context: None,
             compact_threshold: None,
             auto_compact_threshold_tokens: Some(400_000),
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         let cmd = build_command(&cfg, &[], &[]);
         let envs: Vec<(String, String)> = cmd

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -1758,6 +1758,109 @@ mod tests {
         assert!(!empty_restart_allowed(Some(&now), 60));
     }
 
+    // ─── update_empty_completion_state tests (#424) ─────────────────────────
+
+    /// Set up an isolated HOME under /tmp and persist a minimal `AgentState`
+    /// for `name` so `update_empty_completion_state` can load + save it.
+    /// Returns the agent name (caller passes it back to the function under test).
+    fn setup_agent_state(threshold: Option<u32>) -> String {
+        // Unique HOME per test so concurrent runs don't clobber each other's state.
+        let name = format!("emptyfn-{}", uuid::Uuid::new_v4());
+        let tmp = std::env::temp_dir().join(format!("deskd-test-{}", &name));
+        std::fs::create_dir_all(tmp.join(".deskd/agents")).unwrap();
+        // SAFETY: override HOME for the duration of the test. Per-test unique
+        // tmp dir means concurrent tests do not corrupt each other's state file.
+        unsafe { std::env::set_var("HOME", &tmp) };
+
+        let cfg = crate::app::agent::AgentConfig {
+            name: name.clone(),
+            model: "claude-sonnet-4-6".into(),
+            system_prompt: String::new(),
+            work_dir: "/tmp".into(),
+            max_turns: 10,
+            unix_user: None,
+            budget_usd: 50.0,
+            command: vec!["claude".into()],
+            config_path: None,
+            container: None,
+            session: crate::infra::dto::ConfigSessionMode::Persistent,
+            runtime: crate::infra::dto::ConfigAgentRuntime::Claude,
+            kind: crate::infra::dto::ConfigAgentKind::Executor,
+            context: None,
+            compact_threshold: None,
+            auto_compact_threshold_tokens: None,
+            empty_completion_threshold: threshold,
+            empty_completion_restart_min_secs: None,
+        };
+        let state = crate::app::agent::AgentState {
+            config: cfg,
+            pid: 0,
+            session_id: String::new(),
+            total_turns: 0,
+            total_cost: 0.0,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            status: "idle".into(),
+            current_task: String::new(),
+            parent: None,
+            scope: None,
+            can_message: None,
+            env_keys: None,
+            session_start: None,
+            session_cost: 0.0,
+            session_turns: 0,
+            consecutive_empty_completions: 0,
+            last_empty_restart_at: None,
+            total_empty_restarts: 0,
+        };
+        crate::app::agent::save_state_pub(&state).unwrap();
+        name
+    }
+
+    #[test]
+    fn test_update_empty_completion_state_normal_resets_counter() {
+        let name = setup_agent_state(Some(3));
+        // Pre-seed counter to 2 so we can verify the reset path.
+        let mut st = crate::app::agent::load_state(&name).unwrap();
+        st.consecutive_empty_completions = 2;
+        crate::app::agent::save_state_pub(&st).unwrap();
+
+        let outcome = update_empty_completion_state(&name, false);
+        assert_eq!(outcome, EmptyCompletionOutcome::Normal);
+
+        let st = crate::app::agent::load_state(&name).unwrap();
+        assert_eq!(st.consecutive_empty_completions, 0);
+    }
+
+    #[test]
+    fn test_update_empty_completion_state_below_threshold_increments() {
+        let name = setup_agent_state(Some(3));
+
+        let outcome = update_empty_completion_state(&name, true);
+        assert_eq!(outcome, EmptyCompletionOutcome::BelowThreshold);
+        let st = crate::app::agent::load_state(&name).unwrap();
+        assert_eq!(st.consecutive_empty_completions, 1);
+
+        let outcome = update_empty_completion_state(&name, true);
+        assert_eq!(outcome, EmptyCompletionOutcome::BelowThreshold);
+        let st = crate::app::agent::load_state(&name).unwrap();
+        assert_eq!(st.consecutive_empty_completions, 2);
+    }
+
+    #[test]
+    fn test_update_empty_completion_state_threshold_reached() {
+        let name = setup_agent_state(Some(3));
+        // Seed counter to 2 so the next empty completion reaches threshold (3).
+        let mut st = crate::app::agent::load_state(&name).unwrap();
+        st.consecutive_empty_completions = 2;
+        crate::app::agent::save_state_pub(&st).unwrap();
+
+        let outcome = update_empty_completion_state(&name, true);
+        assert_eq!(outcome, EmptyCompletionOutcome::ThresholdReached);
+
+        let st = crate::app::agent::load_state(&name).unwrap();
+        assert_eq!(st.consecutive_empty_completions, 3);
+    }
+
     // ─── budget_enforced tests ───────────────────────────────────────────────
 
     #[test]

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, bail};
 use std::io::Write;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::app::acp;
@@ -13,6 +13,47 @@ use crate::app::unified_inbox;
 use crate::domain::agent::{AgentKind, AgentRuntime};
 use crate::domain::config_types::ConfigSessionMode;
 use crate::domain::events::DomainEvent;
+
+// ─── Empty-completion detection (#424) ──────────────────────────────────────
+//
+// A `result` event from a hung claude worker can land with `output_tokens=0`
+// AND `duration_secs<2` and otherwise looks like a successful turn. The
+// heuristic below flags those, increments a per-agent counter, and triggers
+// an auto-restart once `consecutive_empty_completions` crosses the threshold.
+
+/// Default threshold of consecutive empty completions before auto-restart.
+pub const DEFAULT_EMPTY_COMPLETION_THRESHOLD: u32 = 3;
+
+/// Default minimum seconds between auto-restarts triggered by empty-completion
+/// detection. Prevents tight restart loops when the upstream model is dead.
+pub const DEFAULT_EMPTY_COMPLETION_RESTART_MIN_SECS: u64 = 60;
+
+/// Maximum duration (seconds) a "real" completion is expected to take when
+/// `output_tokens` is also 0. Anything below this with zero output is treated
+/// as suspect (likely-hung worker).
+const EMPTY_COMPLETION_DURATION_THRESHOLD_SECS: u64 = 2;
+
+/// Returns true if a `result` event looks like a hung-worker empty completion:
+/// zero output tokens AND sub-threshold wall-clock duration.
+///
+/// Heuristic is callable from tests as well as the worker loop.
+pub fn is_empty_completion(output_tokens: u64, duration_secs: u64) -> bool {
+    output_tokens == 0 && duration_secs < EMPTY_COMPLETION_DURATION_THRESHOLD_SECS
+}
+
+/// Returns true if `last_restart_at` is far enough in the past (or absent)
+/// that another auto-restart is allowed under the rate-limit window.
+pub fn empty_restart_allowed(last_restart_at: Option<&str>, min_interval_secs: u64) -> bool {
+    let Some(ts) = last_restart_at else {
+        return true;
+    };
+    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(ts) else {
+        // Malformed timestamp — be permissive rather than wedging the agent.
+        return true;
+    };
+    let elapsed = chrono::Utc::now().signed_duration_since(parsed.with_timezone(&chrono::Utc));
+    elapsed.num_seconds() >= min_interval_secs as i64
+}
 
 /// Create an executor for the given runtime type.
 ///
@@ -670,7 +711,7 @@ pub async fn run(
                 // Track cumulative session input tokens for compaction trigger.
                 session_input_tokens += turn.token_usage.input_tokens;
 
-                handle_task_success(
+                let empty_outcome = handle_task_success(
                     name,
                     &msg,
                     &ctx,
@@ -682,8 +723,40 @@ pub async fn run(
                     &initial_state.config.model,
                     &writer,
                     task_store,
+                    &agent_runtime,
                 )
                 .await;
+
+                // Empty-completion auto-restart (#424). When the heuristic has
+                // tripped N consecutive times we kill the (likely-hung) claude
+                // worker and respawn with a fresh session, gated by a
+                // configurable rate-limit window.
+                if empty_outcome == EmptyCompletionOutcome::ThresholdReached
+                    && note_empty_restart(name)
+                {
+                    error!(
+                        agent = %name,
+                        "agent {} hit empty-completion threshold — auto-restarting worker",
+                        name
+                    );
+                    process.stop().await;
+                    match start_executor_fresh(name, &effective_bus, &agent_runtime).await {
+                        Ok(new_proc) => {
+                            process = new_proc;
+                            info!(
+                                agent = %name,
+                                "agent process auto-restarted after empty-completion threshold"
+                            );
+                        }
+                        Err(re) => {
+                            warn!(
+                                agent = %name,
+                                error = %re,
+                                "failed to auto-restart agent after empty-completion threshold"
+                            );
+                        }
+                    }
+                }
 
                 // Check compaction trigger for all agent types.
                 // Memory agents have their own injection-based trigger above;
@@ -775,6 +848,10 @@ pub async fn run(
 }
 
 /// Log token usage for a completed task to a JSONL file.
+///
+/// `status` marks entries the doctor (#422) treats specially. `Some("empty")`
+/// signals the empty-completion heuristic fired (#424); `None` means the
+/// completion looked normal and no status field is written.
 #[allow(clippy::too_many_arguments)]
 fn log_token_usage(
     work_dir: &str,
@@ -786,6 +863,7 @@ fn log_token_usage(
     model: &str,
     github_repo: Option<&str>,
     github_pr: Option<u64>,
+    status: Option<&str>,
 ) {
     let deskd_dir = std::path::Path::new(work_dir).join(".deskd");
     if let Err(e) = std::fs::create_dir_all(&deskd_dir) {
@@ -821,6 +899,9 @@ fn log_token_usage(
     }
     if let Some(pr) = github_pr {
         entry["github_pr"] = serde_json::json!(pr);
+    }
+    if let Some(s) = status {
+        entry["status"] = serde_json::json!(s);
     }
 
     match std::fs::OpenOptions::new()
@@ -1077,6 +1158,18 @@ fn recover_orphaned_tasks(agent_name: &str, task_store: &dyn crate::ports::store
 }
 
 /// Handle successful task completion: log, inbox, queue update, bus reply.
+/// Outcome of a successful task w.r.t. the empty-completion heuristic (#424).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmptyCompletionOutcome {
+    /// Completion looked normal — counter has been reset.
+    Normal,
+    /// Empty completion detected; counter incremented but below threshold.
+    BelowThreshold,
+    /// Empty completion detected; counter has reached or exceeded threshold —
+    /// caller should attempt a rate-limited auto-restart.
+    ThresholdReached,
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_task_success(
     name: &str,
@@ -1090,14 +1183,43 @@ async fn handle_task_success(
     model: &str,
     writer: &std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
     task_store: &dyn crate::ports::store::TaskRepository,
-) {
-    info!(
-        agent = %name,
-        cost = turn.cost_usd,
-        turns = turn.num_turns,
-        "task completed (persistent)"
-    );
+    runtime: &AgentRuntime,
+) -> EmptyCompletionOutcome {
+    // Empty-completion detection is restricted to `runtime: claude` per #424.
+    // Memory agents share the Claude executor but their zero-output turns are
+    // legitimate (event ingestion only), so we exclude them here.
+    let detect_empty = matches!(runtime, AgentRuntime::Claude);
+    let is_empty =
+        detect_empty && is_empty_completion(turn.token_usage.output_tokens, task_duration_secs);
 
+    let outcome = update_empty_completion_state(name, is_empty);
+
+    if is_empty {
+        warn!(
+            agent = %name,
+            output_tokens = turn.token_usage.output_tokens,
+            duration_secs = task_duration_secs,
+            consecutive = match outcome {
+                EmptyCompletionOutcome::BelowThreshold | EmptyCompletionOutcome::ThresholdReached => {
+                    agent::load_state(name)
+                        .map(|s| s.consecutive_empty_completions)
+                        .unwrap_or(0)
+                }
+                EmptyCompletionOutcome::Normal => 0,
+            },
+            "agent {} returned empty completion — likely hung",
+            name
+        );
+    } else {
+        info!(
+            agent = %name,
+            cost = turn.cost_usd,
+            turns = turn.num_turns,
+            "task completed (persistent)"
+        );
+    }
+
+    let usage_status = if is_empty { Some("empty") } else { None };
     log_token_usage(
         work_dir,
         name,
@@ -1108,8 +1230,10 @@ async fn handle_task_success(
         model,
         ctx.github_repo.as_deref(),
         ctx.github_pr,
+        usage_status,
     );
 
+    let task_status = if is_empty { "empty" } else { "ok" };
     let parent_agent = agent::load_state(name).ok().and_then(|s| s.parent);
     let log_entry = tasklog::TaskLog {
         ts: chrono::Utc::now().to_rfc3339(),
@@ -1117,7 +1241,7 @@ async fn handle_task_success(
         turns: turn.num_turns,
         cost: turn.cost_usd,
         duration_ms: task_duration_ms,
-        status: "ok".to_string(),
+        status: task_status.to_string(),
         task: tasklog::truncate_task(&ctx.task_raw, 60),
         error: None,
         msg_id: msg.id.clone(),
@@ -1191,6 +1315,81 @@ async fn handle_task_success(
         },
     )
     .await;
+
+    outcome
+}
+
+/// Update the persistent agent state for empty-completion tracking (#424).
+///
+/// Increments `consecutive_empty_completions` when `is_empty` is true; resets
+/// to zero on the first non-empty completion. Returns the resulting outcome
+/// so the caller can decide whether to trigger a restart.
+///
+/// State write failures are logged at WARN level but do not propagate — the
+/// detector is best-effort and must not block task completion.
+fn update_empty_completion_state(name: &str, is_empty: bool) -> EmptyCompletionOutcome {
+    let mut st = match agent::load_state(name) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(agent = %name, error = %e, "empty-detection: failed to load state");
+            return if is_empty {
+                EmptyCompletionOutcome::BelowThreshold
+            } else {
+                EmptyCompletionOutcome::Normal
+            };
+        }
+    };
+
+    let threshold = st
+        .config
+        .empty_completion_threshold
+        .unwrap_or(DEFAULT_EMPTY_COMPLETION_THRESHOLD);
+
+    let outcome = if !is_empty {
+        st.consecutive_empty_completions = 0;
+        EmptyCompletionOutcome::Normal
+    } else {
+        st.consecutive_empty_completions = st.consecutive_empty_completions.saturating_add(1);
+        if st.consecutive_empty_completions >= threshold {
+            EmptyCompletionOutcome::ThresholdReached
+        } else {
+            EmptyCompletionOutcome::BelowThreshold
+        }
+    };
+
+    if let Err(e) = agent::save_state_pub(&st) {
+        warn!(agent = %name, error = %e, "empty-detection: failed to save state");
+    }
+    outcome
+}
+
+/// Note an empty-completion-triggered restart in agent state and return
+/// whether the restart was permitted by the rate-limit window. Updates
+/// `last_empty_restart_at` and `total_empty_restarts` on success and resets
+/// the consecutive counter so post-restart traffic doesn't immediately
+/// re-trigger another restart.
+fn note_empty_restart(name: &str) -> bool {
+    let Ok(mut st) = agent::load_state(name) else {
+        return false;
+    };
+    let min_secs = st
+        .config
+        .empty_completion_restart_min_secs
+        .unwrap_or(DEFAULT_EMPTY_COMPLETION_RESTART_MIN_SECS);
+    if !empty_restart_allowed(st.last_empty_restart_at.as_deref(), min_secs) {
+        warn!(
+            agent = %name,
+            "empty-detection: threshold reached but restart suppressed by rate-limit"
+        );
+        return false;
+    }
+    st.last_empty_restart_at = Some(chrono::Utc::now().to_rfc3339());
+    st.total_empty_restarts = st.total_empty_restarts.saturating_add(1);
+    st.consecutive_empty_completions = 0;
+    if let Err(e) = agent::save_state_pub(&st) {
+        warn!(agent = %name, error = %e, "empty-detection: failed to save restart state");
+    }
+    true
 }
 
 /// Handle task failure: log, queue update, crash recovery, bus reply.
@@ -1510,6 +1709,54 @@ fn truncate(s: &str, max: usize) -> &str {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // ─── empty-completion heuristic tests (#424) ────────────────────────────
+
+    #[test]
+    fn test_is_empty_completion_zero_tokens_short_duration_is_empty() {
+        assert!(is_empty_completion(0, 0));
+        assert!(is_empty_completion(0, 1));
+    }
+
+    #[test]
+    fn test_is_empty_completion_real_completion_is_not_empty() {
+        // Real completions emit tokens; that alone disqualifies.
+        assert!(!is_empty_completion(100, 0));
+        assert!(!is_empty_completion(1, 60));
+    }
+
+    #[test]
+    fn test_is_empty_completion_long_zero_token_duration_is_not_empty() {
+        // A worker that genuinely ran but legitimately returned zero tokens
+        // (e.g. tool-only turn) takes more than the threshold — don't flag.
+        assert!(!is_empty_completion(
+            0,
+            EMPTY_COMPLETION_DURATION_THRESHOLD_SECS
+        ));
+        assert!(!is_empty_completion(
+            0,
+            EMPTY_COMPLETION_DURATION_THRESHOLD_SECS + 5
+        ));
+    }
+
+    #[test]
+    fn test_empty_restart_allowed_when_no_prior_restart() {
+        assert!(empty_restart_allowed(None, 60));
+    }
+
+    #[test]
+    fn test_empty_restart_allowed_when_window_elapsed() {
+        // Pick a timestamp clearly older than any plausible window.
+        let stale = "2020-01-01T00:00:00Z";
+        assert!(empty_restart_allowed(Some(stale), 60));
+    }
+
+    #[test]
+    fn test_empty_restart_allowed_blocks_within_window() {
+        // Use "now" so the window is fresh.
+        let now = chrono::Utc::now().to_rfc3339();
+        assert!(!empty_restart_allowed(Some(&now), 60));
+    }
 
     // ─── budget_enforced tests ───────────────────────────────────────────────
 

--- a/src/app/worker.rs
+++ b/src/app/worker.rs
@@ -1762,14 +1762,19 @@ mod tests {
 
     /// Set up an isolated HOME under /tmp and persist a minimal `AgentState`
     /// for `name` so `update_empty_completion_state` can load + save it.
-    /// Returns the agent name (caller passes it back to the function under test).
-    fn setup_agent_state(threshold: Option<u32>) -> String {
-        // Unique HOME per test so concurrent runs don't clobber each other's state.
+    /// Returns the agent name plus the env-lock guard — callers MUST keep
+    /// the guard alive for the test's full duration so concurrent env
+    /// mutations elsewhere can't race with this test's file I/O.
+    fn setup_agent_state(threshold: Option<u32>) -> (String, tokio::sync::MutexGuard<'static, ()>) {
+        // Acquire the global env lock BEFORE mutating HOME. setenv is not
+        // thread-safe on POSIX; without serialization, concurrent set_var
+        // calls cause UB that flakes unrelated file-I/O tests.
+        let guard = crate::test_support::env_lock().blocking_lock();
         let name = format!("emptyfn-{}", uuid::Uuid::new_v4());
         let tmp = std::env::temp_dir().join(format!("deskd-test-{}", &name));
         std::fs::create_dir_all(tmp.join(".deskd/agents")).unwrap();
-        // SAFETY: override HOME for the duration of the test. Per-test unique
-        // tmp dir means concurrent tests do not corrupt each other's state file.
+        // SAFETY: ENV_LOCK serializes all env-mutating tests, and per-test
+        // unique tmp dir keeps state files from clobbering each other.
         unsafe { std::env::set_var("HOME", &tmp) };
 
         let cfg = crate::app::agent::AgentConfig {
@@ -1813,12 +1818,12 @@ mod tests {
             total_empty_restarts: 0,
         };
         crate::app::agent::save_state_pub(&state).unwrap();
-        name
+        (name, guard)
     }
 
     #[test]
     fn test_update_empty_completion_state_normal_resets_counter() {
-        let name = setup_agent_state(Some(3));
+        let (name, _env_guard) = setup_agent_state(Some(3));
         // Pre-seed counter to 2 so we can verify the reset path.
         let mut st = crate::app::agent::load_state(&name).unwrap();
         st.consecutive_empty_completions = 2;
@@ -1833,7 +1838,7 @@ mod tests {
 
     #[test]
     fn test_update_empty_completion_state_below_threshold_increments() {
-        let name = setup_agent_state(Some(3));
+        let (name, _env_guard) = setup_agent_state(Some(3));
 
         let outcome = update_empty_completion_state(&name, true);
         assert_eq!(outcome, EmptyCompletionOutcome::BelowThreshold);
@@ -1848,7 +1853,7 @@ mod tests {
 
     #[test]
     fn test_update_empty_completion_state_threshold_reached() {
-        let name = setup_agent_state(Some(3));
+        let (name, _env_guard) = setup_agent_state(Some(3));
         // Seed counter to 2 so the next empty completion reaches threshold (3).
         let mut st = crate::app::agent::load_state(&name).unwrap();
         st.consecutive_empty_completions = 2;

--- a/src/config.rs
+++ b/src/config.rs
@@ -577,6 +577,15 @@ pub struct SubAgentDef {
     /// then to the built-in default (300k).
     #[serde(default)]
     pub auto_compact_threshold_tokens: Option<u64>,
+    /// Empty-completion auto-restart threshold (issue #424). After this many
+    /// consecutive zero-token / sub-2s completions, the worker is restarted.
+    /// `None` falls back to the workspace default.
+    #[serde(default)]
+    pub empty_completion_threshold: Option<u32>,
+    /// Minimum seconds between auto-restarts triggered by empty-completion
+    /// detection (rate-limit). `None` falls back to the workspace default.
+    #[serde(default)]
+    pub empty_completion_restart_min_secs: Option<u64>,
 }
 
 impl SubAgentDef {
@@ -1603,6 +1612,8 @@ agents:
             compact_threshold: None,
             compact_strategy: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         assert!(sub.validate_work_dir("/tmp/parent").is_ok());
     }
@@ -1627,6 +1638,8 @@ agents:
             compact_threshold: None,
             compact_strategy: None,
             auto_compact_threshold_tokens: None,
+            empty_completion_threshold: None,
+            empty_completion_restart_min_secs: None,
         };
         assert!(sub.validate_work_dir("/tmp/parent").is_err());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -779,6 +779,8 @@ mod tests {
 
     #[test]
     fn test_expand_env_vars_braces() {
+        // Serialize env mutation; setenv is not thread-safe on POSIX.
+        let _env_guard = crate::test_support::env_lock().blocking_lock();
         unsafe { std::env::set_var("TEST_TOKEN_DESKD", "abc123") };
         let result = expand_env_vars("token: ${TEST_TOKEN_DESKD}");
         assert_eq!(result, "token: abc123");
@@ -786,6 +788,8 @@ mod tests {
 
     #[test]
     fn test_expand_env_vars_dollar() {
+        // Serialize env mutation; setenv is not thread-safe on POSIX.
+        let _env_guard = crate::test_support::env_lock().blocking_lock();
         unsafe { std::env::set_var("TEST_VAR_DESKD", "hello") };
         let result = expand_env_vars("val: $TEST_VAR_DESKD end");
         assert_eq!(result, "val: hello end");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,23 @@ pub mod config;
 pub mod domain;
 pub mod infra;
 pub mod ports;
+
+pub mod test_support {
+    //! Test-only utilities. `env_lock()` returns a process-wide mutex that
+    //! serializes any test mutating environment variables — `setenv`/`unsetenv`
+    //! are not thread-safe on POSIX, so concurrent mutations under cargo's
+    //! parallel test runner cause UB that surfaces as flaky failures in
+    //! unrelated tests doing file I/O.
+    //!
+    //! Backed by `tokio::sync::Mutex` so async tests can hold the guard across
+    //! `.await` without tripping clippy's `await_holding_lock`. Sync tests use
+    //! `blocking_lock()`; async tests use `lock().await`. Exposed unconditionally
+    //! so integration tests (separate compilation units) can use it too.
+    use std::sync::OnceLock;
+    use tokio::sync::Mutex;
+
+    pub fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,8 @@ mod tests {
 
     #[test]
     fn test_handle_remind_writes_file() {
+        // Serialize env mutation; setenv is not thread-safe on POSIX.
+        let _env_guard = deskd::test_support::env_lock().blocking_lock();
         let tmp = std::path::PathBuf::from(format!(
             "/tmp/deskd-test-remind-{}",
             std::time::SystemTime::now()

--- a/tests/agent_lifecycle.rs
+++ b/tests/agent_lifecycle.rs
@@ -84,6 +84,8 @@ fn make_config(name: &str) -> deskd::app::agent::AgentConfig {
 /// Covers: create, load, update, list, duplicate check, remove, remove-nonexistent.
 #[tokio::test]
 async fn test_agent_state_lifecycle() {
+    // Serialize env mutation; setenv is not thread-safe on POSIX.
+    let _env_guard = deskd::test_support::env_lock().lock().await;
     // Set up isolated HOME.
     let tmp = std::path::PathBuf::from(format!(
         "/tmp/deskd-test-state-{}",
@@ -92,7 +94,7 @@ async fn test_agent_state_lifecycle() {
             .unwrap()
             .as_nanos()
     ));
-    // SAFETY: single test, no other test modifies HOME concurrently in this file.
+    // SAFETY: ENV_LOCK serializes all env-mutating tests across the workspace.
     unsafe { std::env::set_var("HOME", &tmp) };
     std::fs::create_dir_all(tmp.join(".deskd/agents")).unwrap();
 

--- a/tests/agent_lifecycle.rs
+++ b/tests/agent_lifecycle.rs
@@ -74,6 +74,8 @@ fn make_config(name: &str) -> deskd::app::agent::AgentConfig {
         context: None,
         compact_threshold: None,
         auto_compact_threshold_tokens: None,
+        empty_completion_threshold: None,
+        empty_completion_restart_min_secs: None,
     }
 }
 

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -58,7 +58,11 @@ async fn read_one(
         .and_then(|l| serde_json::from_str(&l).ok())
 }
 
-fn setup_state_dir() -> std::path::PathBuf {
+async fn setup_state_dir() -> (std::path::PathBuf, tokio::sync::MutexGuard<'static, ()>) {
+    // Serialize env mutation; setenv is not thread-safe on POSIX. Caller MUST
+    // keep the returned guard alive for the test's full duration so concurrent
+    // env-mutating tests can't race with this test's file I/O.
+    let guard = deskd::test_support::env_lock().lock().await;
     let tmp = std::path::PathBuf::from(format!(
         "/tmp/deskd-test-crash-state-{}",
         std::time::SystemTime::now()
@@ -66,10 +70,10 @@ fn setup_state_dir() -> std::path::PathBuf {
             .unwrap()
             .as_nanos()
     ));
-    // SAFETY: test runs single-threaded at this point.
+    // SAFETY: ENV_LOCK serializes all env-mutating tests across the workspace.
     unsafe { std::env::set_var("HOME", &tmp) };
     std::fs::create_dir_all(tmp.join(".deskd/agents")).unwrap();
-    tmp
+    (tmp, guard)
 }
 
 fn test_agent_config(name: &str) -> deskd::app::agent::AgentConfig {
@@ -98,7 +102,7 @@ fn test_agent_config(name: &str) -> deskd::app::agent::AgentConfig {
 /// State persistence survives crash: session_id, cost, turns preserved.
 #[tokio::test]
 async fn test_state_survives_crash() {
-    let _tmp = setup_state_dir();
+    let (_tmp, _env_guard) = setup_state_dir().await;
 
     let cfg = test_agent_config("crash-agent");
     let state = deskd::app::agent::create(&cfg).await.unwrap();

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -90,6 +90,8 @@ fn test_agent_config(name: &str) -> deskd::app::agent::AgentConfig {
         context: None,
         compact_threshold: None,
         auto_compact_threshold_tokens: None,
+        empty_completion_threshold: None,
+        empty_completion_restart_min_secs: None,
     }
 }
 

--- a/tests/workflow_transitions.rs
+++ b/tests/workflow_transitions.rs
@@ -571,6 +571,8 @@ async fn test_sm_move_notifies_workflow_engine() {
 /// Starts workflow engine → only the instance without result should be dispatched.
 #[tokio::test]
 async fn test_dispatch_pending_skips_completed_instances() {
+    // Serialize env mutation; setenv is not thread-safe on POSIX.
+    let _env_guard = deskd::test_support::env_lock().lock().await;
     let socket = temp_socket();
     let tmp = temp_dir();
 


### PR DESCRIPTION
Refs #424.

## Summary

`result` events from claude workers with `output_tokens=0 AND duration_secs<2` are now treated as suspect "hung worker" completions instead of being silently logged as success. The agent registry tracks per-agent counters; once a configurable threshold is hit, the worker auto-restarts itself with a rate-limit guard so a wedged model can't restart-loop.

## What's in this PR

- `worker::is_empty_completion()` heuristic + threshold constants.
- `worker::empty_restart_allowed()` rate-limit predicate (skips restart when last attempt was inside the configured window).
- New `AgentState` fields: \`consecutive_empty_completions\`, \`last_empty_restart_at\`, \`total_empty_restarts\` — all \`#[serde(default)]\` so existing on-disk state files load unchanged.
- New `AgentConfig` fields: \`empty_completion_threshold\` (default **3**), \`empty_completion_restart_min_secs\` (default **60**).
- Mirror config fields on \`SubAgentDef\` plumbed into \`AgentConfig\` during config reload.
- Worker emits \`tracing::warn!\` ("agent X returned empty completion — likely hung"), bumps the counter, marks \`usage.jsonl\` entry status accordingly, and triggers auto-restart at threshold (logs at \`error!\` level).

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test --all\` — passes
  - 6 new unit tests for \`is_empty_completion\` (zero-tokens-short-duration positive, real-completion negative, long-duration-zero-token negative) and \`empty_restart_allowed\` (no prior, window elapsed, window blocking)
  - all existing suites green

## Out of scope

- Bus-event publication for the WARN (covered by #426)
- Verdict synthesis from this counter (covered by #422 / #425)

🤖 Generated with [Claude Code](https://claude.com/claude-code)