### PR TITLE
fix(#475): pr-review-merge graph — remote detection + atomic merge

### DIFF
--- a/graphs/pr-review-merge.yaml
+++ b/graphs/pr-review-merge.yaml
@@ -56,7 +56,18 @@ steps:
     condition: "'merge' in action"
     tools:
       - tool: bash
-        args: "cd {work_dir} && git checkout -b _pr_{pr_number} kira/{branch} 2>&1 && git rebase main 2>&1"
+        args: |
+          cd {work_dir} && \
+          if git rev-parse --verify origin/{branch} >/dev/null 2>&1; then \
+            REMOTE=origin; \
+          elif git rev-parse --verify kira/{branch} >/dev/null 2>&1; then \
+            REMOTE=kira; \
+          else \
+            echo "FATAL: branch {branch} not found on origin or kira (post-fetch)" >&2; exit 1; \
+          fi && \
+          echo "PR branch resolved to: $REMOTE/{branch}" && \
+          git checkout -b _pr_{pr_number} $REMOTE/{branch} 2>&1 && \
+          git rebase main 2>&1
 
   - id: quality_check
     depends_on: [rebase_branch]
@@ -75,46 +86,37 @@ steps:
       - tool: bash
         args: "cd {work_dir} && ~/.cargo/bin/cargo fmt 2>&1"
 
-  - id: squash_merge
+  # Single atomic step: merge → close PR → tag release.
+  # Chained with `set -euo pipefail` so any failure (e.g. push rejection,
+  # remote misconfiguration) aborts BEFORE the PR is closed or the tag is
+  # pushed. The graph engine's condition language can't gate on a prior
+  # step's exit code, so collapsing avoids the false-positive "merged"
+  # signal that #475 (and the #460 incident) reported.
+  - id: merge_close_tag
     depends_on: [fix_fmt]
     condition: "'merge' in action"
     tools:
       - tool: bash
-        args: >
-          cd {work_dir} &&
-          git checkout main &&
-          git merge --squash _pr_{pr_number} &&
-          git commit -m "{title} (#{pr_number})" &&
-          git push origin main 2>&1
-
-  - id: cleanup_branch
-    depends_on: [squash_merge]
-    condition: "'merge' in action"
-    tools:
-      - tool: bash
-        args: "cd {work_dir} && git branch -D _pr_{pr_number} 2>&1"
-
-  - id: close_pr
-    depends_on: [squash_merge]
-    condition: "'merge' in action"
-    tools:
-      - tool: bash
-        args: "gh pr close {pr_number} --repo {repo} --comment 'Merged to main via skill graph.' 2>&1"
-
-  - id: tag_release
-    depends_on: [squash_merge]
-    condition: "'merge' in action"
-    tools:
-      - tool: bash
-        args: >
-          cd {work_dir} &&
-          LATEST=$(git tag -l 'v*' | sort -V | tail -1) &&
-          MAJOR=$(echo $LATEST | cut -d. -f1) &&
-          MINOR=$(echo $LATEST | cut -d. -f2) &&
-          PATCH=$(echo $LATEST | cut -d. -f3) &&
-          NEXT="$MAJOR.$MINOR.$((PATCH+1))" &&
-          git tag $NEXT &&
-          git push origin $NEXT 2>&1 &&
+        args: |
+          set -euo pipefail
+          cd {work_dir}
+          # 1. Merge to origin/main. If this fails, nothing below runs.
+          git checkout main
+          git merge --squash _pr_{pr_number}
+          git commit -m "{title} (#{pr_number})"
+          git push origin main
+          # 2. Merge succeeded — safe to close the PR.
+          gh pr close {pr_number} --repo {repo} --comment 'Merged to main via skill graph.'
+          # 3. Local cleanup (non-fatal but useful).
+          git branch -D _pr_{pr_number}
+          # 4. Tag a patch release.
+          LATEST=$(git tag -l 'v*' | sort -V | tail -1)
+          MAJOR=$(echo $LATEST | cut -d. -f1)
+          MINOR=$(echo $LATEST | cut -d. -f2)
+          PATCH=$(echo $LATEST | cut -d. -f3)
+          NEXT="$MAJOR.$MINOR.$((PATCH+1))"
+          git tag $NEXT
+          git push origin $NEXT
           echo "tagged: $NEXT"
 
   - id: comment_issues
@@ -125,7 +127,7 @@ steps:
         args: "gh pr review {pr_number} --repo {repo} --comment --body '{issues}' 2>&1"
 
   - id: notify_telegram
-    depends_on: [tag_release, comment_issues]
+    depends_on: [merge_close_tag, comment_issues]
     type: llm
     prompt: |
       Based on the results, compose a brief Telegram notification (2-3 lines).


### PR DESCRIPTION
Closes #475.

## Summary

The `pr-review-merge` graph hardcoded `kira/{branch}` for the rebase step, which fails when the PR branch lives on `origin` (e.g. `feat/` branches from the parallel runner). On PR #460 this caused the merge step to fail silently while close + tag steps still executed, posting a false-positive «Merged to main via skill graph.» message before Konstantin recovered manually.

## Fix

- **`rebase_branch`**: probe `origin/{branch}` first, fall back to `kira/{branch}`, fail loudly if neither exists post-fetch.
- **Collapse `squash_merge` + `cleanup_branch` + `close_pr` + `tag_release` into one atomic step `merge_close_tag`** chained with `set -euo pipefail`. Any failure (push rejection, remote misconfiguration, tag conflict) aborts BEFORE the PR is closed or the tag is pushed.
- **`notify_telegram`** dep updated to `merge_close_tag`.

## Why the collapse?

The graph engine's `condition` language (`src/app/graph.rs` `eval_condition`) only supports `'value' in var`, `!var`, and truthy checks — it can't reference a prior step's exit code. So the original `condition: \"'merge' in action\"` on `close_pr` / `tag_release` only gated on the upstream decision, not on whether `squash_merge` actually succeeded. Collapsing into one bash step with chained execution enforces all-or-nothing semantics without engine changes.

## AC checklist

- ✅ \`pr-review-merge\` graph always targets the correct remote (origin first, kira fallback) for the merge step.
- ✅ If merge fails (any reason), close-PR and tag-release steps do NOT run — \`set -euo pipefail\` aborts the chain.
- ⏳ Smoke test / replay of #460's scenario — deferred. \`deskd graph validate\` confirms DAG OK, but a full integration replay would need a Rust test harness for graph execution (out of scope for this YAML-only fix). Happy to file a follow-up if you want it tracked.

## Validation

\`\`\`
\$ deskd graph validate graphs/pr-review-merge.yaml
Graph 'pr-review-merge' is valid: 10 steps, DAG OK
\`\`\`

## Notes

- Falling back to \`kira\` for \`kira/*\` branches preserves prior behavior for kira's PRs (though in practice all of my recent PRs push to \`origin\`).
- If both remotes have the same ref name, origin wins — that's the right default since origin is canonical for shared branches.
- The error message on the no-branch path includes "(post-fetch)" to make it obvious that \`fetch_branch\` ran first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)