### PR TITLE
feat(#426): convert supervisor + telegram send-side WARN sites to diag

### DIFF
--- a/src/app/adapters/telegram/mod.rs
+++ b/src/app/adapters/telegram/mod.rs
@@ -222,8 +222,10 @@ pub async fn run(
     let sender_task = {
         let bot = bot.clone();
         let cancel = cancel.clone();
+        let bus = socket_path.clone();
+        let name = agent_name.clone();
         tokio::spawn(async move {
-            outbound_sender(bot, outbound_rx, cancel).await;
+            outbound_sender(bot, outbound_rx, cancel, bus, name).await;
         })
     };
 
@@ -438,6 +440,8 @@ async fn outbound_sender(
     bot: Bot,
     mut rx: mpsc::UnboundedReceiver<OutboundCmd>,
     cancel: CancellationToken,
+    bus_socket: String,
+    agent_name: String,
 ) {
     let mut typing_tasks: HashMap<i64, tokio::task::JoinHandle<()>> = HashMap::new();
     let mut progress_ids: HashMap<i64, teloxide::types::MessageId> = HashMap::new();
@@ -478,7 +482,13 @@ async fn outbound_sender(
                     if result.is_err()
                         && let Err(e) = bot.send_message(chat, chunk).await
                     {
-                        warn!(chat_id = chat_id, error = %e, "failed to send Telegram message");
+                        crate::infra::diag::warn_event(
+                            Some(&bus_socket),
+                            &agent_name,
+                            "transport.send_failed",
+                            format!("failed to send Telegram message: {}", e),
+                            serde_json::json!({ "chat_id": chat_id }),
+                        );
                     }
                 }
 

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -27,12 +27,13 @@
 /// `classify_config_change` inspects what actually changed and returns a
 /// `ConfigChangeset` so only the affected components are restarted, avoiding
 /// unnecessary adapter disruption on system-prompt-only or schedule-only edits.
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::app::agent_components::AgentComponents;
 use crate::app::config_changeset::{ConfigChangeset, classify_config_change};
 use crate::app::{adapters, config_watcher, schedule, worker};
 use crate::config;
+use crate::infra::diag;
 
 /// Spawn all restartable components for an agent and return their handles.
 pub async fn spawn_components(
@@ -58,8 +59,14 @@ pub async fn spawn_components(
         let name = agent_name.to_string();
         let adapter_name = adapter.name().to_string();
         let handle = tokio::spawn(async move {
-            if let Err(e) = adapter.run(bus, name).await {
-                tracing::error!(adapter = %adapter_name, error = %e, "adapter failed");
+            if let Err(e) = adapter.run(bus.clone(), name.clone()).await {
+                diag::error_event(
+                    Some(&bus),
+                    "supervisor",
+                    "adapter.failed",
+                    format!("adapter failed: {}", e),
+                    serde_json::json!({ "adapter": adapter_name, "agent": name }),
+                );
             }
         });
         components.adapter_handles.push(handle);
@@ -175,7 +182,13 @@ pub async fn spawn_components(
                 )
                 .await
                 {
-                    tracing::error!(agent = %sub_name, error = %e, "sub-agent worker exited");
+                    diag::error_event(
+                        Some(&bus),
+                        "supervisor",
+                        "sub_agent.exited",
+                        format!("sub-agent worker exited: {}", e),
+                        serde_json::json!({ "agent": sub_name }),
+                    );
                 }
             });
             components.sub_agent_handles.push(handle);
@@ -199,8 +212,14 @@ async fn spawn_adapters(
         let name = agent_name.to_string();
         let adapter_name = adapter.name().to_string();
         let handle = tokio::spawn(async move {
-            if let Err(e) = adapter.run(bus, name).await {
-                tracing::error!(adapter = %adapter_name, error = %e, "adapter failed");
+            if let Err(e) = adapter.run(bus.clone(), name.clone()).await {
+                diag::error_event(
+                    Some(&bus),
+                    "supervisor",
+                    "adapter.failed",
+                    format!("adapter failed: {}", e),
+                    serde_json::json!({ "adapter": adapter_name, "agent": name }),
+                );
             }
         });
         components.adapter_handles.push(handle);
@@ -279,10 +298,12 @@ pub async fn watch_and_reload(
         let new_user_cfg = match config::UserConfig::load(&cfg_path) {
             Ok(cfg) => cfg,
             Err(e) => {
-                warn!(
-                    agent = %agent_name,
-                    error = %e,
-                    "failed to reload config, components unchanged"
+                diag::warn_event(
+                    Some(&bus_socket),
+                    "config_reload",
+                    "config.reload_failed",
+                    format!("failed to reload config, components unchanged: {}", e),
+                    serde_json::json!({ "agent": agent_name, "path": cfg_path }),
                 );
                 continue;
             }
@@ -362,11 +383,12 @@ pub async fn watch_and_reload(
         for removed in &changeset.removed_sub_agents {
             match crate::app::agent_registry::remove(removed).await {
                 Ok(()) => info!(agent = %agent_name, removed = %removed, "evicted sub-agent state"),
-                Err(e) => warn!(
-                    agent = %agent_name,
-                    removed = %removed,
-                    error = %e,
-                    "failed to evict sub-agent state"
+                Err(e) => diag::warn_event(
+                    Some(&bus_socket),
+                    "config_reload",
+                    "sub_agent.evict_failed",
+                    format!("failed to evict sub-agent state: {}", e),
+                    serde_json::json!({ "agent": agent_name, "removed": removed }),
                 ),
             }
         }
@@ -391,10 +413,12 @@ pub async fn watch_and_reload(
                 );
             }
             Err(e) => {
-                warn!(
-                    agent = %agent_name,
-                    error = %e,
-                    "failed to respawn components after config reload"
+                diag::warn_event(
+                    Some(&bus_socket),
+                    "config_reload",
+                    "components.respawn_failed",
+                    format!("failed to respawn components after config reload: {}", e),
+                    serde_json::json!({ "agent": agent_name }),
                 );
             }
         }

--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -5,6 +5,7 @@ use tracing::info;
 
 use crate::app::{agent, alerts, bus, bus_api, config_reload, worker, workflow};
 use crate::config;
+use crate::infra::diag;
 
 /// Start per-agent buses and workers for all agents in workspace config.
 /// Each agent has its own isolated bus at {work_dir}/.deskd/bus.sock.
@@ -37,7 +38,18 @@ pub async fn serve(config_path: String) -> Result<()> {
         );
     }
     if let Err(e) = serve_state.save() {
-        tracing::warn!(error = %e, "failed to write serve state");
+        let bus_for_diag = workspace
+            .agents
+            .first()
+            .map(|a| a.bus_socket())
+            .unwrap_or_default();
+        diag::warn_event(
+            Some(&bus_for_diag),
+            "supervisor",
+            "state.write_failed",
+            format!("failed to write serve state: {}", e),
+            serde_json::json!({}),
+        );
     }
 
     for def in &workspace.agents {
@@ -65,7 +77,16 @@ pub async fn serve(config_path: String) -> Result<()> {
             let agent_name = name.clone();
             tokio::spawn(async move {
                 if let Err(e) = bus::serve(&bus).await {
-                    tracing::error!(agent = %agent_name, socket = %bus, error = %e, "bus failed");
+                    diag::error_event(
+                        Some(&bus),
+                        "supervisor",
+                        "bus.serve_failed",
+                        format!("bus failed: {}", e),
+                        serde_json::json!({
+                            "agent": agent_name,
+                            "socket": bus,
+                        }),
+                    );
                 }
             });
         }
@@ -88,7 +109,13 @@ pub async fn serve(config_path: String) -> Result<()> {
                 )
                 .await
                 {
-                    tracing::error!(agent = %agent_name, error = %e, "bus_api exited");
+                    diag::error_event(
+                        Some(&bus),
+                        "supervisor",
+                        "bus_api.exited",
+                        format!("bus_api exited: {}", e),
+                        serde_json::json!({ "agent": agent_name }),
+                    );
                 }
             });
             info!(agent = %name, "started bus API handler");
@@ -109,7 +136,13 @@ pub async fn serve(config_path: String) -> Result<()> {
                 )
                 .await
                 {
-                    tracing::error!(agent = %worker_name, error = %e, "worker exited with error");
+                    diag::error_event(
+                        Some(&bus),
+                        "supervisor",
+                        "worker.exited",
+                        format!("worker exited with error: {}", e),
+                        serde_json::json!({ "agent": worker_name }),
+                    );
                 }
             });
         }
@@ -126,7 +159,13 @@ pub async fn serve(config_path: String) -> Result<()> {
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, String>>()
                 .unwrap_or_else(|e| {
-                    tracing::error!(agent = %def.name, "invalid model definition: {e}");
+                    diag::error_event(
+                        Some(&bus_socket),
+                        "supervisor",
+                        "config.invalid_model",
+                        format!("invalid model definition: {}", e),
+                        serde_json::json!({ "agent": def.name }),
+                    );
                     vec![]
                 });
             let agent_name = def.name.clone();
@@ -151,16 +190,24 @@ pub async fn serve(config_path: String) -> Result<()> {
                 let bus_client = match crate::app::bus::connect_bus(&bus).await {
                     Ok(b) => b,
                     Err(e) => {
-                        tracing::error!(
-                            agent = %agent_name,
-                            error = %e,
-                            "workflow engine failed to connect to bus"
+                        diag::error_event(
+                            Some(&bus),
+                            "supervisor",
+                            "workflow.bus_connect_failed",
+                            format!("workflow engine failed to connect to bus: {}", e),
+                            serde_json::json!({ "agent": agent_name }),
                         );
                         return;
                     }
                 };
                 if let Err(e) = workflow::run(&bus_client, models, &sm_store, &task_store).await {
-                    tracing::error!(agent = %agent_name, error = %e, "workflow engine exited");
+                    diag::error_event(
+                        Some(&bus),
+                        "supervisor",
+                        "workflow.exited",
+                        format!("workflow engine exited: {}", e),
+                        serde_json::json!({ "agent": agent_name }),
+                    );
                 }
             });
             info!(agent = %def.name, models = ucfg.models.len(), "started workflow engine");
@@ -228,8 +275,9 @@ pub async fn serve(config_path: String) -> Result<()> {
             let manager = alerts::AlertManager::from_config(&alerts_cfg, &any_socket, "deskd");
             let source = alerts::HeuristicVerdictSource::new(agents_for_source);
             let interval = std::time::Duration::from_secs(alerts_cfg.poll_interval_secs.max(1));
+            let diag_bus = any_socket.clone();
             tokio::spawn(async move {
-                run_alerts_loop(manager, source, interval).await;
+                run_alerts_loop(manager, source, interval, diag_bus).await;
             });
             info!(
                 sinks = alerts_cfg.sinks.len(),
@@ -251,8 +299,12 @@ pub async fn serve(config_path: String) -> Result<()> {
 
 /// Run a single poll-and-dispatch loop for the alert manager.
 /// Exits only when the deskd serve process stops.
-async fn run_alerts_loop<S>(manager: alerts::AlertManager, source: S, interval: std::time::Duration)
-where
+async fn run_alerts_loop<S>(
+    manager: alerts::AlertManager,
+    source: S,
+    interval: std::time::Duration,
+    bus_socket: String,
+) where
     S: alerts::VerdictSource,
 {
     if manager.is_empty() {
@@ -268,7 +320,13 @@ where
         match source.poll().await {
             Ok(reports) => manager.observe(reports).await,
             Err(e) => {
-                tracing::warn!(error = %e, "alert verdict source poll failed");
+                diag::warn_event(
+                    Some(&bus_socket),
+                    "alerts",
+                    "verdict.poll_failed",
+                    format!("alert verdict source poll failed: {}", e),
+                    serde_json::json!({}),
+                );
             }
         }
     }

--- a/tests/schedule_to_worker.rs
+++ b/tests/schedule_to_worker.rs
@@ -14,13 +14,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 fn temp_socket() -> String {
-    format!(
-        "/tmp/deskd-test-sched-{}.sock",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    )
+    format!("/tmp/deskd-test-sched-{}.sock", uuid::Uuid::new_v4())
 }
 
 async fn connect_and_register(


### PR DESCRIPTION
Refs #426. Continues PR #433 by routing the remaining operationally-meaningful WARN/ERROR sites through `infra::diag::warn_event` / `error_event`.

## Sites converted

**Supervisor (`src/app/serve.rs`)** — agent lifecycle and core-task crashes
- `state.write_failed` — `ServeState::save` failure
- `bus.serve_failed` — agent-bus task exits
- `bus_api.exited` — bus API handler exits
- `worker.exited` — worker task exits
- `config.invalid_model` — model definition fails to validate
- `workflow.bus_connect_failed` — workflow engine cannot connect to bus
- `workflow.exited` — workflow task exits
- `verdict.poll_failed` — alert manager (#425) verdict source poll error

**Config reload (`src/app/config_reload.rs`)** — hot-reload failure modes
- `adapter.failed` (both initial-spawn and reload-time-spawn paths)
- `sub_agent.exited`
- `config.reload_failed` — `UserConfig::load` fails during hot reload
- `sub_agent.evict_failed`
- `components.respawn_failed`

**Telegram send-side (`src/app/adapters/telegram/mod.rs`)**
`outbound_sender` now takes `bus_socket` and `agent_name` so a `bot.send_message` failure publishes `transport.send_failed`. Closes the deferred case explicitly noted in PR #433.

## Sites intentionally not converted

- `bus_server.rs:117` (`no subscriber for target`) — this is the bus core's own delivery warning. Publishing a diag event from here would re-enter the same delivery path and recurse when the diagnostics topic has no subscriber. Belongs in a metric, not the bus itself.
- `mcp_tools.rs` JWT-key load warnings — startup-only, not operationally meaningful at runtime.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --tests -- -D warnings` clean
- [x] `cargo test` — 581 unit + integration tests pass (incl. the 3 diag publish tests from #433)
- The diag publish path itself is covered by `tests/diag_publish.rs` from #433; new sites just call the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)