### PR TITLE
feat(#426): convert config_watcher + schedule WARN sites to diag

### DIFF
--- a/src/app/config_watcher.rs
+++ b/src/app/config_watcher.rs
@@ -4,7 +4,7 @@
 /// Polls the agent's deskd.yaml file for system_prompt changes. When detected,
 /// updates the stored agent state and sends a bus message with the new prompt
 /// content so the worker injects it into the existing session (no restart).
-use tracing::{info, warn};
+use tracing::info;
 
 /// Watch a config file for system_prompt changes and inject updates.
 ///
@@ -16,7 +16,16 @@ pub async fn watch_system_prompt(config_path: String, bus_socket: String, agent_
     let mut last_prompt = match crate::config::UserConfig::load(&config_path) {
         Ok(cfg) => cfg.system_prompt,
         Err(e) => {
-            warn!(agent = %agent_name, error = %e, "config_watcher: failed to load initial config");
+            crate::infra::diag::warn_event(
+                Some(&bus_socket),
+                "config_watcher",
+                "config.load_failed",
+                format!(
+                    "failed to load initial config for agent {}: {}",
+                    agent_name, e
+                ),
+                serde_json::json!({"agent": agent_name, "config_path": config_path}),
+            );
             String::new()
         }
     };
@@ -61,12 +70,27 @@ pub async fn watch_system_prompt(config_path: String, bus_socket: String, agent_
             Ok(mut state) => {
                 state.config.system_prompt = cfg.system_prompt.clone();
                 if let Err(e) = crate::app::agent::save_state_pub(&state) {
-                    warn!(agent = %agent_name, error = %e, "config_watcher: failed to save updated state");
+                    crate::infra::diag::warn_event(
+                        Some(&bus_socket),
+                        "config_watcher",
+                        "config.state_save_failed",
+                        format!(
+                            "failed to save updated state for agent {}: {}",
+                            agent_name, e
+                        ),
+                        serde_json::json!({"agent": agent_name}),
+                    );
                     continue;
                 }
             }
             Err(e) => {
-                warn!(agent = %agent_name, error = %e, "config_watcher: failed to load agent state");
+                crate::infra::diag::warn_event(
+                    Some(&bus_socket),
+                    "config_watcher",
+                    "config.state_load_failed",
+                    format!("failed to load agent state for {}: {}", agent_name, e),
+                    serde_json::json!({"agent": agent_name}),
+                );
                 continue;
             }
         }
@@ -81,7 +105,16 @@ pub async fn watch_system_prompt(config_path: String, bus_socket: String, agent_
         if let Err(e) =
             crate::app::bus::send_message(&bus_socket, "config-watcher", &target, &task).await
         {
-            warn!(agent = %agent_name, error = %e, "config_watcher: failed to send prompt update message");
+            crate::infra::diag::warn_event(
+                Some(&bus_socket),
+                "config_watcher",
+                "transport.bus_send_failed",
+                format!(
+                    "failed to send prompt update message to agent {}: {}",
+                    agent_name, e
+                ),
+                serde_json::json!({"agent": agent_name, "target": target}),
+            );
             continue;
         }
 

--- a/src/app/schedule.rs
+++ b/src/app/schedule.rs
@@ -101,7 +101,16 @@ pub async fn watch_and_reload(
                 info!(agent = %agent_name, added, removed, "schedules reloaded");
             }
             Err(e) => {
-                warn!(agent = %agent_name, error = %e, "failed to reload config, schedules stopped");
+                crate::infra::diag::warn_event(
+                    Some(&bus_socket),
+                    "schedule_watcher",
+                    "config.reload_failed",
+                    format!(
+                        "failed to reload config for agent {}, schedules stopped: {}",
+                        agent_name, e
+                    ),
+                    serde_json::json!({"agent": agent_name, "config_path": config_path}),
+                );
             }
         }
     }
@@ -115,7 +124,16 @@ async fn run_schedule(def: ScheduleDef, bus_socket: String, agent_name: String, 
     let schedule = match Schedule::from_str(&def.cron) {
         Ok(s) => s,
         Err(e) => {
-            warn!(agent = %agent_name, cron = %def.cron, error = %e, "invalid cron expression, schedule skipped");
+            crate::infra::diag::warn_event(
+                Some(&bus_socket),
+                "schedule",
+                "config.invalid",
+                format!(
+                    "invalid cron expression {:?}, schedule skipped: {}",
+                    def.cron, e
+                ),
+                serde_json::json!({"agent": agent_name, "cron": def.cron, "target": def.target}),
+            );
             return;
         }
     };
@@ -231,7 +249,16 @@ async fn fire_github_poll(
     let cfg = match &def.config {
         Some(c) => c,
         None => {
-            warn!(agent = %agent_name, "github_poll schedule has no config, skipping");
+            crate::infra::diag::warn_event(
+                Some(bus_socket),
+                "github_poll",
+                "config.invalid",
+                format!(
+                    "github_poll schedule for agent {} has no config, skipping",
+                    agent_name
+                ),
+                serde_json::json!({"agent": agent_name, "target": def.target}),
+            );
             return Ok(());
         }
     };
@@ -494,7 +521,16 @@ async fn poll_issues(
         )
         .await
         {
-            warn!(error = %e, "failed to post github issue to bus");
+            crate::infra::diag::warn_event(
+                Some(bus_socket),
+                "github_poll",
+                "transport.bus_post_failed",
+                format!(
+                    "failed to post github issue {}#{} to bus: {}",
+                    repo, number, e
+                ),
+                serde_json::json!({"agent": agent_name, "repo": repo, "issue": number, "target": target}),
+            );
         }
         count += 1;
     }
@@ -587,7 +623,16 @@ async fn poll_issue_comments(
         )
         .await
         {
-            warn!(error = %e, "failed to post github comment to bus");
+            crate::infra::diag::warn_event(
+                Some(bus_socket),
+                "github_poll",
+                "transport.bus_post_failed",
+                format!(
+                    "failed to post github comment on {}#{} to bus: {}",
+                    repo, issue_number, e
+                ),
+                serde_json::json!({"agent": agent_name, "repo": repo, "issue": issue_number, "target": target, "kind": "comment"}),
+            );
         }
         count += 1;
     }
@@ -686,7 +731,13 @@ async fn poll_pull_requests(
         )
         .await
         {
-            warn!(error = %e, "failed to post github PR to bus");
+            crate::infra::diag::warn_event(
+                Some(bus_socket),
+                "github_poll",
+                "transport.bus_post_failed",
+                format!("failed to post github PR {}#{} to bus: {}", repo, number, e),
+                serde_json::json!({"agent": agent_name, "repo": repo, "pr": number, "target": target}),
+            );
         }
         count += 1;
     }


### PR DESCRIPTION
Continues the call-site sweep for #426. Converts remaining operationally-meaningful WARN sites that the issue lists explicitly under \"config reload\" and \"GitHub poller\" to structured \`diagnostics.warn\` events.

After this lands, the only acceptance-criteria items still open are MCP-server adapter errors (no MCP-server WARN sites currently exist that would need conversion) and any I missed — happy to do another pass if Konstantin sees more.

## Sites converted

\`src/app/config_watcher.rs\`:
- load initial config failure → \`config.load_failed\`
- save updated state failure → \`config.state_save_failed\`
- load agent state failure → \`config.state_load_failed\`
- send prompt update bus failure → \`transport.bus_send_failed\`

\`src/app/schedule.rs\`:
- \`watch_and_reload\` reload failure → \`config.reload_failed\` (source=\`schedule_watcher\`)
- \`run_schedule\` invalid cron → \`config.invalid\` (source=\`schedule\`)
- \`fire_github_poll\` missing config → \`config.invalid\` (source=\`github_poll\`)
- \`poll_issues\` bus post failure → \`transport.bus_post_failed\` (source=\`github_poll\`)
- \`poll_issue_comments\` bus post failure → \`transport.bus_post_failed\` (source=\`github_poll\`)
- \`poll_pull_requests\` bus post failure → \`transport.bus_post_failed\` (source=\`github_poll\`)

Source-scoped naming so subscribers can route by component (e.g. \`source=github_poll AND kind=transport.bus_post_failed\` separates GitHub poll outage from generic bus delivery elsewhere).

## Behavior

- Existing \`tracing::warn!\` semantics preserved — diag's internal log emission still fires at WARN level.
- Best-effort publishing — bus offline doesn't block the underlying flow.
- \`details\` payloads carry the structured fields (agent, repo, issue/pr number, target) for filtered subscriptions.

## Out of scope

- File-IO failures inside since-state persistence and unified-inbox writes — local recoverable IOs that already log appropriately and would add noise to the diagnostics stream.
- Reminder runner WARN sites — separate flow, not in this issue's acceptance criteria.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --all-targets --tests -- -D warnings\` clean
- [x] \`cargo test\` — 586 tests pass (full suite)

Per #433/#434 precedent, mechanical call-site conversions don't add per-site tests. The publish mechanism is already covered end-to-end by \`tests/diag_publish.rs\` (5 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)