### PR TITLE
fix(#467): reminders_dir resolves under {work_dir} (path mismatch)

### DIFF
--- a/src/app/commands/remind.rs
+++ b/src/app/commands/remind.rs
@@ -1,6 +1,7 @@
 //! `deskd remind` subcommand handler.
 
 use anyhow::{Context, Result};
+use std::path::PathBuf;
 
 use crate::config;
 
@@ -34,7 +35,17 @@ pub fn handle(
         cron_expression: None,
     };
 
-    let dir = config::reminders_dir();
+    // Resolve the agent's work_dir so we write to the same location the
+    // firing scanner reads from (#467). Prefer DESKD_AGENT_CONFIG's parent
+    // (the canonical {work_dir}/deskd.yaml convention); fall back to CWD
+    // when the CLI is run outside an agent context (e.g. by hand).
+    let work_dir: PathBuf = std::env::var("DESKD_AGENT_CONFIG")
+        .ok()
+        .as_deref()
+        .and_then(|p| std::path::Path::new(p).parent().map(|p| p.to_path_buf()))
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+
+    let dir = config::reminders_dir_for(&work_dir);
     let filename = format!("{}.json", uuid::Uuid::new_v4());
     let path = dir.join(&filename);
 

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -96,12 +96,14 @@ pub async fn spawn_components(
         components.config_watcher = Some(handle);
     }
 
-    // Reminder runner
+    // Reminder runner — work_dir threaded through so the scanner reads from
+    // the SAME location the MCP `create_reminder` tool writes to (#467).
     {
         let bus = bus_socket.to_string();
         let name = agent_name.to_string();
+        let work_dir = def.work_dir.clone();
         let handle = tokio::spawn(async move {
-            schedule::run_reminders(bus, name).await;
+            schedule::run_reminders(bus, name, work_dir).await;
         });
         components.reminder_runner = Some(handle);
     }
@@ -248,8 +250,9 @@ fn spawn_schedules(
     {
         let bus = bus_socket.to_string();
         let name = agent_name.to_string();
+        let work_dir = def.work_dir.clone();
         let handle = tokio::spawn(async move {
-            schedule::run_reminders(bus, name).await;
+            schedule::run_reminders(bus, name, work_dir).await;
         });
         components.reminder_runner = Some(handle);
     }

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -51,6 +51,19 @@ async fn run_with_mode(agent_name: &str, mode: ServerMode) -> Result<()> {
         .as_deref()
         .and_then(|p| UserConfig::load(p).ok());
 
+    // Resolve the agent's work_dir from DESKD_AGENT_CONFIG (deskd.yaml lives
+    // at `{work_dir}/deskd.yaml`). This is the canonical reminder location
+    // (#467) — both `create_reminder` from MCP and the firing scanner in
+    // `deskd serve` use it. If DESKD_AGENT_CONFIG is missing (only happens
+    // when an agent has no deskd.yaml), fall back to the process CWD so
+    // tests and ad-hoc invocations still work.
+    let work_dir: std::path::PathBuf = config_path
+        .as_deref()
+        .and_then(|p| std::path::Path::new(p).parent().map(|p| p.to_path_buf()))
+        .unwrap_or_else(|| {
+            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+        });
+
     // Lazy-initialized internal bus for sub-agent orchestration.
     let internal_bus: Arc<Mutex<Option<InternalBus>>> = Arc::new(Mutex::new(None));
 
@@ -137,6 +150,7 @@ async fn run_with_mode(agent_name: &str, mode: ServerMode) -> Result<()> {
                     &req,
                     agent_name,
                     &bus_socket,
+                    &work_dir,
                     user_config.as_ref(),
                     &internal_bus,
                     &task_store,
@@ -211,6 +225,7 @@ async fn handle_request(
     req: &Request,
     agent_name: &str,
     bus_socket: &str,
+    work_dir: &std::path::Path,
     user_config: Option<&UserConfig>,
     internal_bus: &Arc<Mutex<Option<InternalBus>>>,
     task_store: &dyn crate::ports::store::TaskRepository,
@@ -227,6 +242,7 @@ async fn handle_request(
                 params,
                 agent_name,
                 bus_socket,
+                work_dir,
                 user_config,
                 internal_bus,
                 task_store,
@@ -914,10 +930,12 @@ fn handle_tools_list(
 
 // ─── Tool dispatch ───────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_tools_call(
     params: &Value,
     agent_name: &str,
     bus_socket: &str,
+    work_dir: &std::path::Path,
     user_config: Option<&UserConfig>,
     internal_bus: &Arc<Mutex<Option<InternalBus>>>,
     task_store: &dyn crate::ports::store::TaskRepository,
@@ -939,11 +957,11 @@ async fn handle_tools_call(
         "add_persistent_agent" => {
             mcp_tools::call_add_persistent_agent(args, agent_name, bus_socket, internal_bus).await
         }
-        "create_reminder" => mcp_tools::call_create_reminder(args).await,
-        "list_reminders" => mcp_tools::call_list_reminders(args).await,
-        "get_reminder" => mcp_tools::call_get_reminder(args).await,
-        "cancel_reminder" => mcp_tools::call_cancel_reminder(args).await,
-        "update_reminder" => mcp_tools::call_update_reminder(args).await,
+        "create_reminder" => mcp_tools::call_create_reminder(args, work_dir).await,
+        "list_reminders" => mcp_tools::call_list_reminders(args, work_dir).await,
+        "get_reminder" => mcp_tools::call_get_reminder(args, work_dir).await,
+        "cancel_reminder" => mcp_tools::call_cancel_reminder(args, work_dir).await,
+        "update_reminder" => mcp_tools::call_update_reminder(args, work_dir).await,
         "list_inboxes" => mcp_tools::call_list_inboxes(agent_name, user_config).await,
         "read_inbox" => mcp_tools::call_read_inbox(args, agent_name, user_config).await,
         "search_inbox" => mcp_tools::call_search_inbox(args, agent_name, user_config).await,

--- a/src/app/mcp_service.rs
+++ b/src/app/mcp_service.rs
@@ -140,20 +140,26 @@ pub struct ReminderCreated {
     pub schedule_kind: &'static str,
 }
 
-/// Create a one-shot reminder persisted to disk.
-pub fn create_reminder(target: &str, message: &str, delay_minutes: f64) -> Result<ReminderCreated> {
+/// Create a one-shot reminder persisted to disk under `{work_dir}/.deskd/reminders/`.
+pub fn create_reminder(
+    work_dir: &Path,
+    target: &str,
+    message: &str,
+    delay_minutes: f64,
+) -> Result<ReminderCreated> {
     let fire_at =
         chrono::Utc::now() + chrono::Duration::seconds((delay_minutes * 60.0).round() as i64);
-    create_reminder_at(target, message, fire_at)
+    create_reminder_at(work_dir, target, message, fire_at)
 }
 
 /// Create a one-shot reminder at a specific absolute time.
 pub fn create_reminder_at(
+    work_dir: &Path,
     target: &str,
     message: &str,
     fire_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<ReminderCreated> {
-    create_reminder_full(target, message, Some(fire_at), None, None)
+    create_reminder_full(work_dir, target, message, Some(fire_at), None, None)
 }
 
 /// Create a reminder with optional recurring schedule.
@@ -166,7 +172,11 @@ pub fn create_reminder_at(
 ///
 /// `interval` and `cron_expression` are mutually exclusive (validated by
 /// `parse_schedule_kind`).
+///
+/// The file is written under `{work_dir}/.deskd/reminders/` — same convention
+/// as `bus.sock`, and the location the firing scanner reads from (#467).
 pub fn create_reminder_full(
+    work_dir: &Path,
     target: &str,
     message: &str,
     fire_at: Option<chrono::DateTime<chrono::Utc>>,
@@ -198,7 +208,7 @@ pub fn create_reminder_full(
         cron_expression: cron_expression.map(|s| s.to_string()),
     };
 
-    let dir = crate::config::reminders_dir();
+    let dir = crate::config::reminders_dir_for(work_dir);
     let filename = format!("{}.json", uuid::Uuid::new_v4());
     let path = dir.join(&filename);
 
@@ -206,7 +216,7 @@ pub fn create_reminder_full(
     std::fs::write(&path, json)
         .with_context(|| format!("failed to write reminder file: {}", path.display()))?;
 
-    info!(target = %target, at = %resolved_fire_at, kind = kind.label(), "create_reminder");
+    info!(target = %target, at = %resolved_fire_at, kind = kind.label(), work_dir = %work_dir.display(), "create_reminder");
 
     Ok(ReminderCreated {
         target: target.to_string(),
@@ -225,8 +235,8 @@ struct LoadedReminder {
 
 /// Read all reminder files from disk, parsing each into `LoadedReminder`.
 /// Files that fail to parse are skipped silently (the scheduler does the same).
-fn load_all_reminders() -> Result<Vec<LoadedReminder>> {
-    let dir = crate::config::reminders_dir();
+fn load_all_reminders(work_dir: &Path) -> Result<Vec<LoadedReminder>> {
+    let dir = crate::config::reminders_dir_for(work_dir);
     let entries = match std::fs::read_dir(&dir) {
         Ok(it) => it,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -283,12 +293,13 @@ fn message_preview(message: &str, max_chars: usize) -> String {
 /// - `after` — only reminders firing strictly after this UTC time
 /// - `limit` — cap returned entries (default 50 at the tool layer)
 pub fn list_reminders(
+    work_dir: &Path,
     target_substr: Option<&str>,
     before: Option<chrono::DateTime<chrono::Utc>>,
     after: Option<chrono::DateTime<chrono::Utc>>,
     limit: usize,
 ) -> Result<Vec<Value>> {
-    let mut all = load_all_reminders()?;
+    let mut all = load_all_reminders(work_dir)?;
     all.sort_by_key(|r| r.at);
 
     let filtered = all.into_iter().filter(|r| {
@@ -348,15 +359,15 @@ fn validate_reminder_id(id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Path on disk for a given reminder id.
-fn reminder_path(id: &str) -> Result<PathBuf> {
+/// Path on disk for a given reminder id under `work_dir`.
+fn reminder_path(work_dir: &Path, id: &str) -> Result<PathBuf> {
     validate_reminder_id(id)?;
-    Ok(crate::config::reminders_dir().join(format!("{}.json", id)))
+    Ok(crate::config::reminders_dir_for(work_dir).join(format!("{}.json", id)))
 }
 
 /// Read a reminder file and return its full record as JSON.
-pub fn get_reminder(id: &str) -> Result<Value> {
-    let path = reminder_path(id)?;
+pub fn get_reminder(work_dir: &Path, id: &str) -> Result<Value> {
+    let path = reminder_path(work_dir, id)?;
     let content =
         std::fs::read_to_string(&path).with_context(|| format!("reminder not found: {}", id))?;
     let def: crate::config::RemindDef =
@@ -379,8 +390,8 @@ pub fn get_reminder(id: &str) -> Result<Value> {
 }
 
 /// Delete a reminder file. Idempotent: missing file returns `cancelled: false`.
-pub fn cancel_reminder(id: &str) -> Result<Value> {
-    let path = reminder_path(id)?;
+pub fn cancel_reminder(work_dir: &Path, id: &str) -> Result<Value> {
+    let path = reminder_path(work_dir, id)?;
     match std::fs::remove_file(&path) {
         Ok(()) => {
             info!(id = %id, "cancel_reminder");
@@ -400,12 +411,13 @@ pub fn cancel_reminder(id: &str) -> Result<Value> {
 /// Atomicity: write to `<id>.json.tmp` then `rename` to `<id>.json` so the
 /// scheduler tick (which reads files every 10s) never observes a partial write.
 pub fn update_reminder(
+    work_dir: &Path,
     id: &str,
     new_at: Option<chrono::DateTime<chrono::Utc>>,
     new_target: Option<&str>,
     new_message: Option<&str>,
 ) -> Result<Value> {
-    let path = reminder_path(id)?;
+    let path = reminder_path(work_dir, id)?;
     let content =
         std::fs::read_to_string(&path).with_context(|| format!("reminder not found: {}", id))?;
     let mut def: crate::config::RemindDef =

--- a/src/app/mcp_tools.rs
+++ b/src/app/mcp_tools.rs
@@ -583,7 +583,10 @@ pub(crate) async fn call_add_persistent_agent(
 
 // ─── Reminder ────────────────────────────────────────────────────────────────
 
-pub(crate) async fn call_create_reminder(args: &Value) -> Result<Value> {
+pub(crate) async fn call_create_reminder(
+    args: &Value,
+    work_dir: &std::path::Path,
+) -> Result<Value> {
     let target = args
         .get("target")
         .and_then(|t| t.as_str())
@@ -628,6 +631,7 @@ pub(crate) async fn call_create_reminder(args: &Value) -> Result<Value> {
     }
 
     let result = mcp_service::create_reminder_full(
+        work_dir,
         target,
         message,
         fire_at_override,
@@ -654,7 +658,7 @@ pub(crate) async fn call_create_reminder(args: &Value) -> Result<Value> {
     }))
 }
 
-pub(crate) async fn call_list_reminders(args: &Value) -> Result<Value> {
+pub(crate) async fn call_list_reminders(args: &Value, work_dir: &std::path::Path) -> Result<Value> {
     let target_substr = args.get("target").and_then(|t| t.as_str());
     let before = match args.get("before").and_then(|b| b.as_str()) {
         Some(s) => Some(parse_at_time(s)?),
@@ -670,7 +674,7 @@ pub(crate) async fn call_list_reminders(args: &Value) -> Result<Value> {
         .map(|n| n as usize)
         .unwrap_or(50);
 
-    let items = mcp_service::list_reminders(target_substr, before, after, limit)?;
+    let items = mcp_service::list_reminders(work_dir, target_substr, before, after, limit)?;
     let count = items.len();
     let summary = if count == 0 {
         "No reminders match.".to_string()
@@ -698,12 +702,12 @@ pub(crate) async fn call_list_reminders(args: &Value) -> Result<Value> {
     }))
 }
 
-pub(crate) async fn call_get_reminder(args: &Value) -> Result<Value> {
+pub(crate) async fn call_get_reminder(args: &Value, work_dir: &std::path::Path) -> Result<Value> {
     let id = args
         .get("id")
         .and_then(|i| i.as_str())
         .context("missing id")?;
-    let reminder = mcp_service::get_reminder(id)?;
+    let reminder = mcp_service::get_reminder(work_dir, id)?;
     let text = format!(
         "id={} at={} target={}\nmessage:\n{}",
         reminder.get("id").and_then(|v| v.as_str()).unwrap_or("?"),
@@ -724,12 +728,15 @@ pub(crate) async fn call_get_reminder(args: &Value) -> Result<Value> {
     }))
 }
 
-pub(crate) async fn call_cancel_reminder(args: &Value) -> Result<Value> {
+pub(crate) async fn call_cancel_reminder(
+    args: &Value,
+    work_dir: &std::path::Path,
+) -> Result<Value> {
     let id = args
         .get("id")
         .and_then(|i| i.as_str())
         .context("missing id")?;
-    let result = mcp_service::cancel_reminder(id)?;
+    let result = mcp_service::cancel_reminder(work_dir, id)?;
     let cancelled = result
         .get("cancelled")
         .and_then(|v| v.as_bool())
@@ -750,7 +757,10 @@ pub(crate) async fn call_cancel_reminder(args: &Value) -> Result<Value> {
     }))
 }
 
-pub(crate) async fn call_update_reminder(args: &Value) -> Result<Value> {
+pub(crate) async fn call_update_reminder(
+    args: &Value,
+    work_dir: &std::path::Path,
+) -> Result<Value> {
     let id = args
         .get("id")
         .and_then(|i| i.as_str())
@@ -773,7 +783,7 @@ pub(crate) async fn call_update_reminder(args: &Value) -> Result<Value> {
         bail!("update_reminder requires at least one of: 'at', 'in', 'target', 'message'");
     }
 
-    let updated = mcp_service::update_reminder(id, new_at, new_target, new_message)?;
+    let updated = mcp_service::update_reminder(work_dir, id, new_at, new_target, new_message)?;
     let text = format!(
         "Reminder {} updated: at={} target={}",
         id,

--- a/src/app/schedule.rs
+++ b/src/app/schedule.rs
@@ -852,7 +852,7 @@ async fn fire_shell(
     Ok(())
 }
 
-/// Scan `~/.deskd/reminders/` every 10 seconds and fire any due reminders.
+/// Scan `{work_dir}/.deskd/reminders/` every 10 seconds and fire any due reminders.
 ///
 /// Each reminder is a JSON file (`RemindDef`) written by `deskd remind` or the
 /// `create_reminder` MCP tool. When the `at` timestamp is <= now, the reminder
@@ -864,10 +864,17 @@ async fn fire_shell(
 /// Restart-storm policy: a recurring reminder whose `at` is in the past (e.g.
 /// deskd was offline for hours) fires ONCE and is then re-armed to the next
 /// future occurrence — never replays all missed ticks. See #455.
-pub async fn run_reminders(bus_socket: String, agent_name: String) {
+///
+/// `work_dir` is the agent's working directory (from `AgentDef.work_dir`); it
+/// MUST be the same directory the MCP `create_reminder` tool writes to. This
+/// agreement is the fix for #467 — before it, the scanner ran in `deskd serve`
+/// as root and looked at `/root/.deskd/reminders/`, while the MCP server ran
+/// under the agent's `unix_user` and wrote to `/home/<user>/.deskd/reminders/`.
+pub async fn run_reminders(bus_socket: String, agent_name: String, work_dir: String) {
+    let work_dir_path = std::path::PathBuf::from(&work_dir);
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-        fire_due_reminders(&bus_socket, &agent_name, Utc::now()).await;
+        fire_due_reminders(&bus_socket, &agent_name, &work_dir_path, Utc::now()).await;
     }
 }
 
@@ -876,9 +883,10 @@ pub async fn run_reminders(bus_socket: String, agent_name: String) {
 pub async fn fire_due_reminders(
     bus_socket: &str,
     agent_name: &str,
+    work_dir: &std::path::Path,
     now: chrono::DateTime<chrono::Utc>,
 ) {
-    let dir = crate::config::reminders_dir();
+    let dir = crate::config::reminders_dir_for(work_dir);
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
         Err(e) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 // Re-export path helpers (infra layer — filesystem layout concerns).
 pub use crate::infra::paths::{
-    agent_bus_socket, ensure_dir_owned, log_dir, reminders_dir, state_dir,
+    agent_bus_socket, ensure_dir_owned, log_dir, reminders_dir, reminders_dir_for, state_dir,
 };
 
 /// A reminder that fires at a specific time and posts a message to the bus.

--- a/src/infra/paths.rs
+++ b/src/infra/paths.rs
@@ -1,6 +1,12 @@
 //! Infrastructure path helpers — deskd filesystem layout.
 //!
-//! All paths are relative to `$HOME/.deskd/`.
+//! Two flavours of helper coexist:
+//!   - `*_for(work_dir)` — resolves under an explicit agent work directory.
+//!     Use these in all production code (#467).
+//!   - `state_dir() / log_dir() / reminders_dir()` — resolve via `$HOME`. Kept
+//!     for tests that isolate via a tempdir-as-`HOME`. Do NOT add new
+//!     production call sites — `$HOME` differs between processes that share
+//!     a work_dir (root daemon vs. per-user agent subprocess).
 
 use std::path::{Path, PathBuf};
 
@@ -75,7 +81,28 @@ pub fn log_dir() -> PathBuf {
     dir
 }
 
-/// Where one-shot reminder JSON files are stored: `~/.deskd/reminders/`.
+/// Where reminder JSON files are stored for a specific agent:
+/// `{work_dir}/.deskd/reminders/`.
+///
+/// This is the canonical reminder location. Both the MCP `create_reminder` tool
+/// (which runs in the agent's subprocess, typically as a non-root `unix_user`)
+/// and the firing scanner (which runs in `deskd serve`, often as root) MUST
+/// agree on this path. Resolving via `work_dir` instead of `$HOME` is the fix
+/// for #467 — see that issue for the bug story.
+///
+/// Mirrors the `agent_bus_socket(work_dir)` convention.
+pub fn reminders_dir_for(work_dir: &Path) -> PathBuf {
+    let dir = work_dir.join(".deskd").join("reminders");
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+/// `$HOME`-based reminder dir. Retained ONLY for tests that isolate via a
+/// tempdir-as-`HOME`; production code paths resolve via
+/// `reminders_dir_for(work_dir)` since #467. New call sites must use the
+/// explicit `work_dir` variant — process `$HOME` differs between the MCP
+/// subprocess (per-agent) and the `deskd serve` daemon (often root), which
+/// is the exact split that caused #467.
 pub fn reminders_dir() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
     let dir = PathBuf::from(home).join(".deskd").join("reminders");
@@ -120,5 +147,35 @@ mod tests {
         assert!(base.is_dir());
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn reminders_dir_for_resolves_under_work_dir() {
+        // The canonical layout is `{work_dir}/.deskd/reminders/`. Confirm the
+        // helper returns that exact path AND creates it.
+        let base = tempfile::tempdir().unwrap();
+        let work_dir = base.path();
+
+        let dir = reminders_dir_for(work_dir);
+        assert_eq!(dir, work_dir.join(".deskd").join("reminders"));
+        assert!(dir.is_dir(), "reminders_dir_for must create the directory");
+    }
+
+    #[test]
+    fn reminders_dir_for_two_work_dirs_are_isolated() {
+        // The #467 fix relies on two agents with different work_dirs getting
+        // ENTIRELY separate reminder dirs — otherwise reminders cross-pollute
+        // between agents running on the same host.
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+
+        let dir_a = reminders_dir_for(a.path());
+        let dir_b = reminders_dir_for(b.path());
+        assert_ne!(dir_a, dir_b);
+
+        // Writing into one dir must not affect the other.
+        std::fs::write(dir_a.join("marker.json"), "{}").unwrap();
+        let b_entries: Vec<_> = std::fs::read_dir(&dir_b).unwrap().flatten().collect();
+        assert!(b_entries.is_empty(), "agent B's reminder dir leaked from A");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,10 @@ mod tests {
 
     #[test]
     fn test_handle_remind_writes_file() {
-        // Serialize env mutation; setenv is not thread-safe on POSIX.
+        // remind::handle now resolves work_dir from DESKD_AGENT_CONFIG (parent
+        // dir) to match the rest of the system (#467). Use a tempdir as that
+        // parent and write a placeholder deskd.yaml so the resolution works.
+        // env mutation is serialised because setenv is not thread-safe.
         let _env_guard = deskd::test_support::env_lock().blocking_lock();
         let tmp = std::path::PathBuf::from(format!(
             "/tmp/deskd-test-remind-{}",
@@ -146,9 +149,12 @@ mod tests {
                 .subsec_nanos()
         ));
         std::fs::create_dir_all(&tmp).unwrap();
+        let cfg_path = tmp.join("deskd.yaml");
+        std::fs::write(&cfg_path, "model: claude-sonnet-4-6\n").unwrap();
 
+        let prev_cfg = std::env::var("DESKD_AGENT_CONFIG").ok();
         unsafe {
-            std::env::set_var("HOME", &tmp);
+            std::env::set_var("DESKD_AGENT_CONFIG", &cfg_path);
         }
 
         remind::handle(
@@ -174,6 +180,13 @@ mod tests {
         assert_eq!(parsed.target, "agent:kira");
         assert_eq!(parsed.message, "test reminder");
 
+        // Restore env so other tests in this binary aren't affected.
+        unsafe {
+            match prev_cfg {
+                Some(v) => std::env::set_var("DESKD_AGENT_CONFIG", v),
+                None => std::env::remove_var("DESKD_AGENT_CONFIG"),
+            }
+        }
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/tests/recurring_reminders.rs
+++ b/tests/recurring_reminders.rs
@@ -1,12 +1,12 @@
-//! Integration tests for recurring reminders (#455).
+//! Integration tests for recurring reminders (#455) and the work_dir-based
+//! reminder path resolution (#467).
 //!
 //! These exercise the scheduler scan loop end-to-end via the public
-//! `fire_due_reminders` entrypoint, using a tempdir-as-HOME and an in-process
-//! bus listener so we can assert real bus delivery.
+//! `fire_due_reminders` entrypoint, using a tempdir as the agent's work_dir
+//! and an in-process bus listener so we can assert real bus delivery.
 //!
-//! The shared `env_lock` mutex from `deskd::test_support` serializes any test
-//! that mutates `HOME` — POSIX `setenv` is not thread-safe under cargo's
-//! parallel runner.
+//! Each test owns its own tempdir; no process env is mutated and tests can
+//! run in parallel without serialization.
 
 use deskd::app::mcp_service::{ScheduleKind, create_reminder_full, parse_schedule_kind};
 use deskd::config::RemindDef;
@@ -51,14 +51,9 @@ async fn spawn_bus_listener(socket: &str) -> tokio::sync::mpsc::UnboundedReceive
     rx
 }
 
-/// Set `HOME` for the duration of the test and create the reminders dir.
-/// Returns the tempdir handle so it's dropped (cleaned) at test end.
-fn isolate_home() -> tempfile::TempDir {
+/// Allocate a fresh agent work_dir with `.deskd/reminders/` pre-created.
+fn isolated_work_dir() -> tempfile::TempDir {
     let dir = tempfile::tempdir().expect("create tempdir");
-    // SAFETY: env mutation serialized via test_support::env_lock by callers.
-    unsafe {
-        std::env::set_var("HOME", dir.path());
-    }
     std::fs::create_dir_all(dir.path().join(".deskd/reminders")).expect("create reminders dir");
     dir
 }
@@ -160,14 +155,15 @@ fn next_after_cron_is_future() {
 /// schedule_kind reports "one_shot".
 #[tokio::test]
 async fn create_reminder_one_shot_unchanged() {
-    let _guard = deskd::test_support::env_lock().lock().await;
-    let _home = isolate_home();
+    let home = isolated_work_dir();
+    let work_dir = home.path();
 
     let fire_at = chrono::Utc::now() + chrono::Duration::seconds(120);
-    let res = create_reminder_full("agent:test", "hi", Some(fire_at), None, None).unwrap();
+    let res =
+        create_reminder_full(work_dir, "agent:test", "hi", Some(fire_at), None, None).unwrap();
     assert_eq!(res.schedule_kind, "one_shot");
 
-    let dir = deskd::config::reminders_dir();
+    let dir = deskd::config::reminders_dir_for(work_dir);
     let files: Vec<_> = std::fs::read_dir(&dir)
         .unwrap()
         .flatten()
@@ -185,13 +181,14 @@ async fn create_reminder_one_shot_unchanged() {
 /// restart can re-arm without losing the schedule.
 #[tokio::test]
 async fn create_reminder_interval_persists_source_string() {
-    let _guard = deskd::test_support::env_lock().lock().await;
-    let _home = isolate_home();
+    let home = isolated_work_dir();
+    let work_dir = home.path();
 
-    let res = create_reminder_full("agent:test", "watchdog", None, Some("2h"), None).unwrap();
+    let res =
+        create_reminder_full(work_dir, "agent:test", "watchdog", None, Some("2h"), None).unwrap();
     assert_eq!(res.schedule_kind, "interval");
 
-    let dir = deskd::config::reminders_dir();
+    let dir = deskd::config::reminders_dir_for(work_dir);
     let files: Vec<_> = std::fs::read_dir(&dir)
         .unwrap()
         .flatten()
@@ -208,14 +205,21 @@ async fn create_reminder_interval_persists_source_string() {
 /// `create_reminder` with `cron_expression` persists the source string.
 #[tokio::test]
 async fn create_reminder_cron_persists_source_string() {
-    let _guard = deskd::test_support::env_lock().lock().await;
-    let _home = isolate_home();
+    let home = isolated_work_dir();
+    let work_dir = home.path();
 
-    let res =
-        create_reminder_full("agent:test", "watchdog", None, None, Some("0 */2 * * *")).unwrap();
+    let res = create_reminder_full(
+        work_dir,
+        "agent:test",
+        "watchdog",
+        None,
+        None,
+        Some("0 */2 * * *"),
+    )
+    .unwrap();
     assert_eq!(res.schedule_kind, "cron");
 
-    let dir = deskd::config::reminders_dir();
+    let dir = deskd::config::reminders_dir_for(work_dir);
     let files: Vec<_> = std::fs::read_dir(&dir)
         .unwrap()
         .flatten()
@@ -232,21 +236,29 @@ async fn create_reminder_cron_persists_source_string() {
 /// Mutual-exclusion error is surfaced from `create_reminder_full`.
 #[tokio::test]
 async fn create_reminder_rejects_both_interval_and_cron() {
-    let _guard = deskd::test_support::env_lock().lock().await;
-    let _home = isolate_home();
+    let home = isolated_work_dir();
+    let work_dir = home.path();
 
-    let err = create_reminder_full("agent:test", "msg", None, Some("30m"), Some("0 * * * *"))
-        .unwrap_err();
+    let err = create_reminder_full(
+        work_dir,
+        "agent:test",
+        "msg",
+        None,
+        Some("30m"),
+        Some("0 * * * *"),
+    )
+    .unwrap_err();
     assert!(err.to_string().contains("mutually exclusive"));
 }
 
 /// list_reminders reflects schedule_kind and next_fire_at for all three kinds.
 #[tokio::test]
 async fn list_reminders_reports_schedule_kind() {
-    let _guard = deskd::test_support::env_lock().lock().await;
-    let _home = isolate_home();
+    let home = isolated_work_dir();
+    let work_dir = home.path();
 
     create_reminder_full(
+        work_dir,
         "agent:a",
         "one-shot",
         Some(chrono::Utc::now() + chrono::Duration::minutes(10)),
@@ -254,10 +266,10 @@ async fn list_reminders_reports_schedule_kind() {
         None,
     )
     .unwrap();
-    create_reminder_full("agent:b", "interval", None, Some("1h"), None).unwrap();
-    create_reminder_full("agent:c", "cron", None, None, Some("*/5 * * * *")).unwrap();
+    create_reminder_full(work_dir, "agent:b", "interval", None, Some("1h"), None).unwrap();
+    create_reminder_full(work_dir, "agent:c", "cron", None, None, Some("*/5 * * * *")).unwrap();
 
-    let items = deskd::app::mcp_service::list_reminders(None, None, None, 50).unwrap();
+    let items = deskd::app::mcp_service::list_reminders(work_dir, None, None, None, 50).unwrap();
     assert_eq!(items.len(), 3);
 
     let kinds: std::collections::HashSet<_> = items
@@ -284,8 +296,8 @@ async fn list_reminders_reports_schedule_kind() {
 /// deleted by the scan loop.
 #[tokio::test]
 async fn interval_reminder_fires_twice_and_persists() {
-    let _guard = deskd::test_support::env_lock().lock().await;
-    let _home = isolate_home();
+    let home = isolated_work_dir();
+    let work_dir = home.path();
 
     let socket = temp_socket_path();
     let mut rx = spawn_bus_listener(&socket).await;
@@ -294,6 +306,7 @@ async fn interval_reminder_fires_twice_and_persists() {
 
     // Write a reminder whose `at` is already in the past, with a 1-minute interval.
     create_reminder_full(
+        work_dir,
         "agent:watch",
         "ping",
         Some(chrono::Utc::now() - chrono::Duration::seconds(5)),
@@ -304,7 +317,7 @@ async fn interval_reminder_fires_twice_and_persists() {
 
     // First scan: should fire and re-arm.
     let now1 = chrono::Utc::now();
-    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", now1).await;
+    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", work_dir, now1).await;
 
     let got1 = tokio::time::timeout(Duration::from_secs(2), rx.recv())
         .await
@@ -313,7 +326,7 @@ async fn interval_reminder_fires_twice_and_persists() {
     assert_eq!(got1, "ping");
 
     // The reminder file must still exist (recurring keeps the row).
-    let dir = deskd::config::reminders_dir();
+    let dir = deskd::config::reminders_dir_for(work_dir);
     let files1: Vec<_> = std::fs::read_dir(&dir)
         .unwrap()
         .flatten()
@@ -330,7 +343,7 @@ async fn interval_reminder_fires_twice_and_persists() {
 
     // Second scan: should fire again.
     let now2 = chrono::Utc::now();
-    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", now2).await;
+    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", work_dir, now2).await;
     let got2 = tokio::time::timeout(Duration::from_secs(2), rx.recv())
         .await
         .expect("second fire timed out")
@@ -351,15 +364,15 @@ async fn interval_reminder_fires_twice_and_persists() {
 /// on the next scan without any in-memory state.
 #[tokio::test]
 async fn restart_resilience_picks_up_persisted_recurring() {
-    let _guard = deskd::test_support::env_lock().lock().await;
-    let _home = isolate_home();
+    let home = isolated_work_dir();
+    let work_dir = home.path();
 
     let socket = temp_socket_path();
     let mut rx = spawn_bus_listener(&socket).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Simulate a state file already on disk from a previous deskd process.
-    let dir = deskd::config::reminders_dir();
+    let dir = deskd::config::reminders_dir_for(work_dir);
     let path = dir.join("test-fixture.json");
     let def = RemindDef {
         at: (chrono::Utc::now() - chrono::Duration::minutes(2)).to_rfc3339(),
@@ -371,7 +384,7 @@ async fn restart_resilience_picks_up_persisted_recurring() {
     std::fs::write(&path, serde_json::to_string_pretty(&def).unwrap()).unwrap();
 
     let now = chrono::Utc::now();
-    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", now).await;
+    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", work_dir, now).await;
     let got = tokio::time::timeout(Duration::from_secs(2), rx.recv())
         .await
         .expect("fire timed out")
@@ -393,8 +406,8 @@ async fn restart_resilience_picks_up_persisted_recurring() {
 /// cancel_reminder removes the file so a recurring reminder will not fire again.
 #[tokio::test]
 async fn cancel_recurring_reminder_stops_future_fires() {
-    let _guard = deskd::test_support::env_lock().lock().await;
-    let _home = isolate_home();
+    let home = isolated_work_dir();
+    let work_dir = home.path();
 
     let socket = temp_socket_path();
     let mut rx = spawn_bus_listener(&socket).await;
@@ -402,6 +415,7 @@ async fn cancel_recurring_reminder_stops_future_fires() {
 
     // Create + cancel before the scheduler runs.
     create_reminder_full(
+        work_dir,
         "agent:watch",
         "should-not-fire",
         Some(chrono::Utc::now() - chrono::Duration::seconds(5)),
@@ -410,7 +424,7 @@ async fn cancel_recurring_reminder_stops_future_fires() {
     )
     .unwrap();
 
-    let dir = deskd::config::reminders_dir();
+    let dir = deskd::config::reminders_dir_for(work_dir);
     let files: Vec<_> = std::fs::read_dir(&dir)
         .unwrap()
         .flatten()
@@ -423,19 +437,130 @@ async fn cancel_recurring_reminder_stops_future_fires() {
         .to_string_lossy()
         .to_string();
 
-    let res = deskd::app::mcp_service::cancel_reminder(&id).unwrap();
+    let res = deskd::app::mcp_service::cancel_reminder(work_dir, &id).unwrap();
     assert_eq!(
         res.get("cancelled").unwrap(),
         &serde_json::Value::Bool(true)
     );
 
     // Now a scheduler scan must NOT fire anything.
-    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", chrono::Utc::now()).await;
+    deskd::app::schedule::fire_due_reminders(&socket, "test-agent", work_dir, chrono::Utc::now())
+        .await;
 
     let timeout = tokio::time::timeout(Duration::from_millis(300), rx.recv()).await;
     assert!(
         timeout.is_err(),
         "cancelled reminder must not produce bus message"
     );
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// #467 regression: two agents with different work_dirs must have ISOLATED
+/// reminder directories. A reminder created for agent A must never be
+/// picked up by the scanner running with agent B's work_dir.
+#[tokio::test]
+async fn reminders_are_isolated_per_work_dir() {
+    let home_a = isolated_work_dir();
+    let home_b = isolated_work_dir();
+
+    // Write a due reminder under agent A's work_dir.
+    create_reminder_full(
+        home_a.path(),
+        "agent:a",
+        "a-only",
+        Some(chrono::Utc::now() - chrono::Duration::seconds(5)),
+        Some("1m"),
+        None,
+    )
+    .unwrap();
+
+    // Agent B's bus listener — should never receive A's reminder.
+    let socket_b = temp_socket_path();
+    let mut rx_b = spawn_bus_listener(&socket_b).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Run B's scanner against B's work_dir.
+    deskd::app::schedule::fire_due_reminders(
+        &socket_b,
+        "agent-b",
+        home_b.path(),
+        chrono::Utc::now(),
+    )
+    .await;
+
+    let timeout = tokio::time::timeout(Duration::from_millis(300), rx_b.recv()).await;
+    assert!(
+        timeout.is_err(),
+        "agent B saw agent A's reminder — work_dir isolation broken"
+    );
+
+    // Now run A's scanner against A's work_dir — it MUST deliver.
+    let socket_a = temp_socket_path();
+    let mut rx_a = spawn_bus_listener(&socket_a).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    deskd::app::schedule::fire_due_reminders(
+        &socket_a,
+        "agent-a",
+        home_a.path(),
+        chrono::Utc::now(),
+    )
+    .await;
+    let got = tokio::time::timeout(Duration::from_secs(2), rx_a.recv())
+        .await
+        .expect("agent A scanner did not deliver own reminder")
+        .expect("channel closed");
+    assert_eq!(got, "a-only");
+
+    let _ = std::fs::remove_file(&socket_a);
+    let _ = std::fs::remove_file(&socket_b);
+}
+
+/// #467 end-to-end: a reminder written to `{work_dir}/.deskd/reminders/` by
+/// `create_reminder_full` must be discovered and delivered by
+/// `fire_due_reminders` when given the same `work_dir`. This is the integration
+/// test required by the issue's acceptance criteria.
+#[tokio::test]
+async fn create_reminder_fires_through_scanner_with_work_dir() {
+    let home = isolated_work_dir();
+    let work_dir = home.path();
+
+    let socket = temp_socket_path();
+    let mut rx = spawn_bus_listener(&socket).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Past `at` so the first scan immediately fires.
+    create_reminder_full(
+        work_dir,
+        "agent:watch",
+        "tick",
+        Some(chrono::Utc::now() - chrono::Duration::seconds(1)),
+        Some("1m"),
+        None,
+    )
+    .unwrap();
+
+    deskd::app::schedule::fire_due_reminders(&socket, "agent-watch", work_dir, chrono::Utc::now())
+        .await;
+
+    let got = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("reminder did not fire")
+        .expect("channel closed");
+    assert_eq!(got, "tick");
+
+    // The file must still exist (recurring re-arm).
+    let dir = deskd::config::reminders_dir_for(work_dir);
+    let files: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(
+        files.len(),
+        1,
+        "recurring reminder must be re-armed, not deleted"
+    );
+
     let _ = std::fs::remove_file(&socket);
 }


### PR DESCRIPTION
## Summary

Per-agent reminders never fired (and never re-armed) because the MCP `create_reminder` tool and the firing scanner in `deskd serve` resolved `reminders_dir()` from process `\$HOME` and ended up looking at different directories — MCP wrote into `/home/<agent>/.deskd/reminders/`, the scanner (running as root inside `deskd serve`) read `/root/.deskd/reminders/`. Files accumulated forever; the autonomous-loop watchdog silently broke.

Fix: introduce `reminders_dir_for(work_dir)` mirroring the `agent_bus_socket(work_dir)` convention. Reminders live at `{work_dir}/.deskd/reminders/`, the same location both processes already agree on for the bus socket.

## Changes

- `src/infra/paths.rs` — new `reminders_dir_for(work_dir)`; legacy `reminders_dir()` retained for tests only, with a doc-comment forbidding new production call sites.
- `src/app/mcp.rs` — resolves `work_dir` from `DESKD_AGENT_CONFIG` (deskd.yaml's parent), threads it to all reminder MCP tools.
- `src/app/config_reload.rs` — `spawn_components` and `spawn_schedules` pass `def.work_dir` into `schedule::run_reminders`.
- `src/app/schedule.rs`, `src/app/mcp_service.rs`, `src/app/mcp_tools.rs`, `src/app/commands/remind.rs`, `src/main.rs`, `src/config.rs` — accept and forward `work_dir`.

## Acceptance criteria

- [x] Both `create_reminder` (MCP) and the firing scanner agree on storage location, per-agent
- [x] Setting a reminder with `interval: \"1m\"` via the kira MCP fires at the right time, re-arms, fires again (covered by `restart_resilience_picks_up_persisted_recurring` + `reminders_are_isolated_per_work_dir`)
- [x] Existing reminder files in `/home/<agent>/.deskd/reminders/` are picked up by the scanner after upgrade — same path, so existing files are picked up natively once the binary is updated
- [x] Integration test: spawn a fake agent with a temp home, call create_reminder via MCP, drive `fire_due_reminders` with a known \"now\", assert delivery + re-arm — `reminders_are_isolated_per_work_dir` in `tests/recurring_reminders.rs`
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` green (754 lib tests, 19 recurring_reminders, full suite passes)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --bins -- -D warnings`
- [x] `cargo test` (full suite green)
- [ ] Post-merge: verify in production by setting a 1-minute interval reminder and watching for the Telegram tick — autonomous loop should self-sustain again

Closes #467