### PR TITLE
feat(#426): convert WARN call sites to diag + add bus subscribe CLI

### DIFF
--- a/src/app/adapters/telegram/mod.rs
+++ b/src/app/adapters/telegram/mod.rs
@@ -833,7 +833,13 @@ async fn polling_loop(
             result = updates_fut => match result {
                 Ok(u) => u,
                 Err(e) => {
-                    warn!(agent = %agent_name, error = %e, "get_updates error, retrying in 5s");
+                    crate::infra::diag::warn_event(
+                        Some(&socket_path),
+                        "telegram",
+                        "transport.poll_failed",
+                        format!("telegram get_updates failed: {}", e),
+                        serde_json::json!({"agent": agent_name}),
+                    );
                     tokio::select! {
                         _ = tokio::time::sleep(Duration::from_secs(5)) => {},
                         _ = cancel.cancelled() => {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -541,6 +541,27 @@ pub enum BusAction {
         #[arg(long, env = "DESKD_AGENT_NAME")]
         agent: Option<String>,
     },
+    /// Tail bus messages matching one or more topic patterns as JSONL.
+    ///
+    /// Each line on stdout is the message payload. Use a glob (`diagnostics.*`)
+    /// to match a topic family, or an exact topic for a single channel.
+    ///
+    /// Examples:
+    ///   deskd bus subscribe diagnostics.warn
+    ///   deskd bus subscribe diagnostics.*
+    ///   deskd bus subscribe --socket /tmp/deskd.sock 'agent:*'
+    Subscribe {
+        /// One or more subscription patterns (exact topic or glob ending in `*`).
+        #[arg(value_name = "PATTERN", required = true, num_args = 1..)]
+        patterns: Vec<String>,
+        /// Bus socket path. Defaults to $DESKD_BUS_SOCKET, or auto-discovered
+        /// from running serve state.
+        #[arg(long, env = "DESKD_BUS_SOCKET")]
+        socket: Option<String>,
+        /// Client name to register on the bus (default: deskd-cli-subscribe).
+        #[arg(long, default_value = "deskd-cli-subscribe")]
+        name: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/app/commands/bus.rs
+++ b/src/app/commands/bus.rs
@@ -17,6 +17,13 @@ pub async fn handle(action: BusAction) -> Result<()> {
         } => {
             return handle_api(socket, config_opt, agent).await;
         }
+        BusAction::Subscribe {
+            patterns,
+            socket,
+            name,
+        } => {
+            return handle_subscribe(patterns, socket, name).await;
+        }
         BusAction::Status { socket } => {
             if !std::path::Path::new(&socket).exists() {
                 println!("Bus is not running (socket not found: {})", socket);
@@ -172,6 +179,60 @@ fn resolve_config(explicit: Option<String>) -> Option<String> {
     }
     config::ServeState::load()
         .and_then(|state| state.find_agent_config().map(|a| a.config_path.clone()))
+}
+
+/// Subscribe to one or more bus topics and emit each received message as a
+/// single JSON line on stdout. Runs until the bus connection drops or the
+/// process is interrupted.
+async fn handle_subscribe(
+    patterns: Vec<String>,
+    socket: Option<String>,
+    name: String,
+) -> Result<()> {
+    let bus_socket = resolve_bus_socket(socket)?;
+
+    if !std::path::Path::new(&bus_socket).exists() {
+        anyhow::bail!("Bus socket not found: {}", bus_socket);
+    }
+
+    let mut stream = UnixStream::connect(&bus_socket)
+        .await
+        .map_err(|e| anyhow::anyhow!("Cannot connect to bus at {}: {}", bus_socket, e))?;
+
+    let reg = serde_json::json!({
+        "type": "register",
+        "name": name,
+        "subscriptions": patterns,
+    });
+    let mut line = serde_json::to_string(&reg)?;
+    line.push('\n');
+    stream.write_all(line.as_bytes()).await?;
+
+    info!(
+        socket = %bus_socket,
+        client = %name,
+        patterns = ?patterns,
+        "subscribed; tailing messages as JSONL"
+    );
+
+    let (reader, _writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    while let Some(l) = lines.next_line().await? {
+        let trimmed = l.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        // Emit just the payload — that's the structured event the producer published.
+        let payload = v.get("payload").cloned().unwrap_or(v);
+        println!("{}", serde_json::to_string(&payload)?);
+    }
+
+    Ok(())
 }
 
 async fn handle_api(

--- a/src/app/config_watcher.rs
+++ b/src/app/config_watcher.rs
@@ -36,7 +36,13 @@ pub async fn watch_system_prompt(config_path: String, bus_socket: String, agent_
         let cfg = match crate::config::UserConfig::load(&config_path) {
             Ok(c) => c,
             Err(e) => {
-                warn!(agent = %agent_name, error = %e, "config_watcher: failed to reload config");
+                crate::infra::diag::warn_event(
+                    Some(&bus_socket),
+                    "config_watcher",
+                    "config.reload_failed",
+                    format!("failed to reload config for agent {}: {}", agent_name, e),
+                    serde_json::json!({"agent": agent_name, "config_path": config_path}),
+                );
                 continue;
             }
         };

--- a/src/app/schedule.rs
+++ b/src/app/schedule.rs
@@ -161,7 +161,13 @@ async fn run_schedule(def: ScheduleDef, bus_socket: String, agent_name: String, 
         info!(agent = %agent_name, target = %def.target, action = ?def.action, "schedule firing");
 
         if let Err(e) = fire(&def, &bus_socket, &agent_name, &home_dir).await {
-            warn!(agent = %agent_name, target = %def.target, error = %e, "schedule fire failed");
+            crate::infra::diag::warn_event(
+                Some(&bus_socket),
+                "schedule",
+                "schedule.fire_failed",
+                format!("schedule fire failed for target {}: {}", def.target, e),
+                serde_json::json!({"agent": agent_name, "target": def.target, "cron": def.cron}),
+            );
         }
     }
 }
@@ -298,7 +304,13 @@ async fn fire_github_poll(
                     );
                 }
                 Err(e) => {
-                    warn!(agent = %agent_name, repo = %repo, error = %e, "github_poll issues failed");
+                    crate::infra::diag::warn_event(
+                        Some(bus_socket),
+                        "github_poll",
+                        "transport.poll_failed",
+                        format!("github_poll issues failed for {}: {}", repo, e),
+                        serde_json::json!({"agent": agent_name, "repo": repo, "event": "issues"}),
+                    );
                 }
             }
         }
@@ -327,7 +339,13 @@ async fn fire_github_poll(
                     );
                 }
                 Err(e) => {
-                    warn!(agent = %agent_name, repo = %repo, error = %e, "github_poll issue_comments failed");
+                    crate::infra::diag::warn_event(
+                        Some(bus_socket),
+                        "github_poll",
+                        "transport.poll_failed",
+                        format!("github_poll issue_comments failed for {}: {}", repo, e),
+                        serde_json::json!({"agent": agent_name, "repo": repo, "event": "issue_comments"}),
+                    );
                 }
             }
         }
@@ -356,7 +374,13 @@ async fn fire_github_poll(
                     );
                 }
                 Err(e) => {
-                    warn!(agent = %agent_name, repo = %repo, error = %e, "github_poll pull_requests failed");
+                    crate::infra::diag::warn_event(
+                        Some(bus_socket),
+                        "github_poll",
+                        "transport.poll_failed",
+                        format!("github_poll pull_requests failed for {}: {}", repo, e),
+                        serde_json::json!({"agent": agent_name, "repo": repo, "event": "pull_requests"}),
+                    );
                 }
             }
         }

--- a/tests/diag_publish.rs
+++ b/tests/diag_publish.rs
@@ -1,0 +1,161 @@
+//! Integration test for #426 call-site coverage: real call sites that publish
+//! a `diagnostics.warn` event to the bus.
+//!
+//! Drives `infra::diag::warn_event` and `error_event` end-to-end through the
+//! bus server, asserting that a subscriber receives a structured event with
+//! the expected `kind`, `source`, and `details` fields.
+
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn temp_socket(label: &str) -> String {
+    format!(
+        "/tmp/deskd-test-diag-{}-{}.sock",
+        label,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )
+}
+
+async fn connect_subscriber(
+    socket: &str,
+    name: &str,
+    subscriptions: &[&str],
+) -> (
+    tokio::io::Lines<BufReader<tokio::net::unix::OwnedReadHalf>>,
+    tokio::net::unix::OwnedWriteHalf,
+) {
+    let stream = UnixStream::connect(socket).await.unwrap();
+    let (reader, mut writer) = stream.into_split();
+
+    let reg = serde_json::json!({
+        "type": "register",
+        "name": name,
+        "subscriptions": subscriptions,
+    });
+    let mut line = serde_json::to_string(&reg).unwrap();
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await.unwrap();
+
+    (BufReader::new(reader).lines(), writer)
+}
+
+async fn read_one(
+    lines: &mut tokio::io::Lines<BufReader<tokio::net::unix::OwnedReadHalf>>,
+    timeout_ms: u64,
+) -> Option<serde_json::Value> {
+    tokio::time::timeout(Duration::from_millis(timeout_ms), lines.next_line())
+        .await
+        .ok()?
+        .ok()?
+        .and_then(|l| serde_json::from_str(&l).ok())
+}
+
+#[tokio::test]
+async fn warn_event_publishes_to_diagnostics_warn_topic() {
+    let socket = temp_socket("warn-exact");
+
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::app::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let (mut sub_rx, _sub_tx) =
+        connect_subscriber(&socket, "test-subscriber", &["diagnostics.warn"]).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    deskd::infra::diag::warn_event(
+        Some(&socket),
+        "telegram",
+        "transport.send_failed",
+        "telegram send failed: rate limited",
+        serde_json::json!({"chat_id": 42}),
+    );
+
+    let received = read_one(&mut sub_rx, 2000).await;
+    assert!(received.is_some(), "subscriber should receive diag event");
+    let received = received.unwrap();
+    assert_eq!(received["target"], "diagnostics.warn");
+    let payload = &received["payload"];
+    assert_eq!(payload["topic"], "diagnostics.warn");
+    assert_eq!(payload["source"], "telegram");
+    assert_eq!(payload["kind"], "transport.send_failed");
+    assert_eq!(payload["details"]["chat_id"], 42);
+    assert!(payload["timestamp"].is_string());
+
+    let _ = std::fs::remove_file(&socket);
+}
+
+#[tokio::test]
+async fn diagnostics_glob_receives_warn_and_error() {
+    let socket = temp_socket("glob");
+
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::app::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let (mut sub_rx, _sub_tx) =
+        connect_subscriber(&socket, "diag-glob-sub", &["diagnostics.*"]).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    deskd::infra::diag::warn_event(
+        Some(&socket),
+        "github_poll",
+        "transport.poll_failed",
+        "x",
+        serde_json::Value::Null,
+    );
+    deskd::infra::diag::error_event(
+        Some(&socket),
+        "supervisor",
+        "respawn.failed",
+        "child died",
+        serde_json::json!({"agent": "life"}),
+    );
+
+    let mut topics: Vec<String> = Vec::new();
+    for _ in 0..2 {
+        if let Some(msg) = read_one(&mut sub_rx, 2000).await
+            && let Some(t) = msg["target"].as_str()
+        {
+            topics.push(t.to_string());
+        }
+    }
+    topics.sort();
+    assert_eq!(topics, vec!["diagnostics.error", "diagnostics.warn"]);
+
+    let _ = std::fs::remove_file(&socket);
+}
+
+#[tokio::test]
+async fn warn_event_is_non_blocking_under_load() {
+    // With no subscriber, each call still spawns a fire-and-forget publish task
+    // that fails silently. The caller path itself must not block.
+    let socket = temp_socket("no-sub");
+
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::app::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let start = std::time::Instant::now();
+    for i in 0..10 {
+        deskd::infra::diag::warn_event(
+            Some(&socket),
+            "test",
+            "load",
+            format!("event {}", i),
+            serde_json::Value::Null,
+        );
+    }
+    assert!(start.elapsed() < Duration::from_secs(1));
+
+    let _ = std::fs::remove_file(&socket);
+}


### PR DESCRIPTION
Refs #426. Builds on #427's `infra::diag` foundation.

## Summary

- Converts 6 operationally-meaningful WARN sites to `infra::diag::warn_event` so they surface as structured events on `diagnostics.warn`:
  - **telegram adapter** — get_updates poll failures (`transport.poll_failed`)
  - **schedule loop** — schedule fire failures (`schedule.fire_failed`)
  - **github_poll** — issues / issue_comments / pull_requests fetch failures (`transport.poll_failed`)
  - **config_watcher** — deskd.yaml reload failures (`config.reload_failed`)
- Adds `deskd bus subscribe <pattern>...` CLI that tails matching messages as JSONL — closes the "no way to tail diagnostics without a custom client" gap noted in #427.

Send-side telegram failures inside `outbound_sender` are intentionally left on plain `tracing::warn` for now: that task doesn't have the bus socket in scope and threading it through requires a wider refactor. Worth a small follow-up PR if/when the rest of the adapter gets touched.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --tests -- -D warnings` clean
- [x] `cargo test` — 3 new integration tests in `tests/diag_publish.rs` cover:
  - exact-topic subscriber receives `warn_event` payload with `kind`/`source`/`details`
  - `diagnostics.*` glob subscriber receives both warn and error topics
  - fire-and-forget call returns under 1s with no subscriber attached
- [x] Stable across re-runs (no flakes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)