### PR TITLE
feat(#155): agent_tasks MCP tool — task history per agent

### DIFF
--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -610,6 +610,32 @@ fn handle_tools_list(
         }
     }));
     tools.push(json!({
+        "name": "agent_tasks",
+        "description": "Read recent task log entries (one per completed task) for an agent. Returns structured records with status (ok/error/skip/empty), source (telegram, github_poll, agent:<name>, ...), turns, cost, duration_ms, and error. Useful for seeing whether a sub-agent processed a message and what happened. Access mirrors agent_logs: caller may read its own history or a sub-agent's.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Agent name"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of recent entries to return (1..=200, default 20)"
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Filter to entries from a specific source channel (e.g. 'telegram', 'github_poll', 'cli')"
+                },
+                "since": {
+                    "type": "string",
+                    "description": "RFC3339 timestamp; only return entries newer than this"
+                }
+            },
+            "required": ["name"]
+        }
+    }));
+    tools.push(json!({
         "name": "bus_status",
         "description": "Snapshot of bus connectivity for diagnostics. Reports internal bus state (running, sub-agents with alive flag) and host bus (clients currently connected). Sub-agent visibility scoped to caller's children.",
         "inputSchema": {
@@ -817,6 +843,7 @@ async fn handle_tools_call(
         "list_agents" => mcp_tools::call_list_agents(agent_name, internal_bus).await,
         "remove_agent" => mcp_tools::call_remove_agent(args, agent_name, internal_bus).await,
         "agent_logs" => mcp_tools::call_agent_logs(args, agent_name).await,
+        "agent_tasks" => mcp_tools::call_agent_tasks(args, agent_name).await,
         "bus_status" => mcp_tools::call_bus_status(agent_name, bus_socket, internal_bus).await,
         "get_scope" => mcp_tools::call_get_scope(agent_name, user_config, internal_bus).await,
         "sm_create" => {

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -1269,6 +1269,65 @@ pub(crate) async fn call_agent_logs(args: &Value, caller: &str) -> Result<Value>
     }))
 }
 
+/// Read recent task log entries (one per completed task) for an agent. Reads
+/// the structured JSONL written by the worker on every task completion, with
+/// `ts`, `source`, `task`, `status`, `turns`, `cost`, `duration_ms`, and
+/// `error` fields. Access mirrors `agent_logs`: caller may read its own
+/// history or a sub-agent's.
+pub(crate) async fn call_agent_tasks(args: &Value, caller: &str) -> Result<Value> {
+    let name = args
+        .get("name")
+        .and_then(|v| v.as_str())
+        .context("agent_tasks: missing required 'name'")?;
+
+    let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
+    if limit == 0 || limit > 200 {
+        bail!("agent_tasks: 'limit' must be in 1..=200 (got {})", limit);
+    }
+
+    let source_filter = args.get("source").and_then(|v| v.as_str());
+
+    let since = match args.get("since").and_then(|v| v.as_str()) {
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .with_context(|| format!("agent_tasks: 'since' must be RFC3339 (got {:?})", s))?
+                .with_timezone(&chrono::Utc),
+        ),
+        None => None,
+    };
+
+    // Access control: caller may read its own task log or its sub-agents'.
+    if name != caller {
+        let state = crate::app::agent::load_state(name)
+            .with_context(|| format!("agent '{}' not found", name))?;
+        match &state.parent {
+            Some(p) if p == caller => {}
+            _ => bail!(
+                "agent '{}' is not a sub-agent of '{}' — task history access denied",
+                name,
+                caller
+            ),
+        }
+    }
+
+    let path = crate::app::tasklog::log_path(name);
+    let entries = crate::app::tasklog::read_logs_from_path(&path, limit, source_filter, since)?;
+
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&json!({
+                "name": name,
+                "path": path.display().to_string(),
+                "exists": path.exists(),
+                "returned": entries.len(),
+                "tasks": entries,
+            }))?
+        }],
+        "isError": false
+    }))
+}
+
 pub(crate) async fn call_remove_agent(
     args: &Value,
     caller: &str,
@@ -1968,6 +2027,145 @@ mod tests {
         assert_eq!(parsed["exists"], false);
         assert_eq!(parsed["source"], "stderr");
         assert!(parsed["lines"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn agent_tasks_rejects_missing_name() {
+        let err = call_agent_tasks(&json!({}), "caller").await.unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("name"), "expected name error, got: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn agent_tasks_rejects_bad_limit() {
+        for bad in [0u64, 500] {
+            let err = call_agent_tasks(&json!({"name": "x", "limit": bad}), "x")
+                .await
+                .unwrap_err();
+            let msg = format!("{:#}", err);
+            assert!(msg.contains("limit"), "expected limit error, got: {}", msg);
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_tasks_rejects_bad_since() {
+        let err = call_agent_tasks(&json!({"name": "x", "since": "yesterday"}), "x")
+            .await
+            .unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("since"), "expected since error, got: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn agent_tasks_self_read_nonexistent_returns_exists_false() {
+        let unique = format!("__agent_tasks_test_{}", Uuid::new_v4());
+        let resp = call_agent_tasks(&json!({"name": unique, "limit": 10}), &unique)
+            .await
+            .expect("self-read must not error on missing file");
+        let text = resp["content"][0]["text"].as_str().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["exists"], false);
+        assert_eq!(parsed["returned"], 0);
+        assert!(parsed["tasks"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn agent_tasks_returns_filtered_entries_from_log() {
+        // Write a synthetic tasks.jsonl into a temporary HOME, then call
+        // call_agent_tasks against it and verify filtering + ordering.
+        let env_guard = crate::test_support::env_lock().lock().await;
+        let tmp =
+            std::path::PathBuf::from(format!("/tmp/deskd-test-agent-tasks-{}", Uuid::new_v4()));
+        // SAFETY: ENV_LOCK serializes env-mutating tests workspace-wide.
+        unsafe { std::env::set_var("HOME", &tmp) };
+
+        let agent = "history-agent";
+        let log = crate::app::tasklog::log_path(agent);
+        let entries = vec![
+            crate::app::tasklog::TaskLog {
+                ts: "2026-05-01T10:00:00Z".into(),
+                source: "telegram".into(),
+                turns: 3,
+                cost: 0.05,
+                duration_ms: 1500,
+                status: "ok".into(),
+                task: "first".into(),
+                error: None,
+                msg_id: "m1".into(),
+                github_repo: None,
+                github_pr: None,
+                input_tokens: None,
+                output_tokens: None,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+                session_count: None,
+                tool_use_count: None,
+                parent_agent: None,
+            },
+            crate::app::tasklog::TaskLog {
+                ts: "2026-05-02T10:00:00Z".into(),
+                source: "github_poll".into(),
+                turns: 5,
+                cost: 0.10,
+                duration_ms: 4000,
+                status: "error".into(),
+                task: "second".into(),
+                error: Some("boom".into()),
+                msg_id: "m2".into(),
+                github_repo: Some("owner/repo".into()),
+                github_pr: None,
+                input_tokens: None,
+                output_tokens: None,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+                session_count: None,
+                tool_use_count: None,
+                parent_agent: None,
+            },
+        ];
+        for e in &entries {
+            crate::app::tasklog::log_task_to_path(&log, e).unwrap();
+        }
+
+        // No filters → both entries returned, oldest-first preserved.
+        let resp = call_agent_tasks(&json!({"name": agent, "limit": 10}), agent)
+            .await
+            .expect("self-read must succeed");
+        let text = resp["content"][0]["text"].as_str().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["exists"], true);
+        assert_eq!(parsed["returned"], 2);
+        let tasks = parsed["tasks"].as_array().unwrap();
+        assert_eq!(tasks[0]["msg_id"], "m1");
+        assert_eq!(tasks[1]["msg_id"], "m2");
+        assert_eq!(tasks[1]["error"], "boom");
+
+        // Source filter narrows to one entry.
+        let resp = call_agent_tasks(
+            &json!({"name": agent, "limit": 10, "source": "github_poll"}),
+            agent,
+        )
+        .await
+        .expect("filtered self-read must succeed");
+        let text = resp["content"][0]["text"].as_str().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["returned"], 1);
+        assert_eq!(parsed["tasks"][0]["source"], "github_poll");
+
+        // since filter excludes older entries.
+        let resp = call_agent_tasks(
+            &json!({"name": agent, "limit": 10, "since": "2026-05-02T00:00:00Z"}),
+            agent,
+        )
+        .await
+        .expect("since-filtered self-read must succeed");
+        let text = resp["content"][0]["text"].as_str().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["returned"], 1);
+        assert_eq!(parsed["tasks"][0]["msg_id"], "m2");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+        drop(env_guard);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes the **P2 \"Sub-agent task history\"** item from #155. The data is already there — every completed task gets one JSON line in \`~/.deskd/logs/{agent}/tasks.jsonl\` via the existing \`tasklog\` module — but until now there was no MCP-level surface to read it. Callers had to scrape inboxes to guess whether a sub-agent processed a message, with zero visibility into status, duration, cost, or errors.

## Tool

\`agent_tasks(name, limit?, source?, since?)\` returns recent task log entries with the structured fields the worker already records:

- \`ts\`, \`source\`, \`task\`
- \`status\` — \`ok\` / \`error\` / \`skip\` / \`empty\`
- \`turns\`, \`cost\`, \`duration_ms\`
- \`error\` (optional, populated when status=error)
- \`msg_id\`, \`github_repo\`, \`github_pr\`, token counts, ...

### Args

| Arg | Type | Default | Description |
|---|---|---|---|
| \`name\` | string (required) | — | Agent to query |
| \`limit\` | integer | 20 (max 200) | Max recent entries |
| \`source\` | string | — | Filter to one source channel (\`github_poll\`, \`telegram\`, \`agent:foo\`, \`cli\`, ...) |
| \`since\` | RFC3339 string | — | Only entries newer than this |

### Access control

Mirrors \`agent_logs\`: callers may read their own task history or that of their direct sub-agents, but not siblings'.

## Implementation

Thin wrapper over the existing \`tasklog::read_logs_from_path\`, which already handles file-missing (returns \`[]\`), source filtering, and time filtering. No new domain logic — purely a surface to expose data the worker is already writing on every task completion.

## Tests (5 new)

- rejects missing \`name\`
- rejects out-of-range \`limit\` (0 and >200)
- rejects malformed \`since\` timestamp
- self-read with no log file returns \`exists: false\` + empty array
- writes synthetic entries through \`tasklog::log_task_to_path\` and asserts unfiltered, source-filtered, and since-filtered reads all return the right rows in the right order

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --all-targets --tests -- -D warnings\` clean
- [x] \`cargo test\` — 591 lib tests + 7 integration suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)