### PR TITLE
feat(#463): federated bus — subscriptions + forward middleware

### DIFF
--- a/src/app/adapters/federation/forward.rs
+++ b/src/app/adapters/federation/forward.rs
@@ -1,0 +1,390 @@
+//! Forward middleware — wires the federation routing table into the hub and
+//! peer (#463).
+//!
+//! Three responsibilities:
+//!
+//! 1. **Peer connection registry** — for each connected peer (hub side) keep
+//!    an `mpsc::UnboundedSender<FederationFrame>` that the writer task drains.
+//!    Sending a `Forward { origin, message }` over this channel reaches the
+//!    peer.
+//! 2. **Local→peer fanout** — when a frame is published on the local bus,
+//!    look up subscribed peers via the [`RoutingTable`] and forward the frame
+//!    to each, **skipping the origin** to prevent loops.
+//! 3. **Peer→local injection** — when a peer's reader receives a frame, inject
+//!    it into the local bus via a [`LocalBusInjector`] (and re-fan-out to any
+//!    *other* matching peers, so the hub also routes between peers).
+//!
+//! ## Loop prevention
+//!
+//! Every federated frame carries an `origin` peer-name field. The hub never
+//! forwards a frame back to its origin. Frames originated locally are
+//! attributed to the hub's own name (configurable; defaults to `local`) so
+//! they fan out to every matching peer.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use super::frame::FederationFrame;
+use super::routing::RoutingTable;
+use crate::ports::bus_wire::BusMessage;
+
+/// Outbound channel handle per connected peer.
+pub type PeerSender = mpsc::UnboundedSender<FederationFrame>;
+
+/// Trait for injecting an inbound federated frame onto the local bus.
+///
+/// Production uses a Unix-socket bus client; tests use a channel-backed stub.
+/// The implementation must not block — calls are made from inside per-peer
+/// reader tasks.
+pub trait LocalBusInjector: Send + Sync {
+    /// Inject `msg` onto the local bus as if it had been published there.
+    ///
+    /// `origin` is the federation origin peer name and is kept for diagnostic
+    /// logging only — local bus subscribers do not see it directly. Failures
+    /// must be logged, not propagated.
+    fn inject(&self, origin: &str, msg: &BusMessage);
+}
+
+/// No-op injector. Used in unit tests that only exercise fanout, not local
+/// delivery, and as a default when the hub is configured without a local bus
+/// connection.
+pub struct NullInjector;
+impl LocalBusInjector for NullInjector {
+    fn inject(&self, _origin: &str, _msg: &BusMessage) {}
+}
+
+/// Connected-peer registry. Maps `peer_name → outbound sender`.
+#[derive(Default)]
+pub struct PeerConnections {
+    inner: Mutex<HashMap<String, PeerSender>>,
+}
+
+impl PeerConnections {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a peer's outbound channel. Replaces any prior sender for the
+    /// same name — last-write-wins, matching the registry's reconnect
+    /// semantics.
+    pub fn insert(&self, peer: &str, tx: PeerSender) {
+        let mut map = self.inner.lock().expect("peer connections mutex poisoned");
+        map.insert(peer.to_string(), tx);
+    }
+
+    /// Drop a peer's channel. Called on disconnect.
+    pub fn remove(&self, peer: &str) {
+        let mut map = self.inner.lock().expect("peer connections mutex poisoned");
+        map.remove(peer);
+    }
+
+    /// Get the sender for `peer`, if connected.
+    pub fn get(&self, peer: &str) -> Option<PeerSender> {
+        let map = self.inner.lock().expect("peer connections mutex poisoned");
+        map.get(peer).cloned()
+    }
+
+    /// Names of all currently connected peers.
+    pub fn connected(&self) -> Vec<String> {
+        let map = self.inner.lock().expect("peer connections mutex poisoned");
+        map.keys().cloned().collect()
+    }
+}
+
+/// Forward middleware — bundles the routing table, peer registry, and the
+/// local injector. Shared by reference (cheap to clone the `Arc`s).
+pub struct ForwardMiddleware {
+    pub routing: Arc<RoutingTable>,
+    pub peers: Arc<PeerConnections>,
+    pub injector: Arc<dyn LocalBusInjector>,
+    /// Name attributed to the hub itself in `origin` fields.
+    pub local_origin: String,
+}
+
+impl ForwardMiddleware {
+    /// Construct a middleware with the supplied dependencies.
+    pub fn new(
+        routing: Arc<RoutingTable>,
+        peers: Arc<PeerConnections>,
+        injector: Arc<dyn LocalBusInjector>,
+        local_origin: impl Into<String>,
+    ) -> Self {
+        Self {
+            routing,
+            peers,
+            injector,
+            local_origin: local_origin.into(),
+        }
+    }
+
+    /// Convenience constructor for testing — no-op injector, fresh routing
+    /// table and peer registry.
+    #[doc(hidden)]
+    pub fn for_test(local_origin: &str) -> Self {
+        Self::new(
+            Arc::new(RoutingTable::new()),
+            Arc::new(PeerConnections::new()),
+            Arc::new(NullInjector),
+            local_origin,
+        )
+    }
+
+    /// Fanout a locally-published frame to all subscribed peers (skipping the
+    /// `origin` peer, if any, to avoid forwarding straight back).
+    ///
+    /// `target_topic` is the bus target the frame was published under — used
+    /// to drive glob matching. Inbox-shaped targets (`inbox/<name>`) fall
+    /// through to the inbox table.
+    pub fn fanout(&self, origin: &str, target_topic: &str, msg: &BusMessage) {
+        let mut peers = self.routing.match_topic(target_topic);
+        for p in self.routing.match_inbox(target_topic) {
+            peers.insert(p);
+        }
+        for peer in peers {
+            if peer == origin {
+                continue;
+            }
+            let Some(tx) = self.peers.get(&peer) else {
+                debug!(
+                    target: "deskd::federation::forward",
+                    peer = %peer,
+                    "skipping fanout — peer not currently connected"
+                );
+                continue;
+            };
+            let frame = FederationFrame::Forward {
+                origin: origin.to_string(),
+                message: msg.clone(),
+            };
+            if let Err(e) = tx.send(frame) {
+                warn!(
+                    target: "deskd::federation::forward",
+                    peer = %peer,
+                    error = %e,
+                    "failed to enqueue federated frame; peer channel closed"
+                );
+            } else {
+                debug!(
+                    target: "deskd::federation::forward",
+                    peer = %peer,
+                    origin = %origin,
+                    target_topic = %target_topic,
+                    "forwarded frame to peer"
+                );
+            }
+        }
+    }
+
+    /// Convenience: fanout a locally-originated publish under
+    /// `self.local_origin`.
+    pub fn fanout_local(&self, target_topic: &str, msg: &BusMessage) {
+        let origin = self.local_origin.clone();
+        self.fanout(&origin, target_topic, msg);
+    }
+
+    /// Handle an inbound frame from a peer connection. Injects into the local
+    /// bus, then re-fans-out to any *other* subscribed peers (so the hub
+    /// routes between peers transparently).
+    pub fn handle_inbound(&self, from_peer: &str, origin: &str, msg: &BusMessage) {
+        // The injector decides whether to surface this on the local bus.
+        self.injector.inject(origin, msg);
+        // Re-fanout to other peers. Skip the sender (the connection we read
+        // from) AND the origin (which may be further upstream) to avoid loops.
+        let target_topic = &msg.target;
+        let mut peers = self.routing.match_topic(target_topic);
+        for p in self.routing.match_inbox(target_topic) {
+            peers.insert(p);
+        }
+        for peer in peers {
+            if peer == from_peer || peer == origin {
+                continue;
+            }
+            let Some(tx) = self.peers.get(&peer) else {
+                continue;
+            };
+            let frame = FederationFrame::Forward {
+                origin: origin.to_string(),
+                message: msg.clone(),
+            };
+            if let Err(e) = tx.send(frame) {
+                warn!(
+                    target: "deskd::federation::forward",
+                    peer = %peer,
+                    error = %e,
+                    "failed to re-forward frame; channel closed"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::bus_wire::BusMetadata;
+    use std::sync::Mutex as StdMutex;
+
+    fn msg(target: &str) -> BusMessage {
+        BusMessage {
+            id: "m-1".into(),
+            source: "agent.x".into(),
+            target: target.into(),
+            payload: serde_json::json!({}),
+            reply_to: None,
+            metadata: BusMetadata {
+                priority: 5,
+                fresh: false,
+            },
+        }
+    }
+
+    struct CapturingInjector {
+        seen: StdMutex<Vec<(String, String)>>,
+    }
+    impl CapturingInjector {
+        fn new() -> Self {
+            Self {
+                seen: StdMutex::new(Vec::new()),
+            }
+        }
+        fn taken(&self) -> Vec<(String, String)> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+    impl LocalBusInjector for CapturingInjector {
+        fn inject(&self, origin: &str, msg: &BusMessage) {
+            self.seen
+                .lock()
+                .unwrap()
+                .push((origin.to_string(), msg.target.clone()));
+        }
+    }
+
+    fn channel() -> (PeerSender, mpsc::UnboundedReceiver<FederationFrame>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (tx, rx)
+    }
+
+    #[test]
+    fn fanout_skips_origin() {
+        let mw = ForwardMiddleware::for_test("local");
+        let (tx_mac, mut rx_mac) = channel();
+        let (tx_phone, mut rx_phone) = channel();
+        mw.peers.insert("mac", tx_mac);
+        mw.peers.insert("phone", tx_phone);
+        mw.routing.subscribe("mac", "voice.*");
+        mw.routing.subscribe("phone", "voice.*");
+
+        // phone originated the frame → should NOT receive it back.
+        mw.fanout("phone", "voice.recorded", &msg("voice.recorded"));
+        assert!(rx_mac.try_recv().is_ok());
+        assert!(rx_phone.try_recv().is_err());
+    }
+
+    #[test]
+    fn fanout_local_uses_local_origin() {
+        let mw = ForwardMiddleware::for_test("local");
+        let (tx_mac, mut rx_mac) = channel();
+        mw.peers.insert("mac", tx_mac);
+        mw.routing.subscribe("mac", "voice.*");
+
+        mw.fanout_local("voice.recorded", &msg("voice.recorded"));
+        let frame = rx_mac.try_recv().unwrap();
+        match frame {
+            FederationFrame::Forward { origin, message } => {
+                assert_eq!(origin, "local");
+                assert_eq!(message.target, "voice.recorded");
+            }
+            _ => panic!("expected Forward"),
+        }
+    }
+
+    #[test]
+    fn fanout_excludes_non_matching_peers() {
+        let mw = ForwardMiddleware::for_test("local");
+        let (tx_mac, mut rx_mac) = channel();
+        let (tx_phone, mut rx_phone) = channel();
+        mw.peers.insert("mac", tx_mac);
+        mw.peers.insert("phone", tx_phone);
+        mw.routing.subscribe("mac", "voice.*");
+        // phone is not subscribed.
+
+        mw.fanout_local("voice.recorded", &msg("voice.recorded"));
+        assert!(rx_mac.try_recv().is_ok());
+        assert!(rx_phone.try_recv().is_err());
+    }
+
+    #[test]
+    fn handle_inbound_injects_and_does_not_loop_back_to_sender() {
+        let routing = Arc::new(RoutingTable::new());
+        let peers = Arc::new(PeerConnections::new());
+        let injector = Arc::new(CapturingInjector::new());
+        let mw = ForwardMiddleware::new(
+            routing,
+            peers.clone(),
+            injector.clone(),
+            "local".to_string(),
+        );
+
+        // mac is subscribed to voice.* and connected.
+        let (tx_mac, mut rx_mac) = channel();
+        mw.peers.insert("mac", tx_mac);
+        mw.routing.subscribe("mac", "voice.*");
+
+        // Inbound from mac with origin=mac — local bus should see it, but
+        // we must NOT echo back to mac.
+        mw.handle_inbound("mac", "mac", &msg("voice.recorded"));
+        assert!(rx_mac.try_recv().is_err());
+        let seen = injector.taken();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].0, "mac");
+        assert_eq!(seen[0].1, "voice.recorded");
+    }
+
+    #[test]
+    fn handle_inbound_forwards_to_other_peers() {
+        let mw = ForwardMiddleware::for_test("local");
+        let (tx_mac, mut rx_mac) = channel();
+        let (tx_phone, mut rx_phone) = channel();
+        mw.peers.insert("mac", tx_mac);
+        mw.peers.insert("phone", tx_phone);
+        mw.routing.subscribe("mac", "voice.*");
+        mw.routing.subscribe("phone", "voice.*");
+
+        // Inbound from mac → re-fanout to phone, skip mac.
+        mw.handle_inbound("mac", "mac", &msg("voice.recorded"));
+        assert!(rx_mac.try_recv().is_err());
+        assert!(rx_phone.try_recv().is_ok());
+    }
+
+    #[test]
+    fn inbox_targets_route_via_inbox_table() {
+        let mw = ForwardMiddleware::for_test("local");
+        let (tx_mac, mut rx_mac) = channel();
+        mw.peers.insert("mac", tx_mac);
+        mw.routing.subscribe_inbox("mac", "personal");
+
+        mw.fanout_local("inbox/personal", &msg("inbox/personal"));
+        assert!(rx_mac.try_recv().is_ok());
+
+        // Cross-device shape: inbox/personal@mac.
+        mw.fanout_local("inbox/personal@mac", &msg("inbox/personal@mac"));
+        assert!(rx_mac.try_recv().is_ok());
+    }
+
+    #[test]
+    fn drop_peer_via_routing_table_clears_subscriptions() {
+        let mw = ForwardMiddleware::for_test("local");
+        let (tx_mac, mut rx_mac) = channel();
+        mw.peers.insert("mac", tx_mac);
+        mw.routing.subscribe("mac", "voice.*");
+        mw.routing.drop_peer("mac");
+        mw.peers.remove("mac");
+
+        mw.fanout_local("voice.recorded", &msg("voice.recorded"));
+        assert!(rx_mac.try_recv().is_err());
+    }
+}

--- a/src/app/adapters/federation/frame.rs
+++ b/src/app/adapters/federation/frame.rs
@@ -1,5 +1,6 @@
 //! Federation wire frame — extends the bus envelope with control frames
-//! (`hello`, `welcome`, `ping`, `pong`) used between federated peers.
+//! (`hello`, `welcome`, `ping`, `pong`, `subscribe`, …) used between
+//! federated peers.
 //!
 //! Serialized as line-delimited JSON with a discriminating `type` field, the
 //! same shape used on the local UNIX socket bus. The `bus_message` variant
@@ -7,18 +8,17 @@
 //! byte-identical between transports — this is the protocol-parity property
 //! the federation epic (#461) calls out.
 //!
-//! # Scope (child 1 of #461)
-//!
-//! The bus is intentionally not federated yet — hubs receive `BusMessage`
-//! frames from connected peers and discard them with a debug log line. Child 2
-//! adds subscriptions + forwarding; child 3 adds replay.
-//!
 //! # Frame variants
 //!
 //! - `hello { peer_name, deskd_version, capabilities }` — peer → hub on connect
 //! - `welcome { hub_name, replay_supported }` — hub → peer in reply
 //! - `ping` / `pong` — bidirectional keepalive (every 30s, two missed → drop)
-//! - `bus_message(BusMessage)` — wraps a regular bus wire message
+//! - `subscribe { pattern }` — peer → hub, register a topic glob subscription
+//! - `unsubscribe { pattern }` — peer → hub, drop a topic glob subscription
+//! - `subscribe_inbox { name }` — peer → hub, register an inbox subscription
+//! - `bus_message(BusMessage)` — raw bus frame (legacy / no origin tracking)
+//! - `forward { origin, message }` — federated bus frame carrying its `origin`
+//!   peer name, used by both directions for loop prevention.
 
 use serde::{Deserialize, Serialize};
 
@@ -49,9 +49,22 @@ pub enum FederationFrame {
     Ping,
     /// Keepalive reply.
     Pong,
+    /// Topic-glob subscription. Issued by a peer; the hub starts forwarding
+    /// matching local frames over this peer link.
+    Subscribe { pattern: String },
+    /// Drop a previously registered glob subscription.
+    Unsubscribe { pattern: String },
+    /// Inbox subscription — preserves the existing `inbox/<name>` shape, with
+    /// optional cross-device `inbox/<name>@<peer>` routing handled by the hub.
+    SubscribeInbox { name: String },
     /// A regular bus message; transparently wrapped so the inner JSON is the
-    /// same shape the UNIX socket bus speaks.
+    /// same shape the UNIX socket bus speaks. No `origin` tracking — used for
+    /// legacy / hello-time greetings only. Federated traffic uses `Forward`.
     BusMessage(BusMessage),
+    /// A federated bus frame with origin tracking. Always sent in both
+    /// directions for actual fanout — the hub uses `origin` to suppress
+    /// forwarding back to the publishing peer, preventing loops.
+    Forward { origin: String, message: BusMessage },
 }
 
 impl FederationFrame {
@@ -164,6 +177,79 @@ mod tests {
                 assert_eq!(m.source, "agent-a");
             }
             _ => panic!("expected BusMessage"),
+        }
+    }
+
+    #[test]
+    fn subscribe_roundtrip() {
+        let frame = FederationFrame::Subscribe {
+            pattern: "voice.*".into(),
+        };
+        let line = frame.to_line().unwrap();
+        assert!(line.contains("\"type\":\"subscribe\""));
+        let back = FederationFrame::parse(line.trim_end()).unwrap();
+        match back {
+            FederationFrame::Subscribe { pattern } => assert_eq!(pattern, "voice.*"),
+            _ => panic!("expected Subscribe"),
+        }
+    }
+
+    #[test]
+    fn unsubscribe_roundtrip() {
+        let frame = FederationFrame::Unsubscribe {
+            pattern: "voice.*".into(),
+        };
+        let line = frame.to_line().unwrap();
+        assert!(line.contains("\"type\":\"unsubscribe\""));
+        let back = FederationFrame::parse(line.trim_end()).unwrap();
+        assert!(matches!(back, FederationFrame::Unsubscribe { .. }));
+    }
+
+    #[test]
+    fn subscribe_inbox_roundtrip() {
+        let frame = FederationFrame::SubscribeInbox {
+            name: "personal".into(),
+        };
+        let line = frame.to_line().unwrap();
+        assert!(line.contains("\"type\":\"subscribe_inbox\""));
+        let back = FederationFrame::parse(line.trim_end()).unwrap();
+        match back {
+            FederationFrame::SubscribeInbox { name } => assert_eq!(name, "personal"),
+            _ => panic!("expected SubscribeInbox"),
+        }
+    }
+
+    #[test]
+    fn forward_roundtrip_preserves_origin_and_inner() {
+        let inner = BusMessage {
+            id: "msg-7".into(),
+            source: "agent.x".into(),
+            target: "voice.recorded".into(),
+            payload: serde_json::json!({"transcript": "hi"}),
+            reply_to: None,
+            metadata: BusMetadata {
+                priority: 5,
+                fresh: false,
+            },
+        };
+        let frame = FederationFrame::Forward {
+            origin: "phone".into(),
+            message: inner,
+        };
+        let line = frame.to_line().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(parsed["type"], "forward");
+        assert_eq!(parsed["origin"], "phone");
+        assert_eq!(parsed["message"]["id"], "msg-7");
+        // Roundtrip.
+        let back = FederationFrame::parse(line.trim_end()).unwrap();
+        match back {
+            FederationFrame::Forward { origin, message } => {
+                assert_eq!(origin, "phone");
+                assert_eq!(message.id, "msg-7");
+                assert_eq!(message.target, "voice.recorded");
+            }
+            _ => panic!("expected Forward"),
         }
     }
 

--- a/src/app/adapters/federation/glob.rs
+++ b/src/app/adapters/federation/glob.rs
@@ -1,0 +1,146 @@
+//! Topic glob matching for federation (#463).
+//!
+//! Two wildcards:
+//! - `*` matches exactly **one** segment (split by `.`).
+//!   `voice.*` matches `voice.recorded` but **not** `voice.recorded.partial`.
+//! - `>` matches **one or more** trailing segments. Must be the final element
+//!   in the pattern. `phone.>` matches `phone.voice.recorded`,
+//!   `phone.voice.recorded.partial`, etc.
+//!
+//! Patterns without wildcards match exactly. Empty patterns and empty topics
+//! never match. The match function is allocation-free in the hot path.
+//!
+//! This is a transport-layer routing primitive — separate from the existing
+//! local-bus glob in `bus_server` (which uses trailing-`*` prefix matching).
+//! Federation segments are `.`-delimited (`<device>.<domain>.<event>` per the
+//! epic's namespace convention).
+
+/// Return `true` if `topic` matches `pattern` under federation glob rules.
+///
+/// See the module docs for the wildcard semantics.
+pub fn matches(pattern: &str, topic: &str) -> bool {
+    if pattern.is_empty() || topic.is_empty() {
+        return false;
+    }
+    // Fast path: literal match (no wildcards present).
+    if !pattern.contains('*') && !pattern.contains('>') {
+        return pattern == topic;
+    }
+
+    let pat_segs: Vec<&str> = pattern.split('.').collect();
+    let topic_segs: Vec<&str> = topic.split('.').collect();
+
+    for (i, pseg) in pat_segs.iter().enumerate() {
+        match *pseg {
+            ">" => {
+                // Must be the last segment in the pattern, and there must be
+                // at least one remaining topic segment.
+                if i + 1 != pat_segs.len() {
+                    // Malformed pattern: `>` not at end → no match.
+                    return false;
+                }
+                return topic_segs.len() > i;
+            }
+            "*" => {
+                if i >= topic_segs.len() {
+                    return false;
+                }
+                // any single segment matches; continue.
+            }
+            literal => {
+                if i >= topic_segs.len() || topic_segs[i] != literal {
+                    return false;
+                }
+            }
+        }
+    }
+    // Both consumed fully — equal segment count, all matched.
+    pat_segs.len() == topic_segs.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_match() {
+        assert!(matches("voice.recorded", "voice.recorded"));
+        assert!(!matches("voice.recorded", "voice.recorded.partial"));
+        assert!(!matches("voice.recorded", "voice"));
+        assert!(!matches("voice.recorded", "voice.published"));
+    }
+
+    #[test]
+    fn star_matches_one_segment() {
+        assert!(matches("voice.*", "voice.recorded"));
+        assert!(matches("voice.*", "voice.published"));
+        // > one segment is forbidden by `*`.
+        assert!(!matches("voice.*", "voice.recorded.partial"));
+        // zero segments doesn't match either.
+        assert!(!matches("voice.*", "voice"));
+    }
+
+    #[test]
+    fn star_in_middle() {
+        assert!(matches("a.*.c", "a.b.c"));
+        assert!(matches("a.*.c", "a.x.c"));
+        assert!(!matches("a.*.c", "a.b.d"));
+        assert!(!matches("a.*.c", "a.b.c.d"));
+    }
+
+    #[test]
+    fn gt_matches_one_or_more_trailing_segments() {
+        assert!(matches("phone.>", "phone.voice"));
+        assert!(matches("phone.>", "phone.voice.recorded"));
+        assert!(matches("phone.>", "phone.voice.recorded.partial"));
+        // exactly the prefix with nothing after must NOT match (>= 1 segment).
+        assert!(!matches("phone.>", "phone"));
+    }
+
+    #[test]
+    fn gt_only_valid_at_end() {
+        // Malformed pattern: > not at end. Treated as no match.
+        assert!(!matches("phone.>.recorded", "phone.voice.recorded"));
+    }
+
+    #[test]
+    fn empty_inputs_never_match() {
+        assert!(!matches("", "anything"));
+        assert!(!matches("voice.*", ""));
+        assert!(!matches("", ""));
+    }
+
+    #[test]
+    fn star_does_not_cross_segment_boundary() {
+        // The local-bus glob (`telegram:*` matching `telegram:foo:bar`) is
+        // separate; federation `*` is strictly single-segment.
+        assert!(!matches("a.*", "a.b.c"));
+    }
+
+    #[test]
+    fn table_driven_cases() {
+        let cases: &[(&str, &str, bool)] = &[
+            ("voice.*", "voice.recorded", true),
+            ("voice.*", "voice.recorded.partial", false),
+            ("phone.>", "phone.voice.recorded", true),
+            ("phone.>", "phone", false),
+            ("agent.dev.completed", "agent.dev.completed", true),
+            ("agent.dev.completed", "agent.dev", false),
+            ("agent.dev.completed", "agent.dev.completed.extra", false),
+            ("*.voice.recorded", "phone.voice.recorded", true),
+            ("*.voice.recorded", "mac.voice.recorded", true),
+            ("*.voice.recorded", "phone.cursor.recorded", false),
+            ("*.*", "a.b", true),
+            ("*.*", "a", false),
+            (">", "phone.voice", true),
+            (">", "phone", true),
+        ];
+        for (pat, topic, expected) in cases {
+            assert_eq!(
+                matches(pat, topic),
+                *expected,
+                "pattern={pat} topic={topic}"
+            );
+        }
+    }
+}

--- a/src/app/adapters/federation/hub.rs
+++ b/src/app/adapters/federation/hub.rs
@@ -1,12 +1,23 @@
-//! Federation hub — TCP listener that accepts peer connections (#462).
+//! Federation hub — TCP listener that accepts peer connections (#462) +
+//! forward middleware (#463).
 //!
 //! On startup [`run_hub`] runs a tailscale preflight, resolves the bind spec,
 //! and binds a TCP listener. Each accepted connection is checked against the
 //! current set of tailnet-allowed source IPs and, if approved, handed to a
-//! per-connection task that runs the hello/welcome handshake and keepalive.
+//! per-connection task that runs the hello/welcome handshake, registers an
+//! outbound channel in [`PeerConnections`], and pumps frames in both
+//! directions:
 //!
-//! Foundation only — inbound `BusMessage` frames are logged and dropped; child
-//! 2 of the federation epic adds routing.
+//! - **Outbound**: any frame published into the per-peer mpsc channel is
+//!   written to the TCP stream. This is how the [`ForwardMiddleware`]'s
+//!   fanout reaches connected peers.
+//! - **Inbound**: subscribe/unsubscribe control frames update the routing
+//!   table; `Forward { origin, message }` frames are injected into the local
+//!   bus and re-fanned-out to other matching peers; legacy `BusMessage`
+//!   frames are treated as `Forward { origin = peer_name }`.
+//!
+//! On disconnect the peer's outbound channel and routing-table entries are
+//! dropped; the peer re-issues its subscriptions on reconnect.
 
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -15,14 +26,16 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc};
 use tokio::time::{Instant, timeout};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use super::forward::{ForwardMiddleware, NullInjector, PeerConnections};
 use super::frame::FederationFrame;
 use super::preflight::{SharedIdentity, TailnetIdentity, preflight_or_error, resolve_bind};
 use super::registry::PeerRegistry;
+use super::routing::RoutingTable;
 
 /// Keepalive cadence — ping every this often, drop after 2 missed pongs.
 pub const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
@@ -44,10 +57,31 @@ pub struct HubConfig {
 
 /// Run the hub listener until `cancel` is triggered. Blocks until the listener
 /// loop exits (cancelled, or the accept call returns a fatal error).
+///
+/// The hub is built without a routing layer — callers that want federation
+/// fanout should use [`run_hub_with_middleware`].
 pub async fn run_hub(
     cfg: HubConfig,
     identity: SharedIdentity,
     registry: Arc<PeerRegistry>,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let middleware = Arc::new(ForwardMiddleware::new(
+        Arc::new(RoutingTable::new()),
+        Arc::new(PeerConnections::new()),
+        Arc::new(NullInjector),
+        cfg.hub_name.clone(),
+    ));
+    run_hub_with_middleware(cfg, identity, registry, middleware, cancel).await
+}
+
+/// Run the hub listener with an explicit forward middleware. Used by serve()
+/// glue and integration tests that want to observe fanout.
+pub async fn run_hub_with_middleware(
+    cfg: HubConfig,
+    identity: SharedIdentity,
+    registry: Arc<PeerRegistry>,
+    middleware: Arc<ForwardMiddleware>,
     cancel: CancellationToken,
 ) -> Result<()> {
     // Preflight: tailscale must be Running.
@@ -94,6 +128,7 @@ pub async fn run_hub(
                         let registry = registry.clone();
                         let hub_name = cfg.hub_name.clone();
                         let cancel = cancel.clone();
+                        let middleware = middleware.clone();
                         tokio::spawn(async move {
                             if let Err(e) = handle_connection(
                                 stream,
@@ -101,6 +136,7 @@ pub async fn run_hub(
                                 allowed,
                                 registry,
                                 hub_name,
+                                middleware,
                                 cancel,
                             ).await {
                                 debug!(
@@ -155,13 +191,15 @@ fn spawn_identity_refresh(
 }
 
 /// Handle a single accepted connection: auth-gate by source IP, run the
-/// hello/welcome handshake, then keepalive until disconnect.
+/// hello/welcome handshake, register the peer's outbound channel, then pump
+/// frames + keepalive until disconnect.
 async fn handle_connection(
     stream: TcpStream,
     peer_ip: IpAddr,
     allowed: Arc<Mutex<std::collections::HashSet<String>>>,
     registry: Arc<PeerRegistry>,
     hub_name: String,
+    middleware: Arc<ForwardMiddleware>,
     cancel: CancellationToken,
 ) -> Result<()> {
     // ── Auth gate ───────────────────────────────────────────────────────
@@ -178,7 +216,6 @@ async fn handle_connection(
             source_ip = %peer_ip_s,
             "rejecting connection: source ip not in tailnet allowlist"
         );
-        // Drop the stream silently from the peer's perspective.
         drop(stream);
         return Ok(());
     }
@@ -246,15 +283,45 @@ async fn handle_connection(
         .context("write welcome")?;
     writer.flush().await.ok();
 
+    // ── Wire up outbound channel ────────────────────────────────────────
+    // The writer task drains this channel onto the TCP socket. Both the
+    // keepalive timer and the forward middleware enqueue frames here.
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<FederationFrame>();
+    middleware.peers.insert(&peer_name, out_tx.clone());
+
+    let peer_name_for_writer = peer_name.clone();
+    let writer_task = tokio::spawn(async move {
+        while let Some(frame) = out_rx.recv().await {
+            let line = match frame.to_line() {
+                Ok(l) => l,
+                Err(e) => {
+                    warn!(
+                        target: "deskd::federation::hub",
+                        peer_name = %peer_name_for_writer,
+                        error = %e,
+                        "frame serialize failed; dropping"
+                    );
+                    continue;
+                }
+            };
+            if writer.write_all(line.as_bytes()).await.is_err() {
+                break;
+            }
+            if writer.flush().await.is_err() {
+                break;
+            }
+        }
+    });
+
     // ── Keepalive + read loop ───────────────────────────────────────────
     let mut last_pong = Instant::now();
     let mut missed = 0u8;
     let mut ticker = tokio::time::interval(KEEPALIVE_INTERVAL);
     ticker.tick().await; // immediate first tick — skip
 
-    loop {
+    let result = loop {
         tokio::select! {
-            _ = cancel.cancelled() => return Ok(()),
+            _ = cancel.cancelled() => break Ok(()),
             _ = ticker.tick() => {
                 if last_pong.elapsed() > KEEPALIVE_INTERVAL.saturating_mul(2) {
                     missed += 1;
@@ -264,20 +331,18 @@ async fn handle_connection(
                             peer_name = %peer_name,
                             "dropping peer: 2 missed pongs"
                         );
-                        return Ok(());
+                        break Ok(());
                     }
                 }
-                let ping = FederationFrame::Ping.to_line()?;
-                if writer.write_all(ping.as_bytes()).await.is_err() {
-                    return Ok(());
+                if out_tx.send(FederationFrame::Ping).is_err() {
+                    break Ok(());
                 }
-                let _ = writer.flush().await;
             }
             line = lines.next_line() => {
                 let line = match line {
                     Ok(Some(l)) => l,
-                    Ok(None) => return Ok(()),
-                    Err(_) => return Ok(()),
+                    Ok(None) => break Ok(()),
+                    Err(_) => break Ok(()),
                 };
                 match FederationFrame::parse(&line) {
                     Ok(FederationFrame::Pong) => {
@@ -285,21 +350,42 @@ async fn handle_connection(
                         missed = 0;
                     }
                     Ok(FederationFrame::Ping) => {
-                        let pong = FederationFrame::Pong.to_line()?;
-                        if writer.write_all(pong.as_bytes()).await.is_err() {
-                            return Ok(());
-                        }
-                        let _ = writer.flush().await;
+                        let _ = out_tx.send(FederationFrame::Pong);
                     }
-                    Ok(FederationFrame::BusMessage(msg)) => {
-                        // Foundation: log + discard. Child 2 owns routing.
+                    Ok(FederationFrame::Subscribe { pattern }) => {
                         debug!(
                             target: "deskd::federation::hub",
                             peer_name = %peer_name,
-                            msg_id = %msg.id,
-                            target = %msg.target,
-                            "discarding inbound bus frame (routing not implemented)"
+                            pattern = %pattern,
+                            "peer subscribed"
                         );
+                        middleware.routing.subscribe(&peer_name, &pattern);
+                    }
+                    Ok(FederationFrame::Unsubscribe { pattern }) => {
+                        debug!(
+                            target: "deskd::federation::hub",
+                            peer_name = %peer_name,
+                            pattern = %pattern,
+                            "peer unsubscribed"
+                        );
+                        middleware.routing.unsubscribe(&peer_name, &pattern);
+                    }
+                    Ok(FederationFrame::SubscribeInbox { name }) => {
+                        debug!(
+                            target: "deskd::federation::hub",
+                            peer_name = %peer_name,
+                            inbox = %name,
+                            "peer subscribed inbox"
+                        );
+                        middleware.routing.subscribe_inbox(&peer_name, &name);
+                    }
+                    Ok(FederationFrame::Forward { origin, message }) => {
+                        middleware.handle_inbound(&peer_name, &origin, &message);
+                    }
+                    Ok(FederationFrame::BusMessage(message)) => {
+                        // Legacy frame (no origin tracked) — treat the peer
+                        // as origin so the message can't loop back.
+                        middleware.handle_inbound(&peer_name, &peer_name, &message);
                     }
                     Ok(FederationFrame::Hello { .. }) | Ok(FederationFrame::Welcome { .. }) => {
                         debug!(
@@ -315,14 +401,26 @@ async fn handle_connection(
                             error = %e,
                             "malformed frame — dropping connection"
                         );
-                        return Ok(());
+                        break Ok(());
                     }
                 }
                 // Touch registry last_seen on every observed line.
                 let _ = registry.upsert_on_hello(&peer_name, Some(&peer_ip_s), now_secs());
             }
         }
-    }
+    };
+
+    // ── Cleanup ─────────────────────────────────────────────────────────
+    middleware.peers.remove(&peer_name);
+    middleware.routing.drop_peer(&peer_name);
+    drop(out_tx);
+    writer_task.abort();
+    info!(
+        target: "deskd::federation::hub",
+        peer_name = %peer_name,
+        "peer disconnected — subscriptions dropped"
+    );
+    result
 }
 
 fn now_secs() -> i64 {
@@ -348,7 +446,12 @@ mod tests {
     async fn start_hub_on(
         addr: &str,
         identity: SharedIdentity,
-    ) -> (Arc<PeerRegistry>, String, CancellationToken) {
+    ) -> (
+        Arc<PeerRegistry>,
+        Arc<ForwardMiddleware>,
+        String,
+        CancellationToken,
+    ) {
         let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
         let local = listener.local_addr().unwrap().to_string();
         drop(listener);
@@ -360,14 +463,20 @@ mod tests {
             tailscale_binary: "true".into(),
             peer_timeout_secs: 60,
         };
+        let middleware = Arc::new(ForwardMiddleware::new(
+            Arc::new(RoutingTable::new()),
+            Arc::new(PeerConnections::new()),
+            Arc::new(NullInjector),
+            "test-hub".to_string(),
+        ));
         let reg2 = registry.clone();
+        let mw2 = middleware.clone();
         let cancel2 = cancel.clone();
         tokio::spawn(async move {
-            let _ = run_hub(cfg, identity, reg2, cancel2).await;
+            let _ = run_hub_with_middleware(cfg, identity, reg2, mw2, cancel2).await;
         });
-        // Give the listener a moment to bind.
         tokio::time::sleep(Duration::from_millis(50)).await;
-        (registry, local, cancel)
+        (registry, middleware, local, cancel)
     }
 
     #[tokio::test]
@@ -377,7 +486,7 @@ mod tests {
             &["100.64.0.1"],
             &[],
         ))) as SharedIdentity;
-        let (registry, addr, cancel) = start_hub_on("127.0.0.1:0", identity).await;
+        let (registry, _mw, addr, cancel) = start_hub_on("127.0.0.1:0", identity).await;
 
         let mut stream = TcpStream::connect(&addr).await.unwrap();
         let hello = FederationFrame::Hello {
@@ -411,7 +520,7 @@ mod tests {
             &["100.64.0.1"],
             &[],
         ))) as SharedIdentity;
-        let (_registry, addr, cancel) = start_hub_on("127.0.0.1:0", identity).await;
+        let (_registry, _mw, addr, cancel) = start_hub_on("127.0.0.1:0", identity).await;
 
         let mut stream = TcpStream::connect(&addr).await.unwrap();
         let ping = FederationFrame::Ping;
@@ -421,11 +530,135 @@ mod tests {
             .unwrap();
         stream.flush().await.unwrap();
 
-        // Hub should close connection without sending welcome.
         let (r, _w) = stream.split();
         let mut lines = BufReader::new(r).lines();
         let res = tokio::time::timeout(Duration::from_secs(2), lines.next_line()).await;
         assert!(matches!(res, Ok(Ok(None))) || matches!(res, Ok(Err(_))));
+        cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn subscribe_frame_registers_in_routing_table() {
+        let identity = Arc::new(StubIdentity::ok(status_with(
+            "Running",
+            &["100.64.0.1"],
+            &[],
+        ))) as SharedIdentity;
+        let (_registry, middleware, addr, cancel) = start_hub_on("127.0.0.1:0", identity).await;
+
+        let mut stream = TcpStream::connect(&addr).await.unwrap();
+        // hello
+        stream
+            .write_all(
+                FederationFrame::Hello {
+                    peer_name: "mac".into(),
+                    deskd_version: "test".into(),
+                    capabilities: vec![],
+                }
+                .to_line()
+                .unwrap()
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        // subscribe
+        stream
+            .write_all(
+                FederationFrame::Subscribe {
+                    pattern: "voice.*".into(),
+                }
+                .to_line()
+                .unwrap()
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        stream.flush().await.unwrap();
+
+        // Wait for routing table to reflect the subscription.
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            let peers = middleware.routing.match_topic("voice.recorded");
+            if peers.contains("mac") {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!("subscribe never registered in routing table");
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn disconnect_drops_subscriptions() {
+        let identity = Arc::new(StubIdentity::ok(status_with(
+            "Running",
+            &["100.64.0.1"],
+            &[],
+        ))) as SharedIdentity;
+        let (_registry, middleware, addr, cancel) = start_hub_on("127.0.0.1:0", identity).await;
+
+        let mut stream = TcpStream::connect(&addr).await.unwrap();
+        stream
+            .write_all(
+                FederationFrame::Hello {
+                    peer_name: "mac".into(),
+                    deskd_version: "test".into(),
+                    capabilities: vec![],
+                }
+                .to_line()
+                .unwrap()
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        stream
+            .write_all(
+                FederationFrame::Subscribe {
+                    pattern: "voice.*".into(),
+                }
+                .to_line()
+                .unwrap()
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        stream.flush().await.unwrap();
+
+        // wait for sub
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            if middleware
+                .routing
+                .match_topic("voice.recorded")
+                .contains("mac")
+            {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!("subscribe never registered");
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        // Close connection. Hub should drop subscriptions.
+        drop(stream);
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            if !middleware
+                .routing
+                .match_topic("voice.recorded")
+                .contains("mac")
+            {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!("subscriptions never dropped after disconnect");
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
         cancel.cancel();
     }
 }

--- a/src/app/adapters/federation/mod.rs
+++ b/src/app/adapters/federation/mod.rs
@@ -1,26 +1,36 @@
-//! Federation transport (#462) — TCP hub + peer dialer foundation.
+//! Federation transport (#462) + routing layer (#463) — TCP hub, peer dialer,
+//! and the forward middleware that turns the deskd bus into a mesh-wide bus.
 //!
-//! This module is the *foundation* of the federated bus epic (#461). It does
-//! not yet forward bus messages between peers — children 2 and 3 add the
-//! routing and replay layers. What lands here:
+//! Module layout:
 //!
-//! - [`frame`] — line-delimited JSON wire frame (hello/welcome/ping/pong/bus).
+//! - [`frame`] — line-delimited JSON wire frame (hello/welcome/ping/pong/bus,
+//!   plus `subscribe`/`unsubscribe`/`subscribe_inbox`/`forward` added in #463).
 //! - [`preflight`] — `tailscale status --json` health check + identity gate.
 //! - [`registry`] — SQLite-backed peer registry.
-//! - [`hub`] — TCP listener that accepts tailnet peers and runs the handshake.
-//! - [`peer`] — dialer that connects to a hub, handles keepalive + reconnect.
+//! - [`glob`] — topic glob matching (`*` one segment, `>` everything below).
+//! - [`routing`] — in-memory routing table (`pattern → peers`).
+//! - [`forward`] — forward middleware (fanout + loop prevention).
+//! - [`hub`] — TCP listener that accepts tailnet peers, runs the handshake,
+//!   and applies the forward middleware.
+//! - [`peer`] — dialer that connects to a hub, handles keepalive + reconnect,
+//!   and registers config-driven subscriptions.
 //!
 //! Both `hub` and `peer` are gated by `federation.{hub,peer}.enabled` in
 //! `workspace.yaml` — block absent or disabled → zero behavior.
 
+pub mod forward;
 pub mod frame;
+pub mod glob;
 pub mod hub;
 pub mod peer;
 pub mod preflight;
 pub mod registry;
+pub mod routing;
 
+pub use forward::{ForwardMiddleware, LocalBusInjector, NullInjector, PeerConnections};
 pub use frame::FederationFrame;
 pub use hub::run_hub;
 pub use peer::run_peer;
 pub use preflight::{CliTailnetIdentity, SharedIdentity, TailnetIdentity, preflight_or_error};
 pub use registry::{PeerRecord, PeerRegistry};
+pub use routing::RoutingTable;

--- a/src/app/adapters/federation/peer.rs
+++ b/src/app/adapters/federation/peer.rs
@@ -1,17 +1,26 @@
-//! Federation peer dialer (#462) — connects to a hub and stays connected.
+//! Federation peer dialer (#462) — connects to a hub and stays connected,
+//! plus forward middleware integration (#463).
 //!
 //! [`run_peer`] runs a connect/handshake/keepalive/reconnect loop with
-//! exponential backoff from config. The dialer is foundation-only: it does
-//! not currently forward bus traffic — child 2 wires that in.
+//! exponential backoff from config. After welcome, the peer issues any
+//! configured `Subscribe`/`SubscribeInbox` frames so the hub starts forwarding
+//! matching traffic over the link. Inbound `Forward` frames are handed to the
+//! configured [`LocalBusInjector`].
+//!
+//! Locally-originated publishes that should reach the hub are sent through
+//! the per-connection `outbound` channel returned by [`PeerSessionHandle`].
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
+use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use super::forward::{LocalBusInjector, NullInjector};
 use super::frame::FederationFrame;
 use super::hub::KEEPALIVE_INTERVAL;
 
@@ -27,10 +36,78 @@ pub struct PeerDialerConfig {
     pub reconnect_backoff_secs: Vec<u64>,
     /// `deskd_version` value to advertise. Typically `env!("CARGO_PKG_VERSION")`.
     pub deskd_version: String,
+    /// Topic-glob subscriptions to issue immediately after welcome.
+    #[doc(alias = "subscriptions")]
+    pub subscribe_patterns: Vec<String>,
+    /// Inbox subscriptions to issue immediately after welcome.
+    pub subscribe_inboxes: Vec<String>,
 }
 
-/// Run the dialer until cancelled.
+impl Default for PeerDialerConfig {
+    fn default() -> Self {
+        Self {
+            hub_addr: String::new(),
+            peer_name: String::new(),
+            reconnect_backoff_secs: vec![1, 2, 5, 15, 60],
+            deskd_version: "0.0.0".into(),
+            subscribe_patterns: Vec::new(),
+            subscribe_inboxes: Vec::new(),
+        }
+    }
+}
+
+/// Handle for sending frames over the *current* peer session. The dialer
+/// swaps the inner sender on every reconnect; frames enqueued while
+/// disconnected are silently dropped (we don't queue across reconnects in v1
+/// — that's the replay log work in #464).
+#[derive(Clone, Default)]
+pub struct PeerSessionHandle {
+    inner: Arc<Mutex<Option<mpsc::UnboundedSender<FederationFrame>>>>,
+}
+
+impl PeerSessionHandle {
+    /// Construct an empty handle. Initially disconnected.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Try to send a frame over the current session. Returns `false` if not
+    /// currently connected.
+    pub async fn send(&self, frame: FederationFrame) -> bool {
+        let guard = self.inner.lock().await;
+        if let Some(tx) = guard.as_ref() {
+            tx.send(frame).is_ok()
+        } else {
+            false
+        }
+    }
+
+    async fn set(&self, tx: Option<mpsc::UnboundedSender<FederationFrame>>) {
+        let mut guard = self.inner.lock().await;
+        *guard = tx;
+    }
+}
+
+/// Run the dialer until cancelled. The returned [`PeerSessionHandle`] is a
+/// future-proof outbound API for child 2 wiring on the peer side.
 pub async fn run_peer(cfg: PeerDialerConfig, cancel: CancellationToken) -> Result<()> {
+    run_peer_with_injector(
+        cfg,
+        Arc::new(NullInjector) as Arc<dyn LocalBusInjector>,
+        PeerSessionHandle::new(),
+        cancel,
+    )
+    .await
+}
+
+/// Run the dialer with an injector + session handle supplied by serve() glue
+/// or tests.
+pub async fn run_peer_with_injector(
+    cfg: PeerDialerConfig,
+    injector: Arc<dyn LocalBusInjector>,
+    session: PeerSessionHandle,
+    cancel: CancellationToken,
+) -> Result<()> {
     let mut attempt: usize = 0;
     let backoff = if cfg.reconnect_backoff_secs.is_empty() {
         vec![1u64, 2, 5, 15, 60]
@@ -42,7 +119,7 @@ pub async fn run_peer(cfg: PeerDialerConfig, cancel: CancellationToken) -> Resul
         if cancel.is_cancelled() {
             return Ok(());
         }
-        match dial_once(&cfg, &cancel).await {
+        match dial_once(&cfg, injector.as_ref(), &session, &cancel).await {
             Ok(SessionExit::Cancelled) => return Ok(()),
             Ok(SessionExit::Disconnected) => {
                 info!(
@@ -60,6 +137,9 @@ pub async fn run_peer(cfg: PeerDialerConfig, cancel: CancellationToken) -> Resul
                 );
             }
         }
+        // Clear the session handle while disconnected so locally-originated
+        // publishes don't try to ride a dead connection.
+        session.set(None).await;
         let delay_secs = *backoff
             .get(attempt.min(backoff.len().saturating_sub(1)))
             .unwrap_or(&60);
@@ -85,7 +165,12 @@ enum SessionExit {
     Disconnected,
 }
 
-async fn dial_once(cfg: &PeerDialerConfig, cancel: &CancellationToken) -> Result<SessionExit> {
+async fn dial_once(
+    cfg: &PeerDialerConfig,
+    injector: &dyn LocalBusInjector,
+    session: &PeerSessionHandle,
+    cancel: &CancellationToken,
+) -> Result<SessionExit> {
     info!(
         target: "deskd::federation::peer",
         hub = %cfg.hub_addr,
@@ -153,15 +238,46 @@ async fn dial_once(cfg: &PeerDialerConfig, cancel: &CancellationToken) -> Result
         }
     }
 
-    // Keepalive loop.
+    // ── Outbound channel + writer task ──────────────────────────────────
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<FederationFrame>();
+    session.set(Some(out_tx.clone())).await;
+
+    // Issue config-driven subscriptions immediately after welcome.
+    for pattern in &cfg.subscribe_patterns {
+        let _ = out_tx.send(FederationFrame::Subscribe {
+            pattern: pattern.clone(),
+        });
+    }
+    for inbox in &cfg.subscribe_inboxes {
+        let _ = out_tx.send(FederationFrame::SubscribeInbox {
+            name: inbox.clone(),
+        });
+    }
+
+    let writer_task = tokio::spawn(async move {
+        while let Some(frame) = out_rx.recv().await {
+            let line = match frame.to_line() {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+            if writer.write_all(line.as_bytes()).await.is_err() {
+                break;
+            }
+            if writer.flush().await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // ── Keepalive + read loop ───────────────────────────────────────────
     let mut last_pong = Instant::now();
     let mut missed: u8 = 0;
     let mut ticker = tokio::time::interval(KEEPALIVE_INTERVAL);
     ticker.tick().await;
 
-    loop {
+    let result = loop {
         tokio::select! {
-            _ = cancel.cancelled() => return Ok(SessionExit::Cancelled),
+            _ = cancel.cancelled() => break Ok(SessionExit::Cancelled),
             _ = ticker.tick() => {
                 if last_pong.elapsed() > KEEPALIVE_INTERVAL.saturating_mul(2) {
                     missed += 1;
@@ -170,19 +286,17 @@ async fn dial_once(cfg: &PeerDialerConfig, cancel: &CancellationToken) -> Result
                             target: "deskd::federation::peer",
                             "hub missed 2 pongs — dropping session"
                         );
-                        return Ok(SessionExit::Disconnected);
+                        break Ok(SessionExit::Disconnected);
                     }
                 }
-                let ping = FederationFrame::Ping.to_line()?;
-                if writer.write_all(ping.as_bytes()).await.is_err() {
-                    return Ok(SessionExit::Disconnected);
+                if out_tx.send(FederationFrame::Ping).is_err() {
+                    break Ok(SessionExit::Disconnected);
                 }
-                let _ = writer.flush().await;
             }
             line = lines.next_line() => {
                 let line = match line {
                     Ok(Some(l)) => l,
-                    Ok(None) | Err(_) => return Ok(SessionExit::Disconnected),
+                    Ok(None) | Err(_) => break Ok(SessionExit::Disconnected),
                 };
                 match FederationFrame::parse(&line) {
                     Ok(FederationFrame::Pong) => {
@@ -190,15 +304,29 @@ async fn dial_once(cfg: &PeerDialerConfig, cancel: &CancellationToken) -> Result
                         missed = 0;
                     }
                     Ok(FederationFrame::Ping) => {
-                        let pong = FederationFrame::Pong.to_line()?;
-                        if writer.write_all(pong.as_bytes()).await.is_err() {
-                            return Ok(SessionExit::Disconnected);
-                        }
-                        let _ = writer.flush().await;
+                        let _ = out_tx.send(FederationFrame::Pong);
                     }
-                    Ok(FederationFrame::BusMessage(_)) => {
-                        // Foundation: log + discard.
-                        debug!(target: "deskd::federation::peer", "discarding inbound bus frame");
+                    Ok(FederationFrame::Forward { origin, message }) => {
+                        debug!(
+                            target: "deskd::federation::peer",
+                            origin = %origin,
+                            target = %message.target,
+                            "injecting forwarded frame into local bus"
+                        );
+                        injector.inject(&origin, &message);
+                    }
+                    Ok(FederationFrame::BusMessage(message)) => {
+                        // Legacy / origin-less; inject as if it came from the
+                        // hub.
+                        injector.inject("hub", &message);
+                    }
+                    Ok(FederationFrame::Subscribe { .. })
+                    | Ok(FederationFrame::Unsubscribe { .. })
+                    | Ok(FederationFrame::SubscribeInbox { .. }) => {
+                        debug!(
+                            target: "deskd::federation::peer",
+                            "ignoring subscribe-class frame from hub"
+                        );
                     }
                     Ok(FederationFrame::Hello { .. }) | Ok(FederationFrame::Welcome { .. }) => {
                         debug!(target: "deskd::federation::peer", "ignoring unexpected handshake frame mid-session");
@@ -209,21 +337,30 @@ async fn dial_once(cfg: &PeerDialerConfig, cancel: &CancellationToken) -> Result
                             error = %e,
                             "malformed frame from hub — dropping"
                         );
-                        return Ok(SessionExit::Disconnected);
+                        break Ok(SessionExit::Disconnected);
                     }
                 }
             }
         }
-    }
+    };
+
+    drop(out_tx);
+    writer_task.abort();
+    session.set(None).await;
+    result
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::adapters::federation::hub::{HubConfig, run_hub};
+    use crate::app::adapters::federation::forward::{
+        ForwardMiddleware, NullInjector, PeerConnections,
+    };
+    use crate::app::adapters::federation::hub::{HubConfig, run_hub_with_middleware};
     use crate::app::adapters::federation::preflight::testing::{StubIdentity, status_with};
     use crate::app::adapters::federation::preflight::{SharedIdentity, TailnetIdentity};
     use crate::app::adapters::federation::registry::PeerRegistry;
+    use crate::app::adapters::federation::routing::RoutingTable;
     use std::sync::Arc;
 
     async fn spawn_test_hub() -> (String, CancellationToken, Arc<PeerRegistry>) {
@@ -243,10 +380,16 @@ mod tests {
             tailscale_binary: "true".into(),
             peer_timeout_secs: 60,
         };
+        let middleware = Arc::new(ForwardMiddleware::new(
+            Arc::new(RoutingTable::new()),
+            Arc::new(PeerConnections::new()),
+            Arc::new(NullInjector),
+            "test-hub".to_string(),
+        ));
         let reg2 = registry.clone();
         let cancel2 = cancel.clone();
         tokio::spawn(async move {
-            let _ = run_hub(cfg, identity, reg2, cancel2).await;
+            let _ = run_hub_with_middleware(cfg, identity, reg2, middleware, cancel2).await;
         });
         tokio::time::sleep(Duration::from_millis(50)).await;
         (addr, cancel, registry)
@@ -262,6 +405,7 @@ mod tests {
             peer_name: "mac".into(),
             reconnect_backoff_secs: vec![1],
             deskd_version: "test".into(),
+            ..Default::default()
         };
         let pc_cancel = peer_cancel.clone();
         let handle = tokio::spawn(async move {
@@ -298,6 +442,7 @@ mod tests {
             peer_name: "mac".into(),
             reconnect_backoff_secs: vec![1],
             deskd_version: "test".into(),
+            ..Default::default()
         };
         let pc_cancel = peer_cancel.clone();
         let handle = tokio::spawn(async move {
@@ -320,10 +465,16 @@ mod tests {
             tailscale_binary: "true".into(),
             peer_timeout_secs: 60,
         };
+        let middleware = Arc::new(ForwardMiddleware::new(
+            Arc::new(RoutingTable::new()),
+            Arc::new(PeerConnections::new()),
+            Arc::new(NullInjector),
+            "test-hub".to_string(),
+        ));
         let reg2 = registry.clone();
         let hub_cancel2 = hub_cancel.clone();
         tokio::spawn(async move {
-            let _ = run_hub(cfg, identity, reg2, hub_cancel2).await;
+            let _ = run_hub_with_middleware(cfg, identity, reg2, middleware, hub_cancel2).await;
         });
 
         let deadline = Instant::now() + Duration::from_secs(8);

--- a/src/app/adapters/federation/routing.rs
+++ b/src/app/adapters/federation/routing.rs
@@ -1,0 +1,245 @@
+//! In-memory routing table for federation (#463).
+//!
+//! Maps subscription patterns to the set of peers that issued them. The hub
+//! consults this table on every locally-published frame to decide where to
+//! fan out. The peer keeps a *local* mirror — the patterns it has subscribed
+//! itself to — used to know which locally-published topics should be sent
+//! upstream.
+//!
+//! ## Lifecycle
+//!
+//! - `subscribe(peer, pattern)`: add `(pattern, peer)`.
+//! - `unsubscribe(peer, pattern)`: remove `(pattern, peer)`.
+//! - `drop_peer(peer)`: remove every pattern → peer mapping. Called on
+//!   disconnect; subscriptions are re-issued on reconnect (peer-side
+//!   responsibility, not the hub's).
+//! - `match_topic(topic)`: return the deduplicated set of peers whose
+//!   subscriptions match.
+//!
+//! Inbox subscriptions live in their own bucket — they don't pattern-match
+//! the topic, they match the literal `inbox/<name>` target shape preserved by
+//! the existing deskd inbox routing. See [`RoutingTable::subscribe_inbox`].
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use super::glob;
+
+/// Routing table — `pattern → set<peer_name>` plus an inbox bucket.
+#[derive(Default)]
+pub struct RoutingTable {
+    inner: Mutex<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Topic-glob subscriptions: pattern → set of peers.
+    by_pattern: HashMap<String, HashSet<String>>,
+    /// Inbox subscriptions: inbox name → set of peers.
+    inboxes: HashMap<String, HashSet<String>>,
+}
+
+impl RoutingTable {
+    /// Create an empty routing table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add `pattern → peer`. Idempotent.
+    pub fn subscribe(&self, peer: &str, pattern: &str) {
+        let mut inner = self.inner.lock().expect("routing mutex poisoned");
+        inner
+            .by_pattern
+            .entry(pattern.to_string())
+            .or_default()
+            .insert(peer.to_string());
+    }
+
+    /// Remove `pattern → peer`. Empty entries collapse.
+    pub fn unsubscribe(&self, peer: &str, pattern: &str) {
+        let mut inner = self.inner.lock().expect("routing mutex poisoned");
+        if let Some(set) = inner.by_pattern.get_mut(pattern) {
+            set.remove(peer);
+            if set.is_empty() {
+                inner.by_pattern.remove(pattern);
+            }
+        }
+    }
+
+    /// Add an inbox-name subscription. Inbox routing preserves the existing
+    /// deskd `inbox/<name>` target shape — the hub forwards a frame to this
+    /// peer when its target matches `inbox/<name>` exactly or
+    /// `inbox/<name>@<peer>`.
+    pub fn subscribe_inbox(&self, peer: &str, inbox: &str) {
+        let mut inner = self.inner.lock().expect("routing mutex poisoned");
+        inner
+            .inboxes
+            .entry(inbox.to_string())
+            .or_default()
+            .insert(peer.to_string());
+    }
+
+    /// Remove an inbox subscription.
+    pub fn unsubscribe_inbox(&self, peer: &str, inbox: &str) {
+        let mut inner = self.inner.lock().expect("routing mutex poisoned");
+        if let Some(set) = inner.inboxes.get_mut(inbox) {
+            set.remove(peer);
+            if set.is_empty() {
+                inner.inboxes.remove(inbox);
+            }
+        }
+    }
+
+    /// Drop all subscriptions for `peer`. Called on disconnect.
+    pub fn drop_peer(&self, peer: &str) {
+        let mut inner = self.inner.lock().expect("routing mutex poisoned");
+        inner.by_pattern.retain(|_, set| {
+            set.remove(peer);
+            !set.is_empty()
+        });
+        inner.inboxes.retain(|_, set| {
+            set.remove(peer);
+            !set.is_empty()
+        });
+    }
+
+    /// Return the deduplicated set of peers whose pattern subscriptions match
+    /// the given topic.
+    pub fn match_topic(&self, topic: &str) -> HashSet<String> {
+        let inner = self.inner.lock().expect("routing mutex poisoned");
+        let mut out = HashSet::new();
+        for (pattern, peers) in inner.by_pattern.iter() {
+            if glob::matches(pattern, topic) {
+                for p in peers {
+                    out.insert(p.clone());
+                }
+            }
+        }
+        out
+    }
+
+    /// Return peers subscribed to a literal inbox target `inbox/<name>` or
+    /// `inbox/<name>@<peer>`. Returns the empty set if `target` is not in the
+    /// inbox-target shape.
+    pub fn match_inbox(&self, target: &str) -> HashSet<String> {
+        let name = match target.strip_prefix("inbox/") {
+            Some(rest) => rest.split('@').next().unwrap_or(rest),
+            None => return HashSet::new(),
+        };
+        let inner = self.inner.lock().expect("routing mutex poisoned");
+        inner.inboxes.get(name).cloned().unwrap_or_default()
+    }
+
+    /// Snapshot the current pattern subscriptions. Used by integration tests
+    /// and admin endpoints.
+    pub fn snapshot_patterns(&self) -> Vec<(String, Vec<String>)> {
+        let inner = self.inner.lock().expect("routing mutex poisoned");
+        let mut out: Vec<(String, Vec<String>)> = inner
+            .by_pattern
+            .iter()
+            .map(|(p, set)| {
+                let mut peers: Vec<String> = set.iter().cloned().collect();
+                peers.sort();
+                (p.clone(), peers)
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
+    /// Number of distinct (pattern, peer) pairs. Cheap consistency probe.
+    pub fn pattern_subscription_count(&self) -> usize {
+        let inner = self.inner.lock().expect("routing mutex poisoned");
+        inner.by_pattern.values().map(|s| s.len()).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscribe_and_match() {
+        let t = RoutingTable::new();
+        t.subscribe("mac", "voice.*");
+        let peers = t.match_topic("voice.recorded");
+        assert!(peers.contains("mac"));
+        assert_eq!(peers.len(), 1);
+    }
+
+    #[test]
+    fn match_dedupes_overlapping_patterns() {
+        let t = RoutingTable::new();
+        t.subscribe("mac", "voice.*");
+        t.subscribe("mac", "voice.recorded");
+        let peers = t.match_topic("voice.recorded");
+        assert_eq!(peers.len(), 1);
+        assert!(peers.contains("mac"));
+    }
+
+    #[test]
+    fn multiple_peers_on_same_pattern() {
+        let t = RoutingTable::new();
+        t.subscribe("mac", "voice.*");
+        t.subscribe("phone", "voice.*");
+        let peers = t.match_topic("voice.recorded");
+        assert_eq!(peers.len(), 2);
+    }
+
+    #[test]
+    fn unsubscribe_removes_mapping() {
+        let t = RoutingTable::new();
+        t.subscribe("mac", "voice.*");
+        t.unsubscribe("mac", "voice.*");
+        assert!(t.match_topic("voice.recorded").is_empty());
+        assert_eq!(t.pattern_subscription_count(), 0);
+    }
+
+    #[test]
+    fn drop_peer_removes_all_subscriptions() {
+        let t = RoutingTable::new();
+        t.subscribe("mac", "voice.*");
+        t.subscribe("mac", "agent.dev.completed");
+        t.subscribe("phone", "voice.*");
+        t.drop_peer("mac");
+        let peers = t.match_topic("voice.recorded");
+        assert_eq!(peers.len(), 1);
+        assert!(peers.contains("phone"));
+        assert!(t.match_topic("agent.dev.completed").is_empty());
+    }
+
+    #[test]
+    fn inbox_routing() {
+        let t = RoutingTable::new();
+        t.subscribe_inbox("mac", "personal");
+        let peers = t.match_inbox("inbox/personal");
+        assert_eq!(peers.len(), 1);
+        assert!(peers.contains("mac"));
+        // Cross-device addressing `inbox/<name>@<device>`.
+        let peers = t.match_inbox("inbox/personal@mac");
+        assert!(peers.contains("mac"));
+        // Non-inbox target → empty.
+        assert!(t.match_inbox("voice.recorded").is_empty());
+    }
+
+    #[test]
+    fn drop_peer_clears_inboxes_too() {
+        let t = RoutingTable::new();
+        t.subscribe_inbox("mac", "personal");
+        t.drop_peer("mac");
+        assert!(t.match_inbox("inbox/personal").is_empty());
+    }
+
+    #[test]
+    fn snapshot_is_stable_sorted() {
+        let t = RoutingTable::new();
+        t.subscribe("b", "y.*");
+        t.subscribe("a", "x.*");
+        t.subscribe("c", "x.*");
+        let snap = t.snapshot_patterns();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].0, "x.*");
+        assert_eq!(snap[0].1, vec!["a".to_string(), "c".to_string()]);
+        assert_eq!(snap[1].0, "y.*");
+    }
+}

--- a/src/app/serve.rs
+++ b/src/app/serve.rs
@@ -388,6 +388,8 @@ pub async fn serve(config_path: String) -> Result<()> {
                     peer_name: peer.peer_name.clone(),
                     reconnect_backoff_secs: peer.reconnect_backoff_secs.clone(),
                     deskd_version: env!("CARGO_PKG_VERSION").to_string(),
+                    subscribe_patterns: peer.subscribe.clone(),
+                    subscribe_inboxes: peer.subscribe_inboxes.clone(),
                 };
                 tokio::spawn(async move {
                     if let Err(e) = federation::run_peer(cfg, cancel_clone).await {

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,6 +141,14 @@ pub struct FederationPeerConfig {
     /// `[1, 2, 5, 15, 60]`.
     #[serde(default = "default_federation_backoff")]
     pub reconnect_backoff_secs: Vec<u64>,
+    /// Topic-glob subscriptions the peer issues to the hub on every
+    /// connect (#463). Wildcards: `*` one segment, `>` everything below.
+    #[serde(default)]
+    pub subscribe: Vec<String>,
+    /// Inbox subscriptions issued on every connect — preserves the existing
+    /// `inbox/<name>` shape (#463).
+    #[serde(default, alias = "subscribe_inbox")]
+    pub subscribe_inboxes: Vec<String>,
 }
 
 impl Default for FederationPeerConfig {
@@ -150,6 +158,8 @@ impl Default for FederationPeerConfig {
             hub_addr: String::new(),
             peer_name: String::new(),
             reconnect_backoff_secs: default_federation_backoff(),
+            subscribe: Vec::new(),
+            subscribe_inboxes: Vec::new(),
         }
     }
 }

--- a/tests/federation_forward.rs
+++ b/tests/federation_forward.rs
@@ -1,0 +1,304 @@
+//! Integration test for the federated bus forward middleware (#463).
+//!
+//! Runs hub + peer in the same process on `127.0.0.1`. The test exercises the
+//! ticket's smoke-test goal:
+//!
+//! 1. Peer subscribes to `voice.*` after welcome.
+//! 2. Hub fans out a local publish on `voice.recorded` → peer receives it on
+//!    its local-bus injector.
+//! 3. Peer publishes back through the session handle → hub's local injector
+//!    sees it; the originating peer is NOT looped back to.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use deskd::app::adapters::federation::forward::{
+    ForwardMiddleware, LocalBusInjector, PeerConnections,
+};
+use deskd::app::adapters::federation::frame::FederationFrame;
+use deskd::app::adapters::federation::hub::{HubConfig, run_hub_with_middleware};
+use deskd::app::adapters::federation::peer::{
+    PeerDialerConfig, PeerSessionHandle, run_peer_with_injector,
+};
+use deskd::app::adapters::federation::preflight::testing::{StubIdentity, status_with};
+use deskd::app::adapters::federation::preflight::{SharedIdentity, TailnetIdentity};
+use deskd::app::adapters::federation::registry::PeerRegistry;
+use deskd::app::adapters::federation::routing::RoutingTable;
+use deskd::ports::bus_wire::{BusMessage, BusMetadata};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Default)]
+struct CapturingInjector {
+    seen: Mutex<Vec<(String, BusMessage)>>,
+}
+impl CapturingInjector {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn taken(&self) -> Vec<(String, BusMessage)> {
+        self.seen.lock().unwrap().clone()
+    }
+}
+impl LocalBusInjector for CapturingInjector {
+    fn inject(&self, origin: &str, msg: &BusMessage) {
+        self.seen
+            .lock()
+            .unwrap()
+            .push((origin.to_string(), msg.clone()));
+    }
+}
+
+async fn pick_free_addr() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    drop(listener);
+    addr
+}
+
+fn msg(id: &str, target: &str) -> BusMessage {
+    BusMessage {
+        id: id.into(),
+        source: "agent.x".into(),
+        target: target.into(),
+        payload: serde_json::json!({"k": "v"}),
+        reply_to: None,
+        metadata: BusMetadata {
+            priority: 5,
+            fresh: false,
+        },
+    }
+}
+
+async fn wait_until<F: Fn() -> bool>(predicate: F, timeout: Duration, label: &str) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if predicate() {
+            return;
+        }
+        if Instant::now() > deadline {
+            panic!("timed out waiting for: {label}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test]
+async fn round_trip_hub_to_peer_and_back() {
+    // ── Hub side ──
+    let addr = pick_free_addr().await;
+    let identity: SharedIdentity = Arc::new(StubIdentity::ok(status_with(
+        "Running",
+        &["100.64.0.1"],
+        &[],
+    ))) as Arc<dyn TailnetIdentity>;
+    let hub_injector = Arc::new(CapturingInjector::new());
+    let hub_routing = Arc::new(RoutingTable::new());
+    let hub_peers = Arc::new(PeerConnections::new());
+    let hub_middleware = Arc::new(ForwardMiddleware::new(
+        hub_routing.clone(),
+        hub_peers.clone(),
+        hub_injector.clone() as Arc<dyn LocalBusInjector>,
+        "vps".to_string(),
+    ));
+
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = Arc::new(PeerRegistry::open(&tmp.path().join("fed.sqlite")).unwrap());
+    let hub_cancel = CancellationToken::new();
+    let hub_cfg = HubConfig {
+        bind: addr.clone(),
+        hub_name: "vps".into(),
+        tailscale_binary: "true".into(),
+        peer_timeout_secs: 60,
+    };
+    let reg_for_hub = registry.clone();
+    let hub_mw_for_run = hub_middleware.clone();
+    let hub_cancel_clone = hub_cancel.clone();
+    let _hub_task = tokio::spawn(async move {
+        let _ = run_hub_with_middleware(
+            hub_cfg,
+            identity,
+            reg_for_hub,
+            hub_mw_for_run,
+            hub_cancel_clone,
+        )
+        .await;
+    });
+
+    // ── Peer side ──
+    let peer_injector = Arc::new(CapturingInjector::new());
+    let session = PeerSessionHandle::new();
+    let peer_cancel = CancellationToken::new();
+    let pc = PeerDialerConfig {
+        hub_addr: addr.clone(),
+        peer_name: "mac".into(),
+        reconnect_backoff_secs: vec![1],
+        deskd_version: "test".into(),
+        subscribe_patterns: vec!["voice.*".into()],
+        subscribe_inboxes: vec![],
+    };
+    let pi = peer_injector.clone() as Arc<dyn LocalBusInjector>;
+    let session_for_peer = session.clone();
+    let peer_cancel_clone = peer_cancel.clone();
+    let _peer_task = tokio::spawn(async move {
+        let _ = run_peer_with_injector(pc, pi, session_for_peer, peer_cancel_clone).await;
+    });
+
+    // ── Wait for handshake + subscription ──
+    let routing_for_check = hub_routing.clone();
+    wait_until(
+        move || {
+            routing_for_check
+                .match_topic("voice.recorded")
+                .contains("mac")
+        },
+        Duration::from_secs(5),
+        "peer 'mac' subscribes to voice.*",
+    )
+    .await;
+
+    // ── Hub → peer fanout ──
+    hub_middleware.fanout_local("voice.recorded", &msg("m1", "voice.recorded"));
+    let injector_for_check = peer_injector.clone();
+    wait_until(
+        move || {
+            injector_for_check
+                .taken()
+                .iter()
+                .any(|(o, m)| o == "vps" && m.id == "m1" && m.target == "voice.recorded")
+        },
+        Duration::from_secs(3),
+        "peer receives m1 forwarded from hub",
+    )
+    .await;
+
+    // ── Non-matching topic must NOT reach the peer ──
+    hub_middleware.fanout_local("other.topic", &msg("m-other", "other.topic"));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        peer_injector.taken().iter().all(|(_, m)| m.id != "m-other"),
+        "peer should not receive non-matching topic"
+    );
+
+    // ── Peer → hub publish via the session handle ──
+    let sent = session
+        .send(FederationFrame::Forward {
+            origin: "mac".into(),
+            message: msg("m2", "voice.recorded"),
+        })
+        .await;
+    assert!(sent, "peer session handle must be connected");
+
+    let hub_inj_for_check = hub_injector.clone();
+    wait_until(
+        move || {
+            hub_inj_for_check
+                .taken()
+                .iter()
+                .any(|(o, m)| o == "mac" && m.id == "m2")
+        },
+        Duration::from_secs(3),
+        "hub injects m2 into local bus",
+    )
+    .await;
+
+    // ── Loop prevention: peer should NOT receive its own publish back ──
+    // Wait for an additional moment to give the hub a chance to (incorrectly)
+    // fan back out, then assert nothing landed.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(
+        peer_injector.taken().iter().all(|(_, m)| m.id != "m2"),
+        "peer must not receive its own publish back (loop prevention)"
+    );
+
+    peer_cancel.cancel();
+    hub_cancel.cancel();
+}
+
+#[tokio::test]
+async fn unsubscribe_stops_fanout_to_peer() {
+    let addr = pick_free_addr().await;
+    let identity: SharedIdentity = Arc::new(StubIdentity::ok(status_with(
+        "Running",
+        &["100.64.0.1"],
+        &[],
+    ))) as Arc<dyn TailnetIdentity>;
+
+    let hub_routing = Arc::new(RoutingTable::new());
+    let hub_peers = Arc::new(PeerConnections::new());
+    let hub_middleware = Arc::new(ForwardMiddleware::new(
+        hub_routing.clone(),
+        hub_peers.clone(),
+        Arc::new(deskd::app::adapters::federation::forward::NullInjector),
+        "vps".to_string(),
+    ));
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = Arc::new(PeerRegistry::open(&tmp.path().join("fed.sqlite")).unwrap());
+    let hub_cancel = CancellationToken::new();
+    let hub_cfg = HubConfig {
+        bind: addr.clone(),
+        hub_name: "vps".into(),
+        tailscale_binary: "true".into(),
+        peer_timeout_secs: 60,
+    };
+    let mw_for_run = hub_middleware.clone();
+    let hub_cancel_clone = hub_cancel.clone();
+    tokio::spawn(async move {
+        let _ = run_hub_with_middleware(hub_cfg, identity, registry, mw_for_run, hub_cancel_clone)
+            .await;
+    });
+
+    let peer_injector = Arc::new(CapturingInjector::new());
+    let session = PeerSessionHandle::new();
+    let peer_cancel = CancellationToken::new();
+    let pc = PeerDialerConfig {
+        hub_addr: addr.clone(),
+        peer_name: "mac".into(),
+        reconnect_backoff_secs: vec![1],
+        deskd_version: "test".into(),
+        subscribe_patterns: vec!["voice.*".into()],
+        subscribe_inboxes: vec![],
+    };
+    let pi = peer_injector.clone() as Arc<dyn LocalBusInjector>;
+    let session_for_peer = session.clone();
+    let peer_cancel_clone = peer_cancel.clone();
+    tokio::spawn(async move {
+        let _ = run_peer_with_injector(pc, pi, session_for_peer, peer_cancel_clone).await;
+    });
+
+    // Wait for sub.
+    let r = hub_routing.clone();
+    wait_until(
+        move || r.match_topic("voice.recorded").contains("mac"),
+        Duration::from_secs(5),
+        "mac subscribes voice.*",
+    )
+    .await;
+
+    // Unsubscribe via the peer session.
+    let sent = session
+        .send(FederationFrame::Unsubscribe {
+            pattern: "voice.*".into(),
+        })
+        .await;
+    assert!(sent);
+
+    // Wait for unsubscribe to take effect.
+    let r = hub_routing.clone();
+    wait_until(
+        move || !r.match_topic("voice.recorded").contains("mac"),
+        Duration::from_secs(3),
+        "voice.* unsubscribed",
+    )
+    .await;
+
+    // Now publish — peer should NOT receive.
+    hub_middleware.fanout_local("voice.recorded", &msg("m-after", "voice.recorded"));
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(
+        peer_injector.taken().iter().all(|(_, m)| m.id != "m-after"),
+        "unsubscribed peer should not receive fanout"
+    );
+
+    peer_cancel.cancel();
+    hub_cancel.cancel();
+}

--- a/tests/federation_smoke.rs
+++ b/tests/federation_smoke.rs
@@ -62,6 +62,8 @@ async fn hub_and_peer_complete_handshake_and_register() {
         peer_name: "smoke-peer".into(),
         reconnect_backoff_secs: vec![1],
         deskd_version: "test".into(),
+        subscribe_patterns: Vec::new(),
+        subscribe_inboxes: Vec::new(),
     };
     let peer_cancel_clone = peer_cancel.clone();
     let _peer = tokio::spawn(async move {


### PR DESCRIPTION
Closes #463. Builds on #462 (PR #466). GitHub will auto-rebase this onto `main` when #466 merges.

## Summary

Adds the actual federation behavior on top of #462's TCP transport:
subscription control frames, glob-based topic routing, and a
bidirectional forward middleware between local bus and peer connections.

## Acceptance criteria

- [x] Subscribe / unsubscribe / subscribe_inbox frames implemented on
      both sides (`FederationFrame::{Subscribe,Unsubscribe,SubscribeInbox}`,
      issued by the peer dialer after welcome, handled by the hub reader).
- [x] Glob matching covers `*` (single segment) and `>` (one or more
      trailing segments); table-driven test in
      `src/app/adapters/federation/glob.rs`.
- [x] Local→peer forwarding: publish on hub fans out to all matching
      peers; non-matching peers don't see the frame
      (`ForwardMiddleware::fanout`, integration test
      `round_trip_hub_to_peer_and_back`).
- [x] Peer→local: frame on peer link arrives via the
      `LocalBusInjector` trait. Production injector wiring to the
      Unix-socket bus is deferred to a follow-up — current `serve()`
      glue uses `NullInjector` so mesh traffic flows between peers and
      into the middleware without yet pushing onto the local bus. Called
      out below.
- [x] Loop prevention: every federated frame carries `origin: <peer>`;
      `fanout` and `handle_inbound` both skip the origin peer. Verified
      by integration test (`peer must not receive its own publish back`).
- [x] Routing table dropped on peer disconnect; re-issued on reconnect
      (verified by `hub::tests::disconnect_drops_subscriptions` — peer
      re-issues from `PeerDialerConfig::subscribe_patterns` on every
      reconnect).
- [ ] Cross-host smoke test (VPS hub + Mac peer over tailnet under
      200ms): not run from this PR — requires deploy. The localhost
      integration test rounds-trip in <10ms; tailnet latency is the
      transport layer's concern.
- [x] `cargo fmt --check && cargo clippy --lib --bins --tests -- -D warnings && cargo test` passes.

## Design decisions

- **Frame extension**: `BusMessage` itself stays untouched on the wire.
  Federated traffic uses a new `Forward { origin, message }` variant; the
  hub treats legacy `BusMessage` frames (without `origin`) as
  `origin = peer_name`. Keeps local-bus protocol untouched and gives a
  clean loop-prevention seam.
- **`LocalBusInjector` trait**: separates the routing/forwarding logic
  from the local-bus client. Tests use a capturing stub; production
  glue can drop in a Unix-socket-bus injector without touching the
  middleware. This deliberately defers the bus-side connector to a
  smaller follow-up.
- **In-memory routing table**: per the ticket — subscriptions live in
  memory and are dropped on disconnect. SQLite persistence is reserved
  for #464's replay log.
- **Inbox routing**: a separate bucket from pattern subscriptions —
  `match_inbox` handles both `inbox/<name>` and the cross-device
  `inbox/<name>@<peer>` shape called out in the epic.
- **Peer session handle**: `PeerSessionHandle` exposes a `send(frame)`
  API for locally-originated outbound frames; swaps the inner sender
  on each reconnect, drops frames published while disconnected (replay
  belongs in #464).

## Test plan

- [x] `cargo test --lib federation` — 59 unit tests
      (glob, routing, forward, hub subscribe/disconnect lifecycle,
      frame round-trips, peer dialer reconnect)
- [x] `cargo test --test federation_forward` — 2 integration tests
      covering the round-trip smoke scenario (hub→peer fanout,
      peer→hub publish, loop prevention) and the unsubscribe path
- [x] `cargo test --test federation_smoke` — existing smoke tests
      remain green
- [x] `cargo test` — full suite: 752 lib tests + every integration
      file green
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --bins --tests -- -D warnings`

## Deferred (iteration 2)

- **Local-bus injection wiring**: production `LocalBusInjector` impl
  that publishes onto the Unix-socket bus. The trait + serve() wiring
  point are in; the connector is a one-file follow-up.
- **24h replay log + msg_id cursor** (#464): out of scope per the
  epic. `PeerRegistry::last_msg_id` column is already there from #462.
- **Per-topic ACLs** (iteration 2 per epic).
- **Cross-host (tailnet) smoke**: requires deploy to Mac + VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)