### PR TITLE
feat(#455): recurring reminders (interval / cron_expression)

### DIFF
--- a/src/app/commands/remind.rs
+++ b/src/app/commands/remind.rs
@@ -30,6 +30,8 @@ pub fn handle(
         at: fire_at.to_rfc3339(),
         target: target.clone(),
         message,
+        interval: None,
+        cron_expression: None,
     };
 
     let dir = config::reminders_dir();

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -385,7 +385,7 @@ fn handle_tools_list(
 
     tools.push(json!({
         "name": "create_reminder",
-        "description": "Schedule a one-shot reminder. Specify time with 'at' (datetime/time string), 'in' (duration like 30m/1h/2h30m), or 'delay_minutes' (number). Exactly one time param required.",
+        "description": "Schedule a reminder (one-shot or recurring). One-shot: specify the time with 'at', 'in', or 'delay_minutes'. Recurring: pass 'interval' (e.g. \"30m\") or 'cron_expression' (5-field UTC); both are mutually exclusive and have a 1-minute minimum tick. Recurring reminders survive deskd restart and re-arm themselves after each fire — use 'cancel_reminder' to stop the loop.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -408,6 +408,14 @@ fn handle_tools_list(
                 "delay_minutes": {
                     "type": "number",
                     "description": "Minutes from now (legacy, prefer 'at' or 'in')"
+                },
+                "interval": {
+                    "type": "string",
+                    "description": "Recurring interval (e.g. \"30m\", \"2h\", \"1d\"). Minimum 1m. Mutually exclusive with cron_expression."
+                },
+                "cron_expression": {
+                    "type": "string",
+                    "description": "5-field UTC cron expression (minute hour day month weekday). Minimum tick 1 minute. Mutually exclusive with interval."
                 }
             },
             "required": ["target", "message"]

--- a/src/app/mcp_service.rs
+++ b/src/app/mcp_service.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use tracing::info;
 
 use crate::app::statemachine;
@@ -21,11 +22,122 @@ use crate::ports::store::{StateMachineRepository, TaskRepository};
 
 // ─── Reminder ────────────────────────────────────────────────────────────────
 
+/// How a reminder reschedules itself after firing.
+///
+/// `OneShot` preserves legacy behaviour — the reminder is deleted after fire.
+/// `Interval` and `Cron` re-arm the reminder; the source string lives on the
+/// `RemindDef` row so deskd-restart re-parses it.
+#[derive(Debug, Clone)]
+pub enum ScheduleKind {
+    OneShot,
+    Interval(std::time::Duration),
+    Cron(Box<cron::Schedule>),
+}
+
+impl ScheduleKind {
+    /// Stable label used in MCP `list_reminders` output.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ScheduleKind::OneShot => "one_shot",
+            ScheduleKind::Interval(_) => "interval",
+            ScheduleKind::Cron(_) => "cron",
+        }
+    }
+
+    /// Compute the next fire time strictly after `now` for a recurring kind.
+    /// `OneShot` returns `None` — callers delete the reminder instead.
+    ///
+    /// For `Interval`, jumps forward by whole intervals from `last_fire` so
+    /// missed firings collapse to one ("fire-once-and-move-on" restart-storm
+    /// policy from #455).
+    pub fn next_after(
+        &self,
+        last_fire: chrono::DateTime<chrono::Utc>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Option<chrono::DateTime<chrono::Utc>> {
+        match self {
+            ScheduleKind::OneShot => None,
+            ScheduleKind::Interval(dur) => {
+                let interval = chrono::Duration::from_std(*dur).ok()?;
+                if interval <= chrono::Duration::zero() {
+                    return None;
+                }
+                let mut next = last_fire + interval;
+                if next <= now {
+                    // Collapse missed firings to a single re-arm.
+                    let elapsed = (now - last_fire).num_milliseconds().max(0);
+                    let step = interval.num_milliseconds().max(1);
+                    let skips = (elapsed / step) + 1;
+                    next = last_fire + chrono::Duration::milliseconds(skips * step);
+                }
+                Some(next)
+            }
+            ScheduleKind::Cron(schedule) => {
+                // cron::Schedule::after returns the next occurrences strictly
+                // after the given anchor. We want strictly after `now` so a
+                // deskd restart that lost time still re-arms to the future.
+                schedule.after(&now).next()
+            }
+        }
+    }
+}
+
+/// Parse the optional recurring fields on a reminder into a `ScheduleKind`,
+/// returning an MCP-shaped error if validation fails (#455).
+///
+/// Rules:
+/// - `interval` and `cron_expression` are mutually exclusive.
+/// - `interval` parses via the shared duration parser; must be >= 60 seconds.
+/// - `cron_expression` must be 5-field; 6-field (with seconds) is rejected.
+pub fn parse_schedule_kind(
+    interval: Option<&str>,
+    cron_expression: Option<&str>,
+) -> Result<ScheduleKind> {
+    match (interval, cron_expression) {
+        (Some(_), Some(_)) => {
+            bail!("interval and cron_expression are mutually exclusive — pass only one")
+        }
+        (Some(s), None) => {
+            let secs = crate::app::commands::parse_duration_secs(s)
+                .with_context(|| format!("invalid interval: {:?}", s))?;
+            if secs < 60 {
+                bail!(
+                    "interval must be >= 1m (got {:?} = {}s); deskd does not support sub-minute reminders",
+                    s,
+                    secs
+                );
+            }
+            Ok(ScheduleKind::Interval(std::time::Duration::from_secs(secs)))
+        }
+        (None, Some(expr)) => {
+            // Reject 6-field cron (includes seconds). Field count is counted
+            // by whitespace-separated tokens.
+            let fields = expr.split_whitespace().count();
+            if fields != 5 {
+                bail!(
+                    "cron_expression must be 5 fields (minute hour day month weekday), got {} field(s) in {:?}",
+                    fields,
+                    expr
+                );
+            }
+            // The `cron` crate expects a leading seconds field. Prepend "0"
+            // so we keep cron's minute-floor semantics.
+            let normalized = format!("0 {}", expr);
+            let schedule = cron::Schedule::from_str(&normalized)
+                .with_context(|| format!("invalid cron_expression {:?}", expr))?;
+            Ok(ScheduleKind::Cron(Box::new(schedule)))
+        }
+        (None, None) => Ok(ScheduleKind::OneShot),
+    }
+}
+
 /// Result of creating a reminder.
+#[derive(Debug)]
 pub struct ReminderCreated {
     pub target: String,
     pub fire_at: String,
     pub delay_minutes: f64,
+    pub schedule_kind: &'static str,
 }
 
 /// Create a one-shot reminder persisted to disk.
@@ -41,13 +153,49 @@ pub fn create_reminder_at(
     message: &str,
     fire_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<ReminderCreated> {
+    create_reminder_full(target, message, Some(fire_at), None, None)
+}
+
+/// Create a reminder with optional recurring schedule.
+///
+/// When `interval` or `cron_expression` is set, the reminder reschedules
+/// itself after each fire. If `fire_at` is `None` and a recurring kind is
+/// supplied, the first fire time is computed from "now":
+///   - `interval` → `now + interval`
+///   - `cron_expression` → next cron occurrence after now
+///
+/// `interval` and `cron_expression` are mutually exclusive (validated by
+/// `parse_schedule_kind`).
+pub fn create_reminder_full(
+    target: &str,
+    message: &str,
+    fire_at: Option<chrono::DateTime<chrono::Utc>>,
+    interval: Option<&str>,
+    cron_expression: Option<&str>,
+) -> Result<ReminderCreated> {
+    let kind = parse_schedule_kind(interval, cron_expression)?;
     let now = chrono::Utc::now();
-    let delay_minutes = (fire_at - now).num_seconds() as f64 / 60.0;
+    let resolved_fire_at = match (fire_at, &kind) {
+        (Some(t), _) => t,
+        (None, ScheduleKind::OneShot) => {
+            bail!("create_reminder requires a fire time (at/in/delay_minutes) when not recurring")
+        }
+        (None, ScheduleKind::Interval(d)) => {
+            now + chrono::Duration::from_std(*d).unwrap_or(chrono::Duration::zero())
+        }
+        (None, ScheduleKind::Cron(schedule)) => schedule.after(&now).next().ok_or_else(|| {
+            anyhow::anyhow!("cron_expression has no upcoming occurrences after now")
+        })?,
+    };
+
+    let delay_minutes = (resolved_fire_at - now).num_seconds() as f64 / 60.0;
 
     let remind = crate::config::RemindDef {
-        at: fire_at.to_rfc3339(),
+        at: resolved_fire_at.to_rfc3339(),
         target: target.to_string(),
         message: message.to_string(),
+        interval: interval.map(|s| s.to_string()),
+        cron_expression: cron_expression.map(|s| s.to_string()),
     };
 
     let dir = crate::config::reminders_dir();
@@ -58,12 +206,13 @@ pub fn create_reminder_at(
     std::fs::write(&path, json)
         .with_context(|| format!("failed to write reminder file: {}", path.display()))?;
 
-    info!(target = %target, at = %fire_at, "create_reminder");
+    info!(target = %target, at = %resolved_fire_at, kind = kind.label(), "create_reminder");
 
     Ok(ReminderCreated {
         target: target.to_string(),
-        fire_at: fire_at.to_rfc3339(),
+        fire_at: resolved_fire_at.to_rfc3339(),
         delay_minutes,
+        schedule_kind: kind.label(),
     })
 }
 
@@ -164,11 +313,22 @@ pub fn list_reminders(
     Ok(filtered
         .take(limit)
         .map(|r| {
+            let kind_label = match parse_schedule_kind(
+                r.def.interval.as_deref(),
+                r.def.cron_expression.as_deref(),
+            ) {
+                Ok(k) => k.label(),
+                Err(_) => "one_shot",
+            };
             json!({
                 "id": r.id,
                 "at": r.def.at,
+                "next_fire_at": r.def.at,
                 "target": r.def.target,
                 "message_preview": message_preview(&r.def.message, 120),
+                "schedule_kind": kind_label,
+                "interval": r.def.interval,
+                "cron_expression": r.def.cron_expression,
             })
         })
         .collect())
@@ -201,11 +361,20 @@ pub fn get_reminder(id: &str) -> Result<Value> {
         std::fs::read_to_string(&path).with_context(|| format!("reminder not found: {}", id))?;
     let def: crate::config::RemindDef =
         serde_json::from_str(&content).context("failed to parse reminder file")?;
+    let kind_label =
+        match parse_schedule_kind(def.interval.as_deref(), def.cron_expression.as_deref()) {
+            Ok(k) => k.label(),
+            Err(_) => "one_shot",
+        };
     Ok(json!({
         "id": id,
         "at": def.at,
+        "next_fire_at": def.at,
         "target": def.target,
         "message": def.message,
+        "schedule_kind": kind_label,
+        "interval": def.interval,
+        "cron_expression": def.cron_expression,
     }))
 }
 

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -593,35 +593,63 @@ pub(crate) async fn call_create_reminder(args: &Value) -> Result<Value> {
         .and_then(|m| m.as_str())
         .context("missing message")?;
 
-    // Support three time specification modes (exactly one required):
-    // 1. "at" — ISO 8601 timestamp or human-friendly time string
-    // 2. "in" — duration string like "30m", "1h", "2h30m"
-    // 3. "delay_minutes" — legacy numeric minutes (backwards compat)
+    // Time specification modes:
+    //   "at"             — ISO 8601 / human-friendly time string
+    //   "in"             — duration string like "30m"
+    //   "delay_minutes"  — legacy numeric minutes
+    // Recurring modes (#455, mutually exclusive with each other):
+    //   "interval"        — fires every <duration> (min 1m)
+    //   "cron_expression" — 5-field UTC cron, fires per schedule
+    // For recurring reminders the absolute time params (at/in/delay_minutes)
+    // are optional — the first fire defaults to now+interval or the next
+    // cron occurrence.
     let at_str = args.get("at").and_then(|a| a.as_str());
     let in_str = args.get("in").and_then(|i| i.as_str());
     let delay_minutes = args.get("delay_minutes").and_then(|d| d.as_f64());
+    let interval = args.get("interval").and_then(|v| v.as_str());
+    let cron_expression = args.get("cron_expression").and_then(|v| v.as_str());
 
-    let result = if let Some(at) = at_str {
-        let fire_at = parse_at_time(at)?;
-        mcp_service::create_reminder_at(target, message, fire_at)?
+    let fire_at_override: Option<chrono::DateTime<chrono::Utc>> = if let Some(at) = at_str {
+        Some(parse_at_time(at)?)
     } else if let Some(dur) = in_str {
         let secs = crate::app::commands::parse_duration_secs(dur)?;
-        let delay = secs as f64 / 60.0;
-        mcp_service::create_reminder(target, message, delay)?
-    } else if let Some(mins) = delay_minutes {
-        mcp_service::create_reminder(target, message, mins)?
+        Some(chrono::Utc::now() + chrono::Duration::seconds(secs as i64))
     } else {
-        bail!("create_reminder requires one of: 'at', 'in', or 'delay_minutes'");
+        delay_minutes.map(|mins| {
+            chrono::Utc::now() + chrono::Duration::seconds((mins * 60.0).round() as i64)
+        })
+    };
+
+    let is_recurring = interval.is_some() || cron_expression.is_some();
+    if fire_at_override.is_none() && !is_recurring {
+        bail!(
+            "create_reminder requires one of: 'at', 'in', 'delay_minutes', 'interval', or 'cron_expression'"
+        );
+    }
+
+    let result = mcp_service::create_reminder_full(
+        target,
+        message,
+        fire_at_override,
+        interval,
+        cron_expression,
+    )?;
+
+    let recurring_suffix = match (interval, cron_expression) {
+        (Some(i), _) => format!(", recurring every {}", i),
+        (_, Some(c)) => format!(", recurring per cron {:?}", c),
+        _ => String::new(),
     };
 
     Ok(json!({
         "content": [{
             "type": "text",
             "text": format!(
-                "Reminder scheduled: target={} at={} (in {:.0} minutes)",
-                result.target, result.fire_at, result.delay_minutes
+                "Reminder scheduled: target={} at={} (in {:.0} minutes){}",
+                result.target, result.fire_at, result.delay_minutes, recurring_suffix
             )
         }],
+        "schedule_kind": result.schedule_kind,
         "isError": false
     }))
 }

--- a/src/app/schedule.rs
+++ b/src/app/schedule.rs
@@ -856,87 +856,143 @@ async fn fire_shell(
 ///
 /// Each reminder is a JSON file (`RemindDef`) written by `deskd remind` or the
 /// `create_reminder` MCP tool. When the `at` timestamp is <= now, the reminder
-/// is fired (message posted to bus) and the file is deleted.
+/// is fired (message posted to bus). After firing:
+///   - one-shot (`interval`/`cron_expression` both absent) → file deleted
+///   - `interval` → `at` advanced to the next future occurrence; file kept
+///   - `cron_expression` → `at` advanced to the next cron tick; file kept
+///
+/// Restart-storm policy: a recurring reminder whose `at` is in the past (e.g.
+/// deskd was offline for hours) fires ONCE and is then re-armed to the next
+/// future occurrence — never replays all missed ticks. See #455.
 pub async fn run_reminders(bus_socket: String, agent_name: String) {
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        fire_due_reminders(&bus_socket, &agent_name, Utc::now()).await;
+    }
+}
 
-        let dir = crate::config::reminders_dir();
-        let entries = match std::fs::read_dir(&dir) {
-            Ok(e) => e,
+/// Single-pass reminder scan, factored out so tests can drive it with a fixed
+/// "now" without sleeping for 10 seconds.
+pub async fn fire_due_reminders(
+    bus_socket: &str,
+    agent_name: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) {
+    let dir = crate::config::reminders_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            warn!(agent = %agent_name, error = %e, "failed to read reminders dir");
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
             Err(e) => {
-                warn!(agent = %agent_name, error = %e, "failed to read reminders dir");
+                warn!(agent = %agent_name, path = %path.display(), error = %e, "failed to read reminder file");
                 continue;
             }
         };
 
-        let now = Utc::now();
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+        let reminder: crate::config::RemindDef = match serde_json::from_str(&content) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(agent = %agent_name, path = %path.display(), error = %e, "failed to parse reminder file");
                 continue;
             }
+        };
 
-            let content = match std::fs::read_to_string(&path) {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!(agent = %agent_name, path = %path.display(), error = %e, "failed to read reminder file");
-                    continue;
-                }
-            };
-
-            let reminder: crate::config::RemindDef = match serde_json::from_str(&content) {
-                Ok(r) => r,
-                Err(e) => {
-                    warn!(agent = %agent_name, path = %path.display(), error = %e, "failed to parse reminder file");
-                    continue;
-                }
-            };
-
-            let fire_at = match chrono::DateTime::parse_from_rfc3339(&reminder.at) {
-                Ok(t) => t.with_timezone(&chrono::Utc),
-                Err(e) => {
-                    warn!(agent = %agent_name, path = %path.display(), error = %e, "invalid reminder timestamp");
-                    continue;
-                }
-            };
-
-            if fire_at > now {
-                // Not yet due.
+        let fire_at = match chrono::DateTime::parse_from_rfc3339(&reminder.at) {
+            Ok(t) => t.with_timezone(&chrono::Utc),
+            Err(e) => {
+                warn!(agent = %agent_name, path = %path.display(), error = %e, "invalid reminder timestamp");
                 continue;
             }
+        };
 
-            info!(agent = %agent_name, target = %reminder.target, "firing reminder");
+        if fire_at > now {
+            // Not yet due.
+            continue;
+        }
 
-            // Write to unified inbox
-            let inbox_name = format!("schedule/{}-reminder", agent_name);
-            let inbox_msg = unified_inbox::InboxMessage {
-                ts: chrono::Utc::now(),
-                source: "reminder".to_string(),
-                from: None,
-                text: reminder.message.clone(),
-                metadata: serde_json::json!({
-                    "target": reminder.target,
-                    "scheduled_at": reminder.at,
-                }),
-            };
-            if let Err(e) = unified_inbox::write_message(&inbox_name, &inbox_msg) {
-                warn!(agent = %agent_name, error = %e, "failed to write reminder to unified inbox");
+        info!(agent = %agent_name, target = %reminder.target, "firing reminder");
+
+        // Write to unified inbox
+        let inbox_name = format!("schedule/{}-reminder", agent_name);
+        let inbox_msg = unified_inbox::InboxMessage {
+            ts: chrono::Utc::now(),
+            source: "reminder".to_string(),
+            from: None,
+            text: reminder.message.clone(),
+            metadata: serde_json::json!({
+                "target": reminder.target,
+                "scheduled_at": reminder.at,
+            }),
+        };
+        if let Err(e) = unified_inbox::write_message(&inbox_name, &inbox_msg) {
+            warn!(agent = %agent_name, error = %e, "failed to write reminder to unified inbox");
+        }
+
+        let delivery = post_to_bus(
+            bus_socket,
+            agent_name,
+            &reminder.target,
+            &reminder.message,
+            "reminder",
+        )
+        .await;
+
+        if let Err(e) = delivery {
+            warn!(agent = %agent_name, target = %reminder.target, error = %e, "failed to fire reminder");
+            // Leave the file in place — next tick will retry. For recurring
+            // reminders this also avoids skipping an interval on a transient
+            // bus failure.
+            continue;
+        }
+
+        // Decide what to do with the file: delete (one-shot) or re-arm (recurring).
+        let kind = crate::app::mcp_service::parse_schedule_kind(
+            reminder.interval.as_deref(),
+            reminder.cron_expression.as_deref(),
+        );
+
+        let next = match &kind {
+            Ok(k) => k.next_after(fire_at, now),
+            Err(e) => {
+                warn!(agent = %agent_name, path = %path.display(), error = %e, "invalid recurring reminder fields; treating as one-shot");
+                None
             }
+        };
 
-            if let Err(e) = post_to_bus(
-                &bus_socket,
-                &agent_name,
-                &reminder.target,
-                &reminder.message,
-                "reminder",
-            )
-            .await
-            {
-                warn!(agent = %agent_name, target = %reminder.target, error = %e, "failed to fire reminder");
-            } else {
-                // Delete the file after successful delivery.
+        match next {
+            Some(next_at) => {
+                let mut updated = reminder.clone();
+                updated.at = next_at.to_rfc3339();
+                match serde_json::to_string_pretty(&updated) {
+                    Ok(json_text) => {
+                        let tmp_path = path.with_extension("json.tmp");
+                        if let Err(e) = std::fs::write(&tmp_path, json_text) {
+                            warn!(agent = %agent_name, path = %tmp_path.display(), error = %e, "failed to write reminder tmp file");
+                        } else if let Err(e) = std::fs::rename(&tmp_path, &path) {
+                            warn!(agent = %agent_name, path = %path.display(), error = %e, "failed to rename reminder tmp file");
+                        } else {
+                            info!(agent = %agent_name, target = %updated.target, next = %updated.at, "recurring reminder re-armed");
+                        }
+                    }
+                    Err(e) => {
+                        warn!(agent = %agent_name, error = %e, "failed to serialize updated reminder");
+                    }
+                }
+            }
+            None => {
+                // One-shot — delete after successful delivery.
                 if let Err(e) = std::fs::remove_file(&path) {
                     warn!(agent = %agent_name, path = %path.display(), error = %e, "failed to delete reminder file");
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,15 +12,28 @@ pub use crate::infra::paths::{
     agent_bus_socket, ensure_dir_owned, log_dir, reminders_dir, state_dir,
 };
 
-/// A one-shot reminder that fires at a specific time and posts a message to the bus.
+/// A reminder that fires at a specific time and posts a message to the bus.
+///
+/// One-shot when neither `interval` nor `cron_expression` is set (legacy
+/// semantics). When `interval` or `cron_expression` is present, the reminder
+/// reschedules itself after each fire — the source string is persisted so the
+/// scheduler can re-parse after a deskd restart.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemindDef {
-    /// ISO 8601 timestamp at which to fire.
+    /// ISO 8601 timestamp at which to fire next.
     pub at: String,
     /// Bus target (e.g. `agent:kira`).
     pub target: String,
     /// Payload text to post.
     pub message: String,
+    /// Recurring interval as a duration string (e.g. "30m", "2h", "1d").
+    /// Mutually exclusive with `cron_expression`. Min effective tick: 1 minute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval: Option<String>,
+    /// Recurring cron expression (5-field UTC). Mutually exclusive with
+    /// `interval`. Min effective tick: 1 minute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cron_expression: Option<String>,
 }
 
 fn default_max_turns() -> u32 {

--- a/tests/recurring_reminders.rs
+++ b/tests/recurring_reminders.rs
@@ -1,0 +1,441 @@
+//! Integration tests for recurring reminders (#455).
+//!
+//! These exercise the scheduler scan loop end-to-end via the public
+//! `fire_due_reminders` entrypoint, using a tempdir-as-HOME and an in-process
+//! bus listener so we can assert real bus delivery.
+//!
+//! The shared `env_lock` mutex from `deskd::test_support` serializes any test
+//! that mutates `HOME` — POSIX `setenv` is not thread-safe under cargo's
+//! parallel runner.
+
+use deskd::app::mcp_service::{ScheduleKind, create_reminder_full, parse_schedule_kind};
+use deskd::config::RemindDef;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::net::UnixListener;
+
+fn temp_socket_path() -> String {
+    format!("/tmp/deskd-test-recur-{}.sock", uuid::Uuid::new_v4())
+}
+
+/// Bind a UnixListener, accept one client, and forward every received `message`
+/// payload (`payload.task`) into the returned channel. Stops on first error
+/// or when the listener task is dropped.
+async fn spawn_bus_listener(socket: &str) -> tokio::sync::mpsc::UnboundedReceiver<String> {
+    let listener = UnixListener::bind(socket).expect("bind bus listener");
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let (reader, _writer) = stream.into_split();
+                let mut lines = BufReader::new(reader).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line)
+                        && v.get("type").and_then(|t| t.as_str()) == Some("message")
+                        && let Some(task) = v
+                            .get("payload")
+                            .and_then(|p| p.get("task"))
+                            .and_then(|t| t.as_str())
+                    {
+                        let _ = tx.send(task.to_string());
+                    }
+                }
+            });
+        }
+    });
+    rx
+}
+
+/// Set `HOME` for the duration of the test and create the reminders dir.
+/// Returns the tempdir handle so it's dropped (cleaned) at test end.
+fn isolate_home() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    // SAFETY: env mutation serialized via test_support::env_lock by callers.
+    unsafe {
+        std::env::set_var("HOME", dir.path());
+    }
+    std::fs::create_dir_all(dir.path().join(".deskd/reminders")).expect("create reminders dir");
+    dir
+}
+
+#[test]
+fn parse_schedule_kind_mutually_exclusive() {
+    let err = parse_schedule_kind(Some("30m"), Some("0 * * * *")).unwrap_err();
+    assert!(
+        err.to_string().contains("mutually exclusive"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
+fn parse_schedule_kind_interval_below_minute_rejected() {
+    let err = parse_schedule_kind(Some("30s"), None).unwrap_err();
+    assert!(
+        err.to_string().contains(">= 1m"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
+fn parse_schedule_kind_interval_valid() {
+    let kind = parse_schedule_kind(Some("2h"), None).unwrap();
+    match kind {
+        ScheduleKind::Interval(d) => assert_eq!(d.as_secs(), 7200),
+        other => panic!("expected Interval, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_schedule_kind_cron_rejects_six_fields() {
+    // 6-field cron implies seconds resolution; deskd is minute-floor only.
+    let err = parse_schedule_kind(None, Some("0 0 * * * *")).unwrap_err();
+    assert!(
+        err.to_string().contains("5 fields"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
+fn parse_schedule_kind_cron_valid_five_field() {
+    let kind = parse_schedule_kind(None, Some("*/5 * * * *")).unwrap();
+    assert_eq!(kind.label(), "cron");
+}
+
+#[test]
+fn parse_schedule_kind_none_is_one_shot() {
+    let kind = parse_schedule_kind(None, None).unwrap();
+    assert_eq!(kind.label(), "one_shot");
+}
+
+#[test]
+fn next_after_interval_advances_one_step() {
+    let now = chrono::Utc::now();
+    let last = now;
+    let kind = ScheduleKind::Interval(Duration::from_secs(60));
+    let next = kind.next_after(last, now).unwrap();
+    // One-minute interval: next should be approximately one minute ahead.
+    assert_eq!((next - last).num_seconds(), 60);
+}
+
+#[test]
+fn next_after_interval_collapses_missed_firings() {
+    // last_fire was 10 minutes ago, interval is 1m → restart-storm policy
+    // should land us at the SINGLE next future tick, not replay 10 ticks.
+    let now = chrono::Utc::now();
+    let last = now - chrono::Duration::seconds(10 * 60);
+    let kind = ScheduleKind::Interval(Duration::from_secs(60));
+    let next = kind.next_after(last, now).unwrap();
+    assert!(
+        next > now,
+        "next must be in the future, got {} vs now {}",
+        next,
+        now
+    );
+    // And no more than one interval into the future.
+    assert!(next <= now + chrono::Duration::seconds(60));
+}
+
+#[test]
+fn next_after_cron_is_future() {
+    // Every minute cron — next occurrence after now is < 60s away and > now.
+    let kind = parse_schedule_kind(None, Some("* * * * *")).unwrap();
+    let now = chrono::Utc::now();
+    let next = kind
+        .next_after(now - chrono::Duration::seconds(10), now)
+        .unwrap();
+    assert!(next > now);
+    assert!(next < now + chrono::Duration::seconds(120));
+}
+
+/// `create_reminder` with neither `interval` nor `cron_expression` keeps the
+/// pre-#455 one-shot semantics: file is written with no recurring fields and
+/// schedule_kind reports "one_shot".
+#[tokio::test]
+async fn create_reminder_one_shot_unchanged() {
+    let _guard = deskd::test_support::env_lock().lock().await;
+    let _home = isolate_home();
+
+    let fire_at = chrono::Utc::now() + chrono::Duration::seconds(120);
+    let res = create_reminder_full("agent:test", "hi", Some(fire_at), None, None).unwrap();
+    assert_eq!(res.schedule_kind, "one_shot");
+
+    let dir = deskd::config::reminders_dir();
+    let files: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(files.len(), 1);
+
+    let content = std::fs::read_to_string(files[0].path()).unwrap();
+    let def: RemindDef = serde_json::from_str(&content).unwrap();
+    assert!(def.interval.is_none());
+    assert!(def.cron_expression.is_none());
+}
+
+/// `create_reminder` with `interval` persists the source string so a deskd
+/// restart can re-arm without losing the schedule.
+#[tokio::test]
+async fn create_reminder_interval_persists_source_string() {
+    let _guard = deskd::test_support::env_lock().lock().await;
+    let _home = isolate_home();
+
+    let res = create_reminder_full("agent:test", "watchdog", None, Some("2h"), None).unwrap();
+    assert_eq!(res.schedule_kind, "interval");
+
+    let dir = deskd::config::reminders_dir();
+    let files: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(files.len(), 1);
+
+    let content = std::fs::read_to_string(files[0].path()).unwrap();
+    let def: RemindDef = serde_json::from_str(&content).unwrap();
+    assert_eq!(def.interval.as_deref(), Some("2h"));
+    assert!(def.cron_expression.is_none());
+}
+
+/// `create_reminder` with `cron_expression` persists the source string.
+#[tokio::test]
+async fn create_reminder_cron_persists_source_string() {
+    let _guard = deskd::test_support::env_lock().lock().await;
+    let _home = isolate_home();
+
+    let res =
+        create_reminder_full("agent:test", "watchdog", None, None, Some("0 */2 * * *")).unwrap();
+    assert_eq!(res.schedule_kind, "cron");
+
+    let dir = deskd::config::reminders_dir();
+    let files: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(files.len(), 1);
+
+    let content = std::fs::read_to_string(files[0].path()).unwrap();
+    let def: RemindDef = serde_json::from_str(&content).unwrap();
+    assert_eq!(def.cron_expression.as_deref(), Some("0 */2 * * *"));
+    assert!(def.interval.is_none());
+}
+
+/// Mutual-exclusion error is surfaced from `create_reminder_full`.
+#[tokio::test]
+async fn create_reminder_rejects_both_interval_and_cron() {
+    let _guard = deskd::test_support::env_lock().lock().await;
+    let _home = isolate_home();
+
+    let err = create_reminder_full("agent:test", "msg", None, Some("30m"), Some("0 * * * *"))
+        .unwrap_err();
+    assert!(err.to_string().contains("mutually exclusive"));
+}
+
+/// list_reminders reflects schedule_kind and next_fire_at for all three kinds.
+#[tokio::test]
+async fn list_reminders_reports_schedule_kind() {
+    let _guard = deskd::test_support::env_lock().lock().await;
+    let _home = isolate_home();
+
+    create_reminder_full(
+        "agent:a",
+        "one-shot",
+        Some(chrono::Utc::now() + chrono::Duration::minutes(10)),
+        None,
+        None,
+    )
+    .unwrap();
+    create_reminder_full("agent:b", "interval", None, Some("1h"), None).unwrap();
+    create_reminder_full("agent:c", "cron", None, None, Some("*/5 * * * *")).unwrap();
+
+    let items = deskd::app::mcp_service::list_reminders(None, None, None, 50).unwrap();
+    assert_eq!(items.len(), 3);
+
+    let kinds: std::collections::HashSet<_> = items
+        .iter()
+        .map(|v| {
+            v.get("schedule_kind")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    assert!(kinds.contains("one_shot"));
+    assert!(kinds.contains("interval"));
+    assert!(kinds.contains("cron"));
+
+    // Every entry has next_fire_at populated.
+    for v in &items {
+        assert!(v.get("next_fire_at").and_then(|x| x.as_str()).is_some());
+    }
+}
+
+/// Recurring reminder fires twice across two scheduler scans and is never
+/// deleted by the scan loop.
+#[tokio::test]
+async fn interval_reminder_fires_twice_and_persists() {
+    let _guard = deskd::test_support::env_lock().lock().await;
+    let _home = isolate_home();
+
+    let socket = temp_socket_path();
+    let mut rx = spawn_bus_listener(&socket).await;
+    // Give the listener a moment to actually bind.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Write a reminder whose `at` is already in the past, with a 1-minute interval.
+    create_reminder_full(
+        "agent:watch",
+        "ping",
+        Some(chrono::Utc::now() - chrono::Duration::seconds(5)),
+        Some("1m"),
+        None,
+    )
+    .unwrap();
+
+    // First scan: should fire and re-arm.
+    let now1 = chrono::Utc::now();
+    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", now1).await;
+
+    let got1 = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("first fire timed out")
+        .expect("channel closed");
+    assert_eq!(got1, "ping");
+
+    // The reminder file must still exist (recurring keeps the row).
+    let dir = deskd::config::reminders_dir();
+    let files1: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(files1.len(), 1, "recurring reminder must not be deleted");
+
+    // Force the `at` to be in the past again so the next scan re-fires.
+    let path = files1[0].path();
+    let content = std::fs::read_to_string(&path).unwrap();
+    let mut def: RemindDef = serde_json::from_str(&content).unwrap();
+    def.at = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+    std::fs::write(&path, serde_json::to_string_pretty(&def).unwrap()).unwrap();
+
+    // Second scan: should fire again.
+    let now2 = chrono::Utc::now();
+    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", now2).await;
+    let got2 = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("second fire timed out")
+        .expect("channel closed");
+    assert_eq!(got2, "ping");
+
+    let files2: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(files2.len(), 1);
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// Restart resilience: write a recurring reminder file directly (simulating
+/// state on disk after a deskd crash) and confirm the scheduler picks it up
+/// on the next scan without any in-memory state.
+#[tokio::test]
+async fn restart_resilience_picks_up_persisted_recurring() {
+    let _guard = deskd::test_support::env_lock().lock().await;
+    let _home = isolate_home();
+
+    let socket = temp_socket_path();
+    let mut rx = spawn_bus_listener(&socket).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Simulate a state file already on disk from a previous deskd process.
+    let dir = deskd::config::reminders_dir();
+    let path = dir.join("test-fixture.json");
+    let def = RemindDef {
+        at: (chrono::Utc::now() - chrono::Duration::minutes(2)).to_rfc3339(),
+        target: "agent:watch".to_string(),
+        message: "from-fixture".to_string(),
+        interval: Some("1m".to_string()),
+        cron_expression: None,
+    };
+    std::fs::write(&path, serde_json::to_string_pretty(&def).unwrap()).unwrap();
+
+    let now = chrono::Utc::now();
+    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", now).await;
+    let got = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("fire timed out")
+        .expect("channel closed");
+    assert_eq!(got, "from-fixture");
+
+    // File still exists with `at` advanced past `now` (restart-storm policy:
+    // fire once and move on).
+    let content = std::fs::read_to_string(&path).unwrap();
+    let updated: RemindDef = serde_json::from_str(&content).unwrap();
+    let updated_at: chrono::DateTime<chrono::Utc> =
+        chrono::DateTime::parse_from_rfc3339(&updated.at)
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+    assert!(updated_at > now, "re-armed time must be in the future");
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// cancel_reminder removes the file so a recurring reminder will not fire again.
+#[tokio::test]
+async fn cancel_recurring_reminder_stops_future_fires() {
+    let _guard = deskd::test_support::env_lock().lock().await;
+    let _home = isolate_home();
+
+    let socket = temp_socket_path();
+    let mut rx = spawn_bus_listener(&socket).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Create + cancel before the scheduler runs.
+    create_reminder_full(
+        "agent:watch",
+        "should-not-fire",
+        Some(chrono::Utc::now() - chrono::Duration::seconds(5)),
+        Some("1m"),
+        None,
+    )
+    .unwrap();
+
+    let dir = deskd::config::reminders_dir();
+    let files: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    let id = files[0]
+        .path()
+        .file_stem()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    let res = deskd::app::mcp_service::cancel_reminder(&id).unwrap();
+    assert_eq!(
+        res.get("cancelled").unwrap(),
+        &serde_json::Value::Bool(true)
+    );
+
+    // Now a scheduler scan must NOT fire anything.
+    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", chrono::Utc::now()).await;
+
+    let timeout = tokio::time::timeout(Duration::from_millis(300), rx.recv()).await;
+    assert!(
+        timeout.is_err(),
+        "cancelled reminder must not produce bus message"
+    );
+    let _ = std::fs::remove_file(&socket);
+}


### PR DESCRIPTION
## Summary

Adds native recurring support to `create_reminder` via two new optional fields — `interval` (e.g. `"30m"`, `"2h"`) and `cron_expression` (5-field UTC cron). The scheduler re-arms a recurring reminder after each fire — no handler-side re-arming, so a forgotten or panicking handler can't silently kill the loop.

## Why

Kira's autonomous-loop pattern (watchdog every 2h, self-pings after every dispatched action) is fragile on one-shot reminders: any bug in the handler that forgets to re-arm kills the loop. Native recurring is the smallest reliable primitive.

## Acceptance criteria

- [x] `create_reminder { interval: "30m", target, message }` fires every 30m; firings continue across deskd restarts.
- [x] `create_reminder { cron_expression: "0 */2 * * *", target, message }` fires at top of every even-numbered hour.
- [x] `list_reminders` includes `schedule_kind` (`one_shot|interval|cron`) and `next_fire_at`.
- [x] `cancel_reminder` cancels the recurring schedule entirely (file deletion).
- [x] `interval` and `cron_expression` mutually exclusive; combine with `at` / `in` / `delay_minutes` for initial fire time.
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` passes.
- [x] One-shot semantics unchanged when neither field is set.

## Notes

- **cron crate**: already a dependency (`cron = 0.12`); UTC only, 5-field; sub-minute rejected.
- **Missed firings collapse**: if deskd was down across multiple scheduled fires, exactly one fires at startup; schedule then advances to the next future tick. No fire-storms.
- **Min tick**: 60s for interval. Cron's natural 1-minute floor.
- **Persistence**: `RemindDef` gains two optional fields (serde defaults); existing one-shot files load unchanged.

## Test plan

`tests/recurring_reminders.rs` — 17 integration tests:

- Parsing: interval valid / sub-minute rejected / cron 5-field valid / 6-field rejected / mutual exclusion / none = one-shot
- Persistence: interval / cron source string round-trips
- Schedule math: `next_after_interval_advances_one_step`, `next_after_interval_collapses_missed_firings`, `next_after_cron_is_future`
- Fire behavior: `interval_reminder_fires_twice_and_persists`, `cancel_recurring_reminder_stops_future_fires`
- API surface: `list_reminders_reports_schedule_kind`
- Restart: `restart_resilience_picks_up_persisted_recurring`
- Backwards compat: `create_reminder_one_shot_unchanged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)