### PR TITLE
feat(#426): publish bus.undeliverable diag event with self-recursion guard

### DIFF
--- a/src/infra/bus_server.rs
+++ b/src/infra/bus_server.rs
@@ -8,6 +8,7 @@ use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, info, warn};
 
 use crate::domain::message::Message;
+use crate::infra::diag;
 use crate::infra::dto::{BusEnvelope, BusMessage};
 
 type Tx = mpsc::UnboundedSender<Message>;
@@ -20,12 +21,25 @@ struct Client {
 
 struct BusState {
     clients: HashMap<String, Client>,
+    /// Bus's own socket path. When set, undeliverable warnings publish a
+    /// best-effort `bus.undeliverable` event to `diagnostics.warn` (#426).
+    /// `None` in unit tests where there is no listening socket.
+    socket_path: Option<String>,
 }
 
 impl BusState {
-    fn new() -> Self {
+    fn with_socket(socket_path: impl Into<String>) -> Self {
         Self {
             clients: HashMap::new(),
+            socket_path: Some(socket_path.into()),
+        }
+    }
+
+    #[cfg(test)]
+    fn for_test() -> Self {
+        Self {
+            clients: HashMap::new(),
+            socket_path: None,
         }
     }
 
@@ -115,6 +129,19 @@ impl BusState {
 
             if !delivered {
                 warn!(target = %target, "no subscriber for target");
+
+                if !target.starts_with("diagnostics.") {
+                    diag::warn_event(
+                        self.socket_path.as_deref(),
+                        "bus",
+                        "bus.undeliverable",
+                        format!("no subscriber for target {target}"),
+                        serde_json::json!({
+                            "target": target,
+                            "source": msg.source,
+                        }),
+                    );
+                }
             }
         }
     }
@@ -139,7 +166,7 @@ pub async fn serve(socket_path: &str) -> Result<()> {
 
     info!(socket = %socket_path, "bus listening");
 
-    let state = Arc::new(RwLock::new(BusState::new()));
+    let state = Arc::new(RwLock::new(BusState::with_socket(socket_path)));
 
     loop {
         let (stream, _) = listener.accept().await?;
@@ -273,7 +300,7 @@ mod tests {
     use std::collections::HashSet;
 
     fn make_bus() -> BusState {
-        BusState::new()
+        BusState::for_test()
     }
 
     fn register_client(

--- a/tests/a2a_cross_instance.rs
+++ b/tests/a2a_cross_instance.rs
@@ -23,13 +23,7 @@ use deskd::app::a2a::{AgentAuthentication, AgentCapabilities, AgentCard, AgentSk
 use deskd::app::a2a_server::{A2aState, A2aTaskRegistry, router};
 
 fn temp_socket() -> String {
-    format!(
-        "/tmp/deskd-a2a-cross-{}.sock",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    )
+    format!("/tmp/deskd-a2a-cross-{}.sock", uuid::Uuid::new_v4())
 }
 
 /// Connect to a bus and register; return (lines reader, writer).

--- a/tests/agent_lifecycle.rs
+++ b/tests/agent_lifecycle.rs
@@ -13,13 +13,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 fn temp_socket() -> String {
-    format!(
-        "/tmp/deskd-test-lifecycle-{}.sock",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    )
+    format!("/tmp/deskd-test-lifecycle-{}.sock", uuid::Uuid::new_v4())
 }
 
 async fn connect_and_register(
@@ -87,13 +81,7 @@ async fn test_agent_state_lifecycle() {
     // Serialize env mutation; setenv is not thread-safe on POSIX.
     let _env_guard = deskd::test_support::env_lock().lock().await;
     // Set up isolated HOME.
-    let tmp = std::path::PathBuf::from(format!(
-        "/tmp/deskd-test-state-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let tmp = std::path::PathBuf::from(format!("/tmp/deskd-test-state-{}", uuid::Uuid::new_v4()));
     // SAFETY: ENV_LOCK serializes all env-mutating tests across the workspace.
     unsafe { std::env::set_var("HOME", &tmp) };
     std::fs::create_dir_all(tmp.join(".deskd/agents")).unwrap();

--- a/tests/budget_enforcement.rs
+++ b/tests/budget_enforcement.rs
@@ -12,22 +12,13 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 fn temp_socket() -> String {
-    format!(
-        "/tmp/deskd-test-budget-{}.sock",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    )
+    format!("/tmp/deskd-test-budget-{}.sock", uuid::Uuid::new_v4())
 }
 
 fn temp_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(format!(
         "/tmp/deskd-test-budget-dir-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
+        uuid::Uuid::new_v4()
     ))
 }
 

--- a/tests/bus_integration.rs
+++ b/tests/bus_integration.rs
@@ -9,13 +9,7 @@ use tokio::net::UnixStream;
 
 /// Create a temp socket path that won't collide with other tests.
 fn temp_socket() -> String {
-    format!(
-        "/tmp/deskd-test-bus-{}.sock",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    )
+    format!("/tmp/deskd-test-bus-{}.sock", uuid::Uuid::new_v4())
 }
 
 /// Helper: connect to bus, register with a name, return (reader, writer).

--- a/tests/crash_recovery.rs
+++ b/tests/crash_recovery.rs
@@ -15,13 +15,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 fn temp_socket() -> String {
-    format!(
-        "/tmp/deskd-test-crash-{}.sock",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    )
+    format!("/tmp/deskd-test-crash-{}.sock", uuid::Uuid::new_v4())
 }
 
 async fn connect_and_register(
@@ -65,10 +59,7 @@ async fn setup_state_dir() -> (std::path::PathBuf, tokio::sync::MutexGuard<'stat
     let guard = deskd::test_support::env_lock().lock().await;
     let tmp = std::path::PathBuf::from(format!(
         "/tmp/deskd-test-crash-state-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
+        uuid::Uuid::new_v4()
     ));
     // SAFETY: ENV_LOCK serializes all env-mutating tests across the workspace.
     unsafe { std::env::set_var("HOME", &tmp) };
@@ -300,13 +291,8 @@ async fn test_crash_error_delivered_to_sender() {
 /// Task log records error status on crash.
 #[tokio::test]
 async fn test_tasklog_records_crash_error() {
-    let log_dir = std::path::PathBuf::from(format!(
-        "/tmp/deskd-test-crashlog-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let log_dir =
+        std::path::PathBuf::from(format!("/tmp/deskd-test-crashlog-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&log_dir).unwrap();
 
     // Create a task log entry for a crashed task (what worker does on error).

--- a/tests/diag_publish.rs
+++ b/tests/diag_publish.rs
@@ -13,10 +13,7 @@ fn temp_socket(label: &str) -> String {
     format!(
         "/tmp/deskd-test-diag-{}-{}.sock",
         label,
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
+        uuid::Uuid::new_v4()
     )
 }
 
@@ -129,6 +126,97 @@ async fn diagnostics_glob_receives_warn_and_error() {
     }
     topics.sort();
     assert_eq!(topics, vec!["diagnostics.error", "diagnostics.warn"]);
+
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// When a message has no matching subscriber on a non-`diagnostics.*` target,
+/// the bus should publish a `bus.undeliverable` diagnostic so monitors see it.
+#[tokio::test]
+async fn bus_undeliverable_publishes_diag_event() {
+    let socket = temp_socket("undeliverable");
+
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::app::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let (mut sub_rx, _sub_tx) =
+        connect_subscriber(&socket, "diag-watcher", &["diagnostics.warn"]).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let (_unused_rx, mut sender_tx) = connect_subscriber(&socket, "test-sender", &[]).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let send = serde_json::json!({
+        "type": "message",
+        "id": uuid::Uuid::new_v4().to_string(),
+        "source": "test-sender",
+        "target": "unmatched.topic",
+        "payload": {"hello": "world"},
+    });
+    let mut line = serde_json::to_string(&send).unwrap();
+    line.push('\n');
+    sender_tx.write_all(line.as_bytes()).await.unwrap();
+
+    let received = read_one(&mut sub_rx, 2000).await;
+    assert!(
+        received.is_some(),
+        "diag-watcher should receive bus.undeliverable event"
+    );
+    let received = received.unwrap();
+    assert_eq!(received["target"], "diagnostics.warn");
+    let payload = &received["payload"];
+    assert_eq!(payload["topic"], "diagnostics.warn");
+    assert_eq!(payload["source"], "bus");
+    assert_eq!(payload["kind"], "bus.undeliverable");
+    assert_eq!(payload["details"]["target"], "unmatched.topic");
+    assert_eq!(payload["details"]["source"], "test-sender");
+
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// When the undeliverable message itself targets `diagnostics.*`, the bus
+/// must NOT publish another `bus.undeliverable` event — that would loop on
+/// every diag emission whose topic has no subscriber.
+///
+/// Subscribe a watcher to `diagnostics.warn`, then send a message to
+/// `diagnostics.error` (a different diagnostic topic with no subscriber).
+/// Without the guard the bus would publish a `bus.undeliverable` event to
+/// `diagnostics.warn`; the watcher would see it. With the guard, the watcher
+/// receives nothing.
+#[tokio::test]
+async fn bus_undeliverable_does_not_recurse_on_diagnostics_target() {
+    let socket = temp_socket("no-recurse");
+
+    let sock = socket.clone();
+    tokio::spawn(async move {
+        deskd::app::bus::serve(&sock).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let (mut sub_rx, _sub_tx) =
+        connect_subscriber(&socket, "diag-watcher", &["diagnostics.warn"]).await;
+    let (_unused_rx, mut sender_tx) = connect_subscriber(&socket, "test-sender", &[]).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let send = serde_json::json!({
+        "type": "message",
+        "id": uuid::Uuid::new_v4().to_string(),
+        "source": "test-sender",
+        "target": "diagnostics.error",
+        "payload": {"x": 1},
+    });
+    let mut line = serde_json::to_string(&send).unwrap();
+    line.push('\n');
+    sender_tx.write_all(line.as_bytes()).await.unwrap();
+
+    let received = read_one(&mut sub_rx, 500).await;
+    assert!(
+        received.is_none(),
+        "bus must not publish bus.undeliverable when the undeliverable target is itself a diagnostics.* topic"
+    );
 
     let _ = std::fs::remove_file(&socket);
 }

--- a/tests/workflow_transitions.rs
+++ b/tests/workflow_transitions.rs
@@ -19,23 +19,11 @@ use tokio::net::UnixStream;
 use deskd::ports::bus::MessageBus;
 
 fn temp_socket() -> String {
-    format!(
-        "/tmp/deskd-test-wf-{}.sock",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    )
+    format!("/tmp/deskd-test-wf-{}.sock", uuid::Uuid::new_v4())
 }
 
 fn temp_dir() -> std::path::PathBuf {
-    std::path::PathBuf::from(format!(
-        "/tmp/deskd-test-wf-dir-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+    std::path::PathBuf::from(format!("/tmp/deskd-test-wf-dir-{}", uuid::Uuid::new_v4()))
 }
 
 async fn connect_and_register(


### PR DESCRIPTION
Closes the last bullet on #426. Converts the bus's own undeliverable warning at \`src/infra/bus_server.rs:117\` to a structured \`diagnostics.warn\` event so monitors and memory agents see undeliverable messages on the same stream as every other operationally-meaningful diag.

## Background

PR #433 explicitly deferred this site:

> \`bus_server.rs:117\` (\"no subscriber for target\") is the bus core's own delivery warning. Publishing a diag event from there would route back through the same delivery path and cause recursive logging when the diagnostics topic itself has no subscriber. Better surfaced via a metric or kept as a plain log.

The fix is a target-prefix guard: skip the diag publish whenever the undeliverable target starts with \`diagnostics.\`. The tracing line still fires, the diag event is suppressed, and the loop is broken.

## Implementation

- \`BusState\` gains \`socket_path: Option<String>\` so the router can connect back to its own socket from the fire-and-forget \`diag::warn_event\` task.
- \`BusState::with_socket(socket_path)\` is the production constructor used by \`serve()\`. \`BusState::for_test()\` (\`cfg(test)\` only) is what the in-file unit tests use — they don't need a real socket.
- The line-117 default-fallthrough path now publishes a \`bus.undeliverable\` event with \`details: { target, source }\` — guarded by \`!target.starts_with(\"diagnostics.\")\`.

## Tests

\`tests/diag_publish.rs\`:

1. **\`bus_undeliverable_publishes_diag_event\`** — sends a message to an unmatched target, asserts a \`diagnostics.warn\` subscriber receives the \`bus.undeliverable\` event with the original target + source in \`details\`.
2. **\`bus_undeliverable_does_not_recurse_on_diagnostics_target\`** — sends to \`diagnostics.error\` with no subscriber, watches \`diagnostics.warn\`, asserts nothing is published (recursion guard works).

Also: replaces \`SystemTime::now().as_nanos()\` in \`temp_socket()\` with \`uuid::Uuid::new_v4()\`, matching the fix Konstantin requested on PR #434. Same parallel-test collision risk applied here.

## Out of scope

The \`agent:\` and \`queue:\` undeliverable paths are left as-is.

- The \`agent:\` path may still deliver to glob subscribers after its \"no such agent on bus\" warn fires (lines 64–73), so calling that case \`bus.undeliverable\` would be misleading.
- The \`queue:\` path silently drops with no existing warn to convert.

Both are existing behaviours outside this issue's scope; could be follow-ups if Konstantin wants them surfaced too.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --all-targets --tests -- -D warnings\` clean
- [x] \`cargo test\` — 586 tests pass (581 lib + 5 in diag_publish.rs, 2 of which are new)
- [x] Recursion-guard test verified to fail without the \`!target.starts_with(\"diagnostics.\")\` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)