### PR TITLE
feat(#426): convert MCP server request-loop sites to diag

### DIFF
--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use std::sync::Arc;
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::Mutex;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::app::mcp_protocol::{
     Request, Response, connect_bus_listener, emit_channel_notification, handle_initialize,
@@ -68,7 +68,13 @@ pub async fn run(agent_name: &str) -> Result<()> {
                     Ok(Some(l)) => l,
                     Ok(None) => break, // stdin closed
                     Err(e) => {
-                        warn!(error = %e, "failed to read line");
+                        crate::infra::diag::warn_event(
+                            Some(&bus_socket),
+                            &format!("mcp-server-{}", agent_name),
+                            "transport.read_failed",
+                            format!("MCP server failed to read line from stdin: {}", e),
+                            serde_json::json!({"agent": agent_name}),
+                        );
                         break;
                     }
                 };
@@ -88,7 +94,16 @@ pub async fn run(agent_name: &str) -> Result<()> {
                 let req: Request = match serde_json::from_str(trimmed) {
                     Ok(r) => r,
                     Err(e) => {
-                        warn!(error = %e, line = %trimmed, "failed to parse JSON-RPC request");
+                        crate::infra::diag::warn_event(
+                            Some(&bus_socket),
+                            &format!("mcp-server-{}", agent_name),
+                            "transport.invalid_message",
+                            format!("MCP server failed to parse JSON-RPC request: {}", e),
+                            serde_json::json!({
+                                "agent": agent_name,
+                                "line_preview": trimmed.chars().take(200).collect::<String>(),
+                            }),
+                        );
                         let resp = Response::err(None, -32700, "Parse error");
                         let mut out = stdout.lock().await;
                         write_response(&mut *out, &resp).await?;
@@ -133,11 +148,23 @@ pub async fn run(agent_name: &str) -> Result<()> {
                         }
                     }
                     Ok(None) => {
-                        warn!("bus connection closed — channel notifications disabled");
+                        crate::infra::diag::warn_event(
+                            Some(&bus_socket),
+                            &format!("mcp-server-{}", agent_name),
+                            "transport.bus_disconnected",
+                            "bus connection closed — channel notifications disabled".to_string(),
+                            serde_json::json!({"agent": agent_name}),
+                        );
                         bus_rx = None;
                     }
                     Err(e) => {
-                        warn!(error = %e, "bus read error");
+                        crate::infra::diag::warn_event(
+                            Some(&bus_socket),
+                            &format!("mcp-server-{}", agent_name),
+                            "transport.bus_read_failed",
+                            format!("MCP server bus read error: {}", e),
+                            serde_json::json!({"agent": agent_name}),
+                        );
                     }
                     _ => {} // empty line, skip
                 }


### PR DESCRIPTION
Closes the **\"MCP servers\"** arm of #426's acceptance criteria. The deskd MCP server's stdin/bus request loop in \`src/app/mcp.rs\` now publishes structured \`diagnostics.warn\` events for transport-layer failures instead of emitting log-only WARN lines that no monitor or doctor agent could see.

## Sites converted

| Site | kind |
|---|---|
| stdin read failure (loop break) | \`transport.read_failed\` |
| JSON-RPC parse failure (per-request) | \`transport.invalid_message\` |
| bus connection closed (\`Ok(None)\`) | \`transport.bus_disconnected\` |
| bus read error (\`Err\`) | \`transport.bus_read_failed\` |

**Source naming:** \`mcp-server-{agent}\` — so subscribers can attribute MCP transport failures to the specific agent's MCP entry point (Claude worker spawned with \`--mcp-config\` pointing at deskd-mcp).

## Out of scope (intentional)

- \`apply_a2a_auth\` JWT signing/loading log lines (\`mcp_tools.rs:1546, 1550\`): the function is a sync helper that doesn't take \`bus_socket\`, and the call chain \`call_a2a_send\` doesn't either. Plumbing the bus socket through requires touching the MCP dispatch signature. The user-facing failure already bubbles via \`bail!\` to the MCP response, so external visibility is preserved through that path.
- \`connect_bus_listener\` setup failures (\`mcp_protocol.rs:106/126/130\`): these fire when the bus connection is the thing that's failing, so a diag publish would also fail. Best-effort fallback would just log via tracing — same behavior as today.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --all-targets --tests -- -D warnings\` clean
- [x] \`cargo test\` — 586 lib + 7 integration suites green

Per #433/#434/#436/#438 precedent, mechanical call-site conversions don't add per-site tests; the publish mechanism is covered end-to-end by \`tests/diag_publish.rs\`.

## Coverage status for #426

After this lands, every acceptance-criteria call-site bullet is covered (separate comment on #426 itself with the audit). I'll propose closure there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)